### PR TITLE
Fix fletcher16 checksum computation.

### DIFF
--- a/common/libs/checksum/checksum.cpp
+++ b/common/libs/checksum/checksum.cpp
@@ -20,36 +20,13 @@
 
 #include "checksum.h"
 
-uint16_t checksum_fletcher16(uint16_t *sum1, uint16_t *sum2,  char *data, uint8_t count)
-{
-    uint8_t index;
-
-    for (index = 0; index < count; ++index)
-    {
-        *sum1 = ((*sum1) + data[index]) % 255;
-        *sum2 = ((*sum2) + (*sum1)) % 255;
-    }
-
-    return ((*sum2) << 8) | *sum1;
-}
-
-bool checksum_check(char *packet, uint8_t packet_len) {
-    uint16_t sum1 = 0;
-    uint16_t sum2 = 0;
-    uint16_t csum;
-    uint8_t c0,c1,f0,f1;
-
-    // TODO Check validity of packet_len ?
-    // TODO Can this code be optimised?
-
-    csum = checksum_fletcher16(&sum1, &sum2, packet, packet_len-2); // Don't check the final two check bytes
-    f0 = csum & 0xff;
-    f1 = (csum >> 8) & 0xff;
-    c0 = 0xff - ((f0 + f1) % 0xff);
-    c1 = 0xff - ((f0 + c0) % 0xff);
-
-    if((packet[packet_len-2] == (char) c0) && (packet[packet_len-1] == (char) c1))
-        return true;
-
-    return false;
+uint16_t checksum_fletcher16(const char *data, uint8_t count,
+                             uint16_t state /*=0*/) {
+  uint8_t s1 = state & 0xff;
+  uint8_t s2 = (state >> 8) & 0xff;
+  for (uint8_t index = 0; index < count; ++index) {
+    s1 = (uint16_t{s1} + static_cast<uint16_t>(data[index])) % 255;
+    s2 = (uint16_t{s2} + uint16_t{s1}) % 255;
+  }
+  return (uint16_t{s2} << 8) | s1;
 }

--- a/common/libs/checksum/checksum.h
+++ b/common/libs/checksum/checksum.h
@@ -21,22 +21,38 @@
 
 #include <stdint.h>
 
-/****************************************************************************************
- *  @brief
- *  @usage
- *  @param
- *  @param
- *  @return
- ****************************************************************************************/
-uint16_t checksum_fletcher16(uint16_t *sum1, uint16_t *sum2,  char *data, uint8_t count );
+// Computes the fletcher16 checksum for a packet.
+//
+// The optional `state` param lets you chain together multiple calls to this
+// function if you want to checksum one "logical message" which isn't in a
+// single buffer.
+//
+//   uint16_t state = checksum_fletcher16(data0, data0_len);
+//   state = checksum_fletcher16(data1, data1_len, state);
+//   uint16_t result = checksum_fletcher16(data2, data2_len, state);
+//
+uint16_t checksum_fletcher16(const char *data, uint8_t count,
+                             uint16_t state = 0);
 
-/****************************************************************************************
- *  @brief
- *  @usage
- *  @param
- *  @param
- *  @return
- ****************************************************************************************/
-bool checksum_check(char *packet, uint8_t packet_len);
+// Computes check bytes for a fletcher16 checksum.
+//
+// Given a packet p and checksum(p) == c, check_bytes_fletcher16(c) returns two
+// bytes [b1 b2] such that checksum(p | b1 | b2) == 0, where `|` represents
+// concatenation.
+inline uint16_t check_bytes_fletcher16(uint16_t checksum) {
+  uint8_t f0 = checksum & 0xff;
+  uint8_t f1 = (checksum >> 8) & 0xff;
+  uint8_t c0 = 0xff - ((f0 + f1) % 0xff);
+  uint8_t c1 = 0xff - ((f0 + c0) % 0xff);
+  return (uint16_t{c0} << 8) | c1;
+}
+
+// Verifies the checksum of a packet.
+//
+// When creating packets, we append "check bytes" so that the whole packet
+// (including the check bytes) has a checksum of 0.
+inline bool checksum_check(const char *packet, uint8_t packet_len) {
+  return checksum_fletcher16(packet, packet_len) == 0;
+}
 
 #endif // CHECKSUM_H

--- a/controller/src/serialIO.cpp
+++ b/controller/src/serialIO.cpp
@@ -20,47 +20,34 @@
 #include "serialIO.h"
 
 void serialIO_init() {
-	// initialize serial communications at 115200 bps
-    Serial.begin(115200, SERIAL_8N1);
+  // Initialize serial communications at 115200 bps.
+  Serial.begin(115200, SERIAL_8N1);
 }
 
 bool serialIO_dataAvailable() {
-
-    return (Serial.available() > 0) ? true : false;
+  return (Serial.available() > 0) ? true : false;
 }
 
 void serialIO_readByte(char *buffer) {
-    // NOTE: This assumes that a byte is ready in the buffer
-    Serial.readBytes(buffer, 1);
+  // NOTE: This assumes that a byte is ready in the buffer
+  Serial.readBytes(buffer, 1);
 }
 
 void serialIO_send(enum msgType type, enum dataID id, char *data, uint8_t len) {
+  char metadata[3] = {
+      (char)((char)type & 0xff),
+      (char)id,
+      (char)len,
+  };
 
-    char metadata[3];
-    uint16_t sum1 = 0;
-    uint16_t sum2 = 0;
-    uint16_t csum;
-    uint8_t c0,c1,f0,f1;
+  // Calculate checksum and check bytes.
+  uint16_t csum = checksum_fletcher16(metadata, sizeof(metadata));
+  csum = checksum_fletcher16(data, len, csum);
+  uint16_t check_bytes = check_bytes_fletcher16(csum);
 
-    metadata[0] = ((char) type) & 0xff; // DATA_TYPE
-    metadata[1] = (char)  id; // DATA_ID
-    metadata[2] = (char)  len; // LEN
-
-    checksum_fletcher16(&sum1, &sum2, metadata, sizeof(metadata));
-    csum = checksum_fletcher16(&sum1, &sum2, data, len);
-
-    // Calculate check bytes
-    // TODO Can this be optimised?
-    f0 = csum & 0xff;
-    f1 = (csum >> 8) & 0xff;
-    c0 = 0xff - ((f0 + f1) % 0xff);
-    c1 = 0xff - ((f0 + c0) % 0xff);
-
-    Serial.write(metadata, sizeof(metadata));  // Send DATA_TYPE, DATA_ID, LEN
-    Serial.write(data, len);  // Send DATA
-
-    // Send checksum
-    Serial.write(c0);
-    Serial.write(c1);
-
+  // Send the packet: [DATA_TYPE, DATA_ID, LEN, DATA, check bytes].
+  Serial.write(metadata, sizeof(metadata));
+  Serial.write(data, len);
+  Serial.write(static_cast<uint8_t>(check_bytes >> 8));
+  Serial.write(static_cast<uint8_t>(check_bytes & 0xff));
 }

--- a/controller/test/checksum/checksum_test.cpp
+++ b/controller/test/checksum/checksum_test.cpp
@@ -1,26 +1,90 @@
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "unity.h"
+#include <map>
+
 #include "checksum.h"
+#include "unity.h"
 
-void test_Empty() {
-  uint16_t sum1 = 0;
-  uint16_t sum2 = 0;
-  uint16_t actual = checksum_fletcher16(&sum1, &sum2, /*data=*/NULL, /*count=*/0);
-  TEST_ASSERT_EQUAL_INT16(0, actual);
+void test_KnownQuantities() {
+  TEST_ASSERT_EQUAL_INT16(0, checksum_fletcher16(NULL, 0));
+  TEST_ASSERT_EQUAL_INT16(0, checksum_fletcher16("", 0));
+  TEST_ASSERT_EQUAL_INT16(24929, checksum_fletcher16("a", 1));
+  TEST_ASSERT_EQUAL_INT16(51440, checksum_fletcher16("abcde", 5));
+  TEST_ASSERT_EQUAL_INT16(8279, checksum_fletcher16("abcdef", 6));
+  TEST_ASSERT_EQUAL_INT16(1575, checksum_fletcher16("abcdefgh", 8));
+  TEST_ASSERT_EQUAL_INT16(0xfefe, checksum_fletcher16("\xff\xfe", 2));
 }
 
-void test_OneByte() {
-  uint16_t sum1 = 0;
-  uint16_t sum2 = 0;
-  char data[1] = {'a'};
-  uint16_t actual = checksum_fletcher16(&sum1, &sum2, data, /*count=*/1);
-  TEST_ASSERT_EQUAL_INT16(24929, actual);
+void test_CheckBytes() {
+  uint16_t csum = checksum_fletcher16("abcde", 5);
+
+  uint16_t checkBytes = check_bytes_fletcher16(csum);
+  char c0 = checkBytes >> 8;
+  char c1 = checkBytes & 0xff;
+  csum = checksum_fletcher16(&c0, 1, csum);
+  csum = checksum_fletcher16(&c1, 1, csum);
+  TEST_ASSERT_EQUAL_INT16(csum, 0);
 }
 
-int main () {
-    UNITY_BEGIN();
-    RUN_TEST(test_Empty);
-    RUN_TEST(test_OneByte);
-    return UNITY_END();
+// Repeatedly flip a random bit in `data` and check that
+//  - a one-bit flip never yields the same checksum, and
+//  - the same checksum doesn't appear "too often" overall.
+void test_BitFlips() {
+  srand(0);
+
+  char data[32];
+  memset(&data, '\0', sizeof(data));
+
+  // Start lastChecksum at -1 because our first test will be checksum'ing the
+  // all-zeroes buffer, which should yield 0.
+  uint16_t lastChecksum = -1;
+
+  const int32_t numTests = int32_t{1} << 16;
+  int32_t singleBitFlipCollisions = 0;
+  std::map<int16_t, int32_t> collisions;
+  for (int32_t i = 0; i < numTests; ++i) {
+    uint16_t checksum = checksum_fletcher16(data, sizeof(data));
+    collisions[checksum]++;
+    if (checksum == lastChecksum) {
+      singleBitFlipCollisions++;
+    }
+
+    lastChecksum = checksum;
+    int bitToFlip = rand() % (8 * sizeof(data));
+    uint8_t byteMask = 1 << (bitToFlip % 8);
+    data[bitToFlip / 8] ^= byteMask;
+  }
+
+  printf("%d/%d collisions after flipping a single bit.\n",
+         singleBitFlipCollisions, numTests);
+  if (singleBitFlipCollisions > 0) {
+    TEST_FAIL_MESSAGE("Got at least one collision from one-bit flips; is the "
+                      "checksum broken?\n");
+  }
+
+  // Find the checksum with the most collisions.  There shouldn't be "too
+  // many".
+  using MapElem = decltype(*collisions.begin());
+  auto it = std::max_element(
+      collisions.begin(), collisions.end(),
+      [](MapElem a, MapElem b) { return a.second < b.second; });
+  int16_t maxCollisionHash = it->first;
+  int32_t maxCollisions = it->second;
+  double maxCollisionsFrac = 1.0 * maxCollisions / numTests;
+  printf("%d/%d collisions on worst checksum, 0x%4x\n", maxCollisions, numTests,
+         maxCollisionHash);
+  if (maxCollisionsFrac >= 0.0002) {
+    TEST_FAIL_MESSAGE(
+        "Too many collisions on worst checksum; is the checksum broken?");
+  }
+}
+
+int main() {
+  UNITY_BEGIN();
+  RUN_TEST(test_KnownQuantities);
+  RUN_TEST(test_BitFlips);
+  return UNITY_END();
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,11 @@ default_envs = uno
 [env]
 lib_ldf_mode = deep+
 lib_extra_dirs = common/libs/
-build_flags = -Icommon/include/
+
+; TODO(jlebar): I'd rather compile as C++17, but when I set that, platformio
+; overrides it and still compiles the Arduino code as C++11.  Unclear if the
+; AVR compiler even supports C++17.
+build_flags = -Icommon/include/ -std=c++11
 
 [env:uno]
 platform = atmelavr


### PR DESCRIPTION
In the process of adding the more elaborate tests in this commit, I
found that fletcher16 was not performing well.  Out of the 2^16 random
single bit-flips I tried, 25 had the same checksum.  And one particular
checksum value had ~128/2^16 preimages, i.e. 128 of the 2^16 inputs we
tried all hashed to the same value.

After a bit of investigation, I realized that this was all due to a
subtle C typecasting bug:

    *sum1 = ((*sum1) + data[index]) % 255;

The issue is that `data` is a `char`, which may be signed or unsigned
depending on the platform.  If it's signed, then this is bad!

This commit fixes the problem, adds tests that catch the problem
statistically and explicitly, and also simplifies the code and API.

Fixes https://github.com/RespiraWorks/VentilatorSoftware/issues/66.

<pr-train-toc>

#### PR chain:
👉 #82 (Fix fletcher16 checksum computation.) 👈 **YOU ARE HERE**
#86 (Delete unused .ino files.)

</pr-train-toc>