### PR TITLE
Adds sanitizers to native tests

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -50,3 +50,4 @@ lib_deps = googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
+extra_scripts = platformio_sanitizers.py

--- a/platformio_sanitizers.py
+++ b/platformio_sanitizers.py
@@ -1,0 +1,18 @@
+# Makes PlatformIO link this environment with sanitizers.
+Import("env")
+
+import sys
+
+# Sanitizers have to be enabled both in CCFLAGS and LINKFLAGS.
+sanitizers = [
+      "-fsanitize=undefined",
+      "-fsanitize=address",
+]
+if sys.platform == "linux":
+    # https://releases.llvm.org/3.7.0/tools/clang/docs/MemorySanitizer.html#supported-platforms
+    # Currently only works on Linux but e.g. not Mac OS.
+    sanitizers.append('-fsanitize=memory')
+
+env.Append(CCFLAGS=sanitizers)
+env.Append(LINKFLAGS=sanitizers)
+


### PR DESCRIPTION
Had to go through a PlatformIO "advanced scripting" script for this, because otherwise it filters out the necessary linker option.

No violations at HEAD, but I confirmed that this works by introducing an out-of-bounds array access in one of the tests and checking that it fails.