### PR TITLE
Add clang-format pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+- repo: https://github.com/jlebar/pre-commit-hooks
+  rev: 3c53ed59c0c749b787e793a9951afb5f877c60e9
+  hooks:
+  - id: clang-format
+    name: clang-format C++
+    types: [c++]
+  - id: clang-format
+    name: clang-format C
+    types: [c]
+    exclude_types: [c++]

--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ Error: Please specify `upload_port` for environment or use global `--upload-port
 
 This has been tested with an RF-nano Arduino board, which has similar parts and
 pinout to an Arduino Nano.
+
+## Developing
+
+Please install [pre-commit](http://pre-commit.com) and activate it for this
+repository.  We use pre-commit to check for consistent formatting and other
+things.
+
+```
+# Install pre-commit
+$ brew install pre-commit
+# OR
+$ apt-get install pre-commit
+
+# Then activate pre-commit in this repository.
+$ pre-commit install
+```


### PR DESCRIPTION
This checks that when you modify some lines of a file, your modifications are clang-formatted.

It doesn't check that the whole file is clang-formatted.

See details at https://github.com/jlebar/pre-commit-hooks

Once we've verified this works for people, I'll do the mass-reformat of all the code.
<pr-train-toc>

#### PR chain:
👉 #84 (Add clang-format pre-commit.) 👈 **YOU ARE HERE**
#82 (Fix fletcher16 checksum computation.)
#86 (Delete unused .ino files.)

</pr-train-toc>