### PR TITLE
Enables C++17 and fixes some resulting declared-but-undefined warnings

### DIFF
--- a/controller/src/comms.cpp
+++ b/controller/src/comms.cpp
@@ -20,7 +20,6 @@ limitations under the License.
  *    PRIVATE FUNCTION PROTOTYPES
  ****************************************************************************************/
 
-static bool packet_check(char *packet);
 static bool packet_receive(char *packet, uint8_t *packet_len);
 static bool packet_checksumValidation(char *packet, uint8_t len);
 static bool packet_cmdValidatation(char *packet);
@@ -29,11 +28,7 @@ static enum processPacket process_packet(char *packet, uint8_t len);
 static void comms_sendModeERR(char *packet);
 static void comms_sendChecksumERR(char *packet);
 static void comms_sendCommandERR(char *packet);
-static void cmd_execute(enum command cmd, char *dataTx, uint8_t lenTx,
-                        char *dataRx, uint8_t *lenRx, uint8_t lenRxMax);
-static void cmd_responseSend(char *packet, uint8_t len);
 static void send_alarm();
-static void cmd_responseSend(uint8_t cmd, char *packet, uint8_t len);
 
 /****************************************************************************************
  *    DEFINE STATEMENTS
@@ -78,7 +73,6 @@ enum class packet_field {
  *    PUBLIC FUNCTIONS
  ****************************************************************************************/
 
-static bool packet_check(char *packet);
 static bool packet_receive(char *packet, uint8_t *packet_len);
 static bool packet_checksumValidation(char *packet, uint8_t len);
 static bool packet_cmdValidatation(char *packet);
@@ -87,11 +81,7 @@ static enum processPacket process_packet(char *packet, uint8_t len);
 static void comms_sendModeERR(char *packet);
 static void comms_sendChecksumERR(char *packet);
 static void comms_sendCommandERR(char *packet);
-static void cmd_execute(enum command cmd, char *dataTx, uint8_t lenTx,
-                        char *dataRx, uint8_t *lenRx, uint8_t lenRxMax);
-static void cmd_responseSend(char *packet, uint8_t len);
 static void send_alarm();
-static void cmd_responseSend(uint8_t cmd, char *packet, uint8_t len);
 
 void comms_init() { serialIO_init(); }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,17 +19,20 @@ default_envs = uno
 [env]
 lib_ldf_mode = deep+
 lib_extra_dirs = common/libs/
-
-; TODO(jlebar): I'd rather compile as C++17, but when I set that, platformio
-; overrides it and still compiles the Arduino code as C++11.  Unclear if the
-; AVR compiler even supports C++17.
-build_flags = -Icommon/include/ -std=c++11
+; TODO(jkff) It might be possible to use C++17 instead of gnu++17, but
+; I hit some build errors, they didn't look too bad but with gnu++17
+; they aren't there at all.
+build_flags = -Icommon/include/ -std=gnu++17
+build_unflags = -std=gnu++11
 
 [env:uno]
 platform = atmelavr
 board = uno
 framework = arduino
 lib_deps = 2 ; PID (specified by number to resolve ambiguity)
+platform_packages =
+; A newer version of the toolchain than the default one, to support C++17.
+  toolchain-atmelavr @1.70300.191015
 
 [env:native]
 platform = native
@@ -37,7 +40,8 @@ lib_extra_dirs =
   common/libs/
   common/test_libs/
 ; googletest requires pthread.
-build_flags = -Icommon/include/ -std=c++11 -DTEST_MODE -pthread
+build_flags = -Icommon/include/ -std=gnu++17 -DTEST_MODE -pthread
+build_unflags = -std=gnu++11
 lib_deps = googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7


### PR DESCRIPTION
This should let us have nice things, like declaring constants as inline constexpr variables.