### PR TITLE
Enables Wall Werror + a few related cleanups.

### DIFF
--- a/controller/include/pid.h
+++ b/controller/include/pid.h
@@ -16,28 +16,29 @@ limitations under the License.
 #define PID_H
 
 #include <PID_v1.h>
-#include <stdint.h>
 
-#define BLOWERSPD_PIN 3
-#define BLOWER_HIGH 142
-#define BLOWER_LOW 130
-#define DPSENSOR_PIN A0
+#include "hal.h"
+
+inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A0;
+inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_3;
+inline constexpr int BLOWER_HIGH = 142;
+inline constexpr int BLOWER_LOW = 130;
 
 // state machine variables
-#define INSPIRE_TIME 1600
-#define INSPIRE_RATE 1
-#define PIP 142
-#define INSPIRE_DWELL 800
-#define INSPIRE_DWELL_PRESSURE 140
-#define EXPIRE_TIME 1000
-#define EXPIRE_RATE 1
-#define PEEP 130
-#define EXPIRE_DWELL 600
+inline constexpr int INSPIRE_TIME = 1600;
+inline constexpr int INSPIRE_RATE = 1;
+inline constexpr int PIP = 142;
+inline constexpr int INSPIRE_DWELL = 800;
+inline constexpr int INSPIRE_DWELL_PRESSURE = 140;
+inline constexpr int EXPIRE_TIME = 1000;
+inline constexpr int EXPIRE_RATE = 1;
+inline constexpr int PEEP = 130;
+inline constexpr int EXPIRE_DWELL = 600;
 
 // not implemented yet
-#define AC 0
-#define RR 0
-#define IE 0
+inline constexpr int AC = 0;
+inline constexpr int RR = 0;
+inline constexpr int IE = 0;
 
 void pid_execute();
 void pid_init();

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -22,13 +22,28 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 #ifndef SENSORS_H
 #define SENSORS_H
 
-/*
- * @brief enum for the three different pressure sensors in the ventilator system
- */
-enum class pressureSensors {
-  PATIENT = 0, // patient pressure sensor
-  INHALATION,  // inhalation diff pressure sensor
-  EXHALATION   // exhalation diff pressure sensor
+#include "hal.h"
+
+// A namespace class for constants related to pressure sensors.
+class PressureSensors {
+public:
+  // Patient pressure sensor pin
+  inline constexpr static AnalogPinId PATIENT_PIN = AnalogPinId::HAL_A0;
+  // Inhalation diff pressure sensor pin
+  inline constexpr static AnalogPinId INHALATION_PIN = AnalogPinId::HAL_A1;
+  // Exhalation diff pressure sensor pin
+  inline constexpr static AnalogPinId EXHALATION_PIN = AnalogPinId::HAL_A2;
+
+  // min/max possible reading from MPXV5004GP [kPa]
+  inline constexpr static float P_VAL_MIN = 0.0f;
+  inline constexpr static float P_VAL_MAX = 3.92f;
+
+  // min/max possible reading from MPXV7002DP [kPa]
+  inline constexpr static float DP_VAL_MIN = -2.0f;
+  inline constexpr static float DP_VAL_MAX = 2.0f;
+
+private:
+  PressureSensors() = delete;
 };
 
 /*
@@ -57,12 +72,11 @@ void zero_sensors();
  * @brief This method gets the specified calibrated sensor reading and performs
  * simple averaging if configured to do so.
  *
- * @param pressureSensor the sensor from the pressureSensor enum that a reading
- * is desired from
+ * @param pinId the pressure sensor pin that a reading is desired from
  *
  * @return The specified pressure sensor calibrated reading in kPa
  */
-float get_pressure_reading(enum pressureSensors pressureSensor);
+float get_pressure_reading(AnalogPinId pinId);
 
 /*
  * @brief Method for setting the number of samples to use for average during

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -144,6 +144,6 @@ void pid_execute() {
   sensorValue = Hal.analogRead(DPSENSOR_PIN); // read sensor
   Input = map(sensorValue, 0, 1023, 0, 255);  // map to output scale
   myPID.Compute();                            // computer PID command
-  analogWrite(BLOWERSPD_PIN, Output);         // write output
+  Hal.analogWrite(BLOWERSPD_PIN, Output);     // write output
   send_periodicData(DELAY_100MS, sensorValue, 0, 0);
 }

--- a/controller/test/sensor_tests/SensorTests.cpp
+++ b/controller/test/sensor_tests/SensorTests.cpp
@@ -116,19 +116,19 @@ TEST(SensorTests, DISABLED_FullScaleReading) {
 
   // First set the simulated analog signals to an ambient 0 kPa corresponding
   // voltage
-  createStaticAnalogSignal((int)pressureSensors::INHALATION,
+  createStaticAnalogSignal((int)PressureSensors::INHALATION_PIN,
                            differentialFlowSensorVoltage_0kPa);
-  createStaticAnalogSignal((int)pressureSensors::EXHALATION,
+  createStaticAnalogSignal((int)PressureSensors::EXHALATION_PIN,
                            differentialFlowSensorVoltage_0kPa);
-  createStaticAnalogSignal((int)pressureSensors::PATIENT,
+  createStaticAnalogSignal((int)PressureSensors::PATIENT_PIN,
                            patientFlowSensorVoltage_0kPa);
 
   // Overwrite the start of the simulated signal to the dynamic signal
-  createDynamicAnalogSignal((int)pressureSensors::INHALATION,
+  createDynamicAnalogSignal((int)PressureSensors::INHALATION_PIN,
                             differentialFlowSensorVoltages, NUM_DIFF_ELEMENTS);
-  createDynamicAnalogSignal((int)pressureSensors::EXHALATION,
+  createDynamicAnalogSignal((int)PressureSensors::EXHALATION_PIN,
                             differentialFlowSensorVoltages, NUM_DIFF_ELEMENTS);
-  createDynamicAnalogSignal((int)pressureSensors::PATIENT,
+  createDynamicAnalogSignal((int)PressureSensors::PATIENT_PIN,
                             patientSensorVoltages, NUM_PATIENT_ELEMENTS);
 
   // Result is now that the dynamic signal is first, then followed by 0 kPa
@@ -141,18 +141,15 @@ TEST(SensorTests, DISABLED_FullScaleReading) {
   for (int i = 0; i < 9; i++) {
     int index = 4 + 2 * i;
     float pressureInhalation =
-        get_pressure_reading(pressureSensors::INHALATION);
+        get_pressure_reading(PressureSensors::INHALATION_PIN);
     float pressureExhalation =
-        get_pressure_reading(pressureSensors::EXHALATION);
+        get_pressure_reading(PressureSensors::EXHALATION_PIN);
     // Inhalation and exhalation should match because they are fed with the same
     // pressure waveform
     EXPECT_EQ(pressureInhalation, pressureExhalation)
         << "Differential Sensor Calculated Inhale/Exhale at index " << index;
     // Calculate deviance from expected. Using only inhalation because we know
     // it is equal to exhalation by now.
-    float inhalationDelta =
-        std::abs(pressureInhalation - differentialFlowPressures[index]);
-
     EXPECT_NEAR(pressureInhalation, differentialFlowPressures[index],
                 COMPARISON_TOLERANCE)
         << "Differential Sensor Calculated Value at index " << index;
@@ -160,7 +157,7 @@ TEST(SensorTests, DISABLED_FullScaleReading) {
 
   for (int i = 0; i < 8; i++) {
     int index = 4 + 2 * i;
-    float pressurePatient = get_pressure_reading(pressureSensors::PATIENT);
+    float pressurePatient = get_pressure_reading(PressureSensors::PATIENT_PIN);
     EXPECT_NEAR(pressurePatient, patientPressures[index], COMPARISON_TOLERANCE)
         << "Patient Sensor at index" << index;
   }

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ lib_extra_dirs = common/libs/
 ; TODO(jkff) It might be possible to use C++17 instead of gnu++17, but
 ; I hit some build errors, they didn't look too bad but with gnu++17
 ; they aren't there at all.
-build_flags = -Icommon/include/ -std=gnu++17
+build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror
 build_unflags = -std=gnu++11
 
 [env:uno]
@@ -40,7 +40,7 @@ lib_extra_dirs =
   common/libs/
   common/test_libs/
 ; googletest requires pthread.
-build_flags = -Icommon/include/ -std=gnu++17 -DTEST_MODE -pthread
+build_flags = -Icommon/include/ -std=gnu++17 -DTEST_MODE -pthread -Wall -Werror
 build_unflags = -std=gnu++11
 lib_deps = googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.


### PR DESCRIPTION
Cleanups:
* Moved pressure constants, together with pressure pin definitions, into `PressureSensors` so the compiler doesn't complain about them being unused
* More type-safe pin ids for analog and PWM pins - hopefully this will help other people be less confused about the fact that e.g. analogWrite is not the opposite of analogRead.
