### PR TITLE
Resurrect sanitizers without msan

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -54,3 +54,4 @@ lib_deps =
 ; This is needed for the googletest lib_dep to work.  I don't understand why.
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
+extra_scripts = platformio_sanitizers.py

--- a/platformio_sanitizers.py
+++ b/platformio_sanitizers.py
@@ -9,10 +9,12 @@ sanitizers = [
       "-fsanitize=address",
 ]
 
-#GCC does not have memory option to -fsanitize
-#if sys.platform == "linux":
-#    # https://releases.llvm.org/3.7.0/tools/clang/docs/MemorySanitizer.html#supported-platforms
-#    # Currently only works on Linux but e.g. not Mac OS.
+# TODO: Add -fsanitize=memory when supported.
+# Caveats: It's only supported in clang and only on Linux.
+# And PlatformIO may choose gcc even if you have clang too.
+# If it didn't, the code below would probably work:
+#
+# if sys.platform == "linux" and env["CC"] == "clang":
 #    sanitizers.append('-fsanitize=memory')
 
 env.Append(CCFLAGS=sanitizers)


### PR DESCRIPTION
Tried to resurrect msan on Linux + clang but even on Martin's machine with Linux and clang, pio still chose gcc. So maybe it's moot - let's just resurrect the basic sanitizers.