### PR TITLE
Downgrade required QML version to match what is included on raspbian

### DIFF
--- a/gui/ControlPanel.qml
+++ b/gui/ControlPanel.qml
@@ -27,9 +27,9 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.12
-import QtQuick.Layouts 1.0
-import QtQuick.Controls 2.5
+import QtQuick 2.11
+import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.4
 
 
 ColumnLayout

--- a/gui/ScopeView.qml
+++ b/gui/ScopeView.qml
@@ -27,7 +27,7 @@
 **
 ****************************************************************************/
 
-import QtQuick 2.12
+import QtQuick 2.11
 import QtCharts 2.1
 
 ChartView

--- a/gui/main.qml
+++ b/gui/main.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.12
+import QtQuick 2.11
 import QtQuick.Layouts 1.3
 
 Item


### PR DESCRIPTION
Downgrade required QML module versions to match what is included on Raspbian. Fixes #81 