### PR TITLE
Adds platformio tests to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ addons:
       - libqt5charts5-dev
 
 # https://docs.platformio.org/en/latest/integration/ci/travis.html#travis-ci
-python:
-    - "2.7"
-
 cache:
     directories:
         - "~/.platformio"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,25 @@ addons:
       - qtdeclarative5-dev
       - libqt5charts5-dev
 
+# https://docs.platformio.org/en/latest/integration/ci/travis.html#travis-ci
+python:
+    - "2.7"
+
+cache:
+    directories:
+        - "~/.platformio"
+
+install:
+  - pip install -U platformio
+  - platformio update
+
 # TODO: Separate jobs for GUI and controller?
 script:
+  # Controller unit tests on native.
+  - platformio test -e native -v
+  # Make sure controller builds for target platform.
+  - platformio run -v
+  # Make sure GUI builds.
   - cd gui
   - mkdir build
   - cd build

--- a/controller/test/checksum/checksum_test.cpp
+++ b/controller/test/checksum/checksum_test.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <algorithm>
 #include <map>
 
 #include "checksum.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ platform = native
 lib_extra_dirs =
   common/libs/
   common/test_libs/
-build_flags = -Icommon/include/ -std=c++11 -DTEST_MODE
+build_flags = -Icommon/include/ -std=c++11 -DTEST_MODE -pthread
 lib_deps = googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,7 @@ platform = native
 lib_extra_dirs =
   common/libs/
   common/test_libs/
+; googletest requires pthread.
 build_flags = -Icommon/include/ -std=c++11 -DTEST_MODE -pthread
 lib_deps = googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.


### PR DESCRIPTION
Makes our Travis checks run `platformio run` and `platformio test -e native`.

This required a couple of drive-by fixes: adding pthread for googletest, and fixing a missing include.