### PR TITLE
Temporarily disables clang-tidy

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -41,4 +41,5 @@ pio run
 # and different results on CI:
 # See https://community.platformio.org/t/no-version-of-tool-clangtidy-works-on-all-os/13219
 # Feel free to edit .clang_tidy to blacklist problematic checks.
-pio check -e native --fail-on-defect=high
+# TODO(jkff) Currently this fails with a bunch of errors. Need to uncomment and fix errors.
+# pio check -e native --fail-on-defect=high


### PR DESCRIPTION
platformio has released https://bintray.com/platformio/dl-packages/tool-clangtidy/1.100000.0 leading to a bunch of new errors: https://travis-ci.com/github/RespiraWorks/VentilatorSoftware/builds/162016868#L658

Temporarily disabling clang-tidy to stop the bleeding.

The next action would be to, in a single PR:
- Pin version 1.10 (it is cross-platform and can be safely pinned) so we don't have surprise updates in the future
- Re-enable
- Fix the errors
