### PR TITLE
Adds a minimal clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+---
+# TODO: Enable as many useful checks as possible.
+# E.g. set to '*', see which of those aren't useful, and disable just those.
+Checks: '-*,readability-redundant-declaration'
+WarningsAsErrors: '*'
+
+# TODO: Add naming style checks (readability-identifier-naming).
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,8 @@ install:
 
 # TODO: Separate jobs for GUI and controller?
 script:
-  # Controller unit tests on native.
-  - platformio test -e native -v
-  # Make sure controller builds for target platform.
-  - platformio run -v
+  # Run checks for non-GUI code
+  - ./test.sh
   # Make sure GUI builds.
   - cd gui
   - mkdir build

--- a/controller/include/comms.h
+++ b/controller/include/comms.h
@@ -16,8 +16,8 @@ limitations under the License.
 #ifndef COMMS_H
 #define COMMS_H
 
-#include <stdint.h>
 #include <Arduino.h>
+#include <stdint.h>
 
 #include "checksum.h"
 #include "command.h"

--- a/controller/src/comms.cpp
+++ b/controller/src/comms.cpp
@@ -73,16 +73,6 @@ enum class packet_field {
  *    PUBLIC FUNCTIONS
  ****************************************************************************************/
 
-static bool packet_receive(char *packet, uint8_t *packet_len);
-static bool packet_checksumValidation(char *packet, uint8_t len);
-static bool packet_cmdValidatation(char *packet);
-static bool packet_modeValidation(char *packet);
-static enum processPacket process_packet(char *packet, uint8_t len);
-static void comms_sendModeERR(char *packet);
-static void comms_sendChecksumERR(char *packet);
-static void comms_sendCommandERR(char *packet);
-static void send_alarm();
-
 void comms_init() { serialIO_init(); }
 
 void comms_handler() {

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,6 +24,10 @@ lib_extra_dirs = common/libs/
 ; they aren't there at all.
 build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror
 build_unflags = -std=gnu++11
+check_tool = clangtidy
+check_flags =
+  ; The actual checks are defined in .clang-tidy.
+  clangtidy: --checks='-*'
 
 [env:uno]
 platform = atmelavr

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Use this script during development to have a good approximation
+# of whether your PR will pass tests on Travis:
+#
+# $ ./test.sh
+#
+# Travis runs this script (via .travis.yml), but might have some
+# environment differences, so the approximation is not perfect.
+#
+# Feel free to add more checks here, but keep in mind that:
+# - They have to pass on Travis
+# - They have to have a very good chance of passing for other
+#   developers if they run via ./test.sh
+
+# Fail if any command fails
+set -e
+set -o pipefail
+
+# Print each command as it executes
+set -o xtrace
+
+# Code style / bug-prone pattern checks (eg. clang-tidy)
+pio check --pattern="*" --fail-on-defect=high
+pio check -e native --pattern="*" --fail-on-defect=high
+# Controller unit tests on native.
+pio test -e native
+# Make sure controller builds for target platform.
+pio run


### PR DESCRIPTION
For now I enabled just a single check that had a handful of violations, to demonstrate that this works at all.

The next steps will be to enable more checks, including naming checks. 

This PR is relevant to issue #117 and issue #132 .