### PR TITLE
Tweak watchdog code.

### DIFF
--- a/controller/include/watchdog.h
+++ b/controller/include/watchdog.h
@@ -16,13 +16,22 @@ limitations under the License.
 #ifndef WATCHDOG_H
 #define WATCHDOG_H
 
-#include <avr/wdt.h>
-#include <stdint.h>
-
-#define WDT_1SECOND 1000
-
+// The watchdog checks for hangs / crashes.  It resets the device if
+// watchdog_handler() is not called for "too long".
+//
+// This module also exposes reset_device(), which immediately restarts the
+// device.
+//
+// Implementation note: reset_device() restarts the controller by setting a
+// short watchdog timeout and then entering an infinite loop; when the short
+// timeout expires, the device restarts.  When the device boots back up, the
+// docs [0] claim that this timeout will be retained.  You should therefore
+// **call watchdog_init() very early in startup**, to reset the timer back to a
+// normal, longer value.
+//
+// [0] https://www.nongnu.org/avr-libc/user-manual/group__avr__watchdog.html
 void watchdog_init();
 void watchdog_handler();
-void watchdog_reboot();
+[[noreturn]] void reset_device();
 
 #endif // WATCHDOG_H

--- a/controller/src/command.cpp
+++ b/controller/src/command.cpp
@@ -120,7 +120,7 @@ void command_execute(enum command cmd, char *dataTx, uint8_t lenTx,
     break;
   case command::reset_vc:
     // TODO Do any necessary cleaning up before reset
-    watchdog_reboot();
+    reset_device();
     break;
 
     /* Mixed mode commands */

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -64,6 +64,16 @@ static void controller_loop() {
 }
 
 void setup() {
+  // Initialize the watchdog first, for two reasons:
+  //
+  //  - The purpose of the watchdog is to catch hangs, and if initializing the
+  //    watchdog weren't the first thing we did, we wouldn't catch hangs in the
+  //    work that came before.
+  //
+  //  - After the device is soft-reset via reset_device(), the watchdog timer
+  //    has a very short value.  We need to watchdog_init() immediately so that
+  //    we don't time out while initializing.
+  watchdog_init();
 
   parameters_init();
   comms_init();
@@ -71,7 +81,6 @@ void setup() {
   blower_init();
   solenoid_init();
 
-  watchdog_init();
   pid_init();
 
   alarm_init();

--- a/controller/src/watchdog.cpp
+++ b/controller/src/watchdog.cpp
@@ -13,31 +13,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include <Arduino.h>
+#include <avr/wdt.h>
+#include <stdint.h>
 
 #include "watchdog.h"
 
+// Reset the device if wdt_reset() is not called within roughly this time
+// period.
+//
+// Options are: 15ms, 30ms, 60ms, 120ms, 250ms, 500ms, 1s, 2s, 4s, 8s.
+//
+// TODO: This value was not chosen carefully.
+#define WATCHDOG_TIMEOUT WDTO_120MS
+
 void watchdog_init() {
   // FIXME Does this pose potential issues for arduino code updates?
-  wdt_enable(WDTO_8S);
+  wdt_enable(WATCHDOG_TIMEOUT);
 }
 
-void watchdog_handler() {
-  static uint32_t time;
-  static bool first_call = true;
+void watchdog_handler() { wdt_reset(); }
 
-  if (first_call == true) {
-    first_call = false;
-    time = millis();
-  } else {
-    // TODO does this rollover properly?
-    if ((millis() - time) > WDT_1SECOND) {
-      wdt_reset();
-      time = millis();
-    }
-  }
-}
-
-void watchdog_reboot() {
+[[noreturn]] void reset_device() {
+  // Reset the device by setting a short watchdog timeout and then entering an
+  // infinite loop.
   wdt_enable(WDTO_15MS);
   while (1) {
   }


### PR DESCRIPTION
- Decrease the watchdog timeout from 8s -> 120ms.  8s seems very long
  for a device that is breathing for someone.  Even 120ms seems long,
  honestly, but at least not "fatally long".

- Simplify code in watchdog_handler().  wdt_reset() is a single
  instruction; I think the old code was a premature optimization and
  might even have been slower than this.

- Make watchdog_init() the first thing we do in main().

- Rename watchdog_reboot -> reset_device, which I think is clearer.

- Comments.

I am not sure how this code is going to work when we switch to STM32.