### PR TITLE
Adds a first code style check: file naming

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,10 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+- repo: local
+  hooks:
+    - id: c-file-naming
+      name: C++ sources and headers must be named in snake case (like_this)
+      entry: C++ sources and headers must be named in snake case (like_this)
+      language: fail
+      files: '[A-Z-].*\.(h|cpp|c)$'


### PR DESCRIPTION
Enforces that C++ files have to be named `like_this`. At the moment there are no violations but I checked that adding a WronglyNamed.cpp file triggers the check.