### PR TITLE
Enables some clang-tidy checks and fixes violations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,8 @@
 ---
-# TODO: Enable as many useful checks as possible.
-# E.g. set to '*', see which of those aren't useful, and disable just those.
-Checks: '-*,readability-redundant-declaration'
+# TODO(jkff): Re-enable google-readability-casting: it can be annoying, but it
+# can catch some nasty bugs. E.g. C-style casts happily cast a pointer to the
+# wrong type.
+Checks: '*,-*-magic-numbers,-hicpp-*,-cppcoreguidelines-*,-fuchsia-*,-clion-*,-cert-*,-readability-named-parameter,-llvm-header-guard,-google-readability-todo,-misc-unused-parameters,-*-braces-around-statements,-google-readability-casting,-readability-else-after-return,-modernize-use-auto,-modernize-deprecated-headers,-llvm-include-order,-modernize-avoid-c-arrays,-readability-uppercase-literal-suffix,-bugprone-narrowing-conversions,-readability-isolate-declaration'
 WarningsAsErrors: '*'
 
 # TODO: Add naming style checks (readability-identifier-naming).

--- a/common/include/packet_types.h
+++ b/common/include/packet_types.h
@@ -125,19 +125,18 @@ enum class operatingMode {
 
 // Solenoid state definitions
 enum class solenoidNormaleState {
-    normally_open    = 0x00,
-    normally_closed  = 0x01,
+  normally_open = 0x00,
+  normally_closed = 0x01,
 
-    count                       /* Sentinel */
+  count /* Sentinel */
 };
 
 // Ventilator medical mode types
 enum class ventilatorMode {
-    PRVC = 0x00,
-    ACV  = 0x01,
+  PRVC = 0x00,
+  ACV = 0x01,
 
-    count                       /* Sentinel */
+  count /* Sentinel */
 };
-
 
 #endif // PACKET_TYPES_H

--- a/common/libs/checksum/checksum.cpp
+++ b/common/libs/checksum/checksum.cpp
@@ -13,9 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include <stdint.h>
-
 #include "checksum.h"
+#include <stdint.h>
 
 uint16_t checksum_fletcher16(const char *data, uint8_t count,
                              uint16_t state /*=0*/) {

--- a/controller/include/command.h
+++ b/controller/include/command.h
@@ -20,7 +20,6 @@
 #define COMMAND_H
 
 #include <stdint.h>
-#include <string.h>
 
 #include "alarm.h"
 #include "packet_types.h"

--- a/controller/lib/core/alarm.cpp
+++ b/controller/lib/core/alarm.cpp
@@ -25,29 +25,23 @@ struct alarm_stack_t {
 alarm_stack_t stack;
 } // anonymous namespace
 
-static bool stack_full() {
-  return (stack.top == (ALARM_NODES - 1)) ? true : false;
-}
+static bool stack_full() { return stack.top == (ALARM_NODES - 1); }
 
-static bool stack_empty() { return (stack.top == -1) ? true : false; }
+static bool stack_empty() { return stack.top == -1; }
 
 static int32_t stack_peek(alarm_t **alarm) {
-  int32_t return_status = VC_STATUS_FAILURE;
-  if (!stack_empty()) {
-    *alarm = &stack.alarm[stack.top];
-    return_status = VC_STATUS_SUCCESS;
-  }
-  return return_status;
+  if (stack_empty())
+    return VC_STATUS_FAILURE;
+  *alarm = &stack.alarm[stack.top];
+  return VC_STATUS_SUCCESS;
 }
 
 static int32_t stack_pop(alarm_t **alarm) {
-  int32_t return_status = VC_STATUS_FAILURE;
-  if (!stack_empty()) {
-    *alarm = &stack.alarm[stack.top];
-    stack.top--;
-    return_status = VC_STATUS_SUCCESS;
-  }
-  return return_status;
+  if (stack_empty())
+    return VC_STATUS_FAILURE;
+  *alarm = &stack.alarm[stack.top];
+  stack.top--;
+  return VC_STATUS_SUCCESS;
 }
 
 static void stack_push(alarm_t alarm) {
@@ -59,10 +53,10 @@ static void stack_push(alarm_t alarm) {
 
 void alarm_init() { stack.top = -1; }
 
-void alarm_add(enum dataID alarmID, char *data) {
-  alarm_t alarm;
+void alarm_add(dataID alarmID, const char *data) {
   if (!stack_full()) {
     // No point spending time doing these operations if the stack is full
+    alarm_t alarm;
     alarm.alarm = alarmID;
     alarm.timestamp = Hal.millis();
 
@@ -78,20 +72,20 @@ void alarm_add(enum dataID alarmID, char *data) {
   }
 }
 
-bool alarm_available() { return (stack_empty() == false) ? true : false; }
+bool alarm_available() { return !stack_empty(); }
 
 void alarm_remove() {
   alarm_t *alarm;
   stack_pop(&alarm); // Don't need this alarm anymore, remove it
 }
 
-int32_t alarm_read(enum dataID *alarmID, uint32_t *timestamp, char *data) {
+int32_t alarm_read(dataID *alarmID, uint32_t *timestamp, char *data) {
   int32_t return_status = VC_STATUS_FAILURE;
   alarm_t *alarm;
   return_status = stack_peek(&alarm);
 
   if (return_status == VC_STATUS_SUCCESS) {
-    *alarmID = (enum dataID)alarm->alarm;
+    *alarmID = alarm->alarm;
     *timestamp = alarm->timestamp;
 
     for (uint8_t idx = 0; idx < ALARM_DATALEN; idx++) {

--- a/controller/lib/core/alarm.h
+++ b/controller/lib/core/alarm.h
@@ -16,10 +16,9 @@ limitations under the License.
 #ifndef ALARM_H
 #define ALARM_H
 
-#include <stdint.h>
-
 #include "errors.h"
 #include "packet_types.h"
+#include <stdint.h>
 
 /* Number of alarms we can store in the queue */
 #define ALARM_NODES 4
@@ -35,8 +34,8 @@ struct alarm_t {
 };
 
 void alarm_init();
-void alarm_add(enum dataID alarm, char *data);
-int32_t alarm_read(enum dataID *alarmID, uint32_t *timestamp, char *data);
+void alarm_add(dataID alarm, const char *data);
+int32_t alarm_read(dataID *alarmID, uint32_t *timestamp, char *data);
 bool alarm_available();
 void alarm_remove();
 

--- a/controller/lib/core/parameters.h
+++ b/controller/lib/core/parameters.h
@@ -60,19 +60,18 @@ void parameters_setDwell(float Dwell);
 float parameters_getDwell();
 
 enum operatingMode parameters_getOperatingMode();
-void parameters_setOperatingMode(enum operatingMode);
+void parameters_setOperatingMode(operatingMode);
 
 void parameters_setPeriodicReadings(bool active);
 bool parameters_getPeriodicReadings();
 
-void parameters_setPeriodicMode(enum periodicMode periodicMode_value);
+void parameters_setPeriodicMode(periodicMode periodicMode_value);
 enum periodicMode parameters_getPeriodicMode();
 
-void parameters_setVentilatorMode(enum ventilatorMode ventilatorMode_value);
+void parameters_setVentilatorMode(ventilatorMode ventilatorMode_value);
 enum ventilatorMode parameters_getVentilatorMode();
 
-void parameters_setSolenoidNormalState(
-    enum solenoidNormaleState normalState_value);
+void parameters_setSolenoidNormalState(solenoidNormaleState normalState_value);
 enum solenoidNormaleState parameters_getSolenoidNormalState();
 
 #endif // PARAMETERS_H

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -30,10 +30,8 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 // per count) [V];
 static const float ADC_LSB = 5.0f / 1024.0f;
 
-// zero calibration values for [0]: patient pressure sensor;[1]:
-// inhalation diff pressure sensor;[2]: exhalation diff pressure
-// sensor; [ADC Counts]
-static int sensorZeroVals[] = {0, 0, 0};
+// zero calibration values for the different pressure sensors.
+static int sensorZeroVals[static_cast<int>(AnalogPinId::COUNT)] = {0};
 
 // number of samples to perform averaging over during sensor zeroization
 static int zeroingAvgSize = 4;

--- a/controller/lib/core/solenoid.cpp
+++ b/controller/lib/core/solenoid.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 
 #include "hal.h"
 #include "parameters.h"
-#include "stdint.h"
+#include <stdint.h>
 
 // Solenoid output pin 5 TBC.
 static const int O_SOLENOID = 5;

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -63,7 +63,7 @@ limitations under the License.
 #define HAL_MOCK_METHOD(returntype, name, args) returntype name args
 
 // "HAL" has to be there because the respective Arduino symbols are macros,
-// e.g. A0 expands to simply 0 so we can't have a constant named A0.
+// e.g. A0 expands to 14, so we can't have a constant named A0.
 #define HAL_CONSTANT(name) HAL_##name = name
 #endif // TEST_MODE
 
@@ -92,6 +92,9 @@ enum class AnalogPinId {
   HAL_CONSTANT(A1),
   HAL_CONSTANT(A2),
   HAL_CONSTANT(A3),
+  // https://github.com/arduino/ArduinoCore-avr/blob/master/variants/standard/pins_arduino.h
+  // has 7 named analog pins, the largest of which, A7, has id 21.
+  COUNT = 22
 };
 
 // ID of one of the digital pins that can be used as a PWM pin.

--- a/controller/src/command.cpp
+++ b/controller/src/command.cpp
@@ -23,6 +23,10 @@ static uint32_t convfloatToInt(float float_value);
 
 void command_execute(enum command cmd, char *dataTx, uint8_t lenTx,
                      char *dataRx, uint8_t *lenRx, uint8_t lenRxMax) {
+  // TODO(lee-matthews): We need to validate that we don't go past dataTx
+  (void)lenTx;
+  // TODO(lee-matthews): We need to ensure that we don't set lenRx > lenRxMax.
+  (void)lenRxMax;
 
   float rr, tv, peep, dwell, ier, pip, Ki, Kd, Kp;
   *lenRx = 0; // Initialise the value to zero
@@ -167,22 +171,22 @@ void command_responseSend(uint8_t cmd, char *packet, uint8_t len) {
 }
 
 static float convIntTofloat(char *data) {
-    float f;
+  float f;
 
 #ifndef __FLOAT_WORD_ORDER__
 #error "Your compiler isn't defining the __FLOAT_WORD_ORDER__ macro?"
 #elif __FLOAT_WORD_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    /* Convert big endian integer to little endian float */
-    uint32_t data_bEndian;
-    memcpy(&data_bEndian, data, sizeof(data_bEndian));
-    uint32_t data_lEndian = __builtin_bswap32(data_bEndian);
-    memcpy(&f, &data_lEndian, sizeof(f));
+  /* Convert big endian integer to little endian float */
+  uint32_t data_bEndian;
+  memcpy(&data_bEndian, data, sizeof(data_bEndian));
+  uint32_t data_lEndian = __builtin_bswap32(data_bEndian);
+  memcpy(&f, &data_lEndian, sizeof(f));
 #else
-    /* Convert big endian to big endian float */
-    memcpy(&f, &data, sizeof(f));
+  /* Convert big endian to big endian float */
+  memcpy(&f, &data, sizeof(f));
 #endif
 
-    return f;
+  return f;
 }
 
 static uint32_t convfloatToInt(float float_value) {

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -36,7 +36,7 @@ static void send_periodicData(uint32_t delay, uint16_t pressure,
   static uint32_t time;
   static bool first_call = true;
 
-  if (first_call == true) {
+  if (first_call) {
     first_call = false;
     time = Hal.millis();
   } else {
@@ -50,7 +50,6 @@ static void send_periodicData(uint32_t delay, uint16_t pressure,
     }
   }
 }
-
 
 enum class pid_fsm_state {
   reset = 0,
@@ -144,6 +143,6 @@ void pid_execute() {
   sensorValue = Hal.analogRead(DPSENSOR_PIN); // read sensor
   Input = map(sensorValue, 0, 1023, 0, 255);  // map to output scale
   myPID.Compute();                            // computer PID command
-  Hal.analogWrite(BLOWERSPD_PIN, Output);     // write output
+  Hal.analogWrite(BLOWERSPD_PIN, static_cast<int>(Output)); // write output
   send_periodicData(DELAY_100MS, sensorValue, 0, 0);
 }

--- a/controller/src/watchdog.cpp
+++ b/controller/src/watchdog.cpp
@@ -37,6 +37,6 @@ void watchdog_handler() { wdt_reset(); }
   // Reset the device by setting a short watchdog timeout and then entering an
   // infinite loop.
   wdt_enable(WDTO_15MS);
-  while (1) {
+  while (true) {
   }
 }

--- a/controller/test/checksum/checksum_test.cpp
+++ b/controller/test/checksum/checksum_test.cpp
@@ -1,7 +1,7 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #include <algorithm>
 #include <map>

--- a/controller/test/sensor_tests/SensorTests.cpp
+++ b/controller/test/sensor_tests/SensorTests.cpp
@@ -26,9 +26,8 @@ limitations under the License.
 #include "gtest/gtest.h"
 #include <assert.h>
 #include <cmath>
+#include <cstdio>
 #include <iostream>
-#include <stdbool.h>
-#include <stdio.h>
 #include <string>
 
 // Maximum allowable delta between calculated sensor readings and the input
@@ -49,9 +48,9 @@ static const float COUNTS_PER_VOLT = 1024.0f / 5.0f;
  * @param *voltageOut pointer to the output voltage buffer
  * @param count is the length of the input buffer
  */
-static void MPXV5004_TransferFn(float *pressureIn, float *voltageOut,
+static void MPXV5004_TransferFn(const float *pressureIn, float *voltageOut,
                                 int count) {
-  assert(pressureIn != NULL && voltageOut != NULL);
+  assert(pressureIn != nullptr && voltageOut != nullptr);
   for (int i = 0; i < count; i++) {
     voltageOut[i] = 5 * (0.2f * pressureIn[i] + 0.2f);
   }
@@ -66,9 +65,9 @@ static void MPXV5004_TransferFn(float *pressureIn, float *voltageOut,
  * @param *voltageOut pointer to the output voltage buffer
  * @param count is the length of the input buffer
  */
-static void MPXV7002_TransferFn(float *pressureIn, float *voltageOut,
+static void MPXV7002_TransferFn(const float *pressureIn, float *voltageOut,
                                 int count) {
-  assert(pressureIn != NULL && voltageOut != NULL);
+  assert(pressureIn != nullptr && voltageOut != nullptr);
   for (int i = 0; i < count; i++) {
     voltageOut[i] = 5 * (0.2f * pressureIn[i] + 0.5f);
   }

--- a/test.sh
+++ b/test.sh
@@ -21,8 +21,13 @@ set -o pipefail
 set -o xtrace
 
 # Code style / bug-prone pattern checks (eg. clang-tidy)
+# WARNING: This might sometimes give different results for different people,
+# and different results on CI:
+# See https://community.platformio.org/t/no-version-of-tool-clangtidy-works-on-all-os/13219
+# Feel free to edit .clang_tidy to blacklist problematic checks.
 pio check --pattern="*" --fail-on-defect=high
 pio check -e native --pattern="*" --fail-on-defect=high
+
 # Controller unit tests on native.
 pio test -e native
 # Make sure controller builds for target platform.


### PR DESCRIPTION
Obtained by running clang-tidy with all checks enabled and going through them by hand: ones that yielded either a perceptible improvement in readability or caught an actual bug (they **did** catch a couple of actual bugs) stayed enabled, ones that didn't (i.e. were more likely to annoy people than help), are disabled. We'll probably need to iterate on this more as we write more code.