### PR TITLE
Cosmetic and functional improvements to pid.cpp

### DIFF
--- a/controller/include/pid.h
+++ b/controller/include/pid.h
@@ -22,6 +22,8 @@ limitations under the License.
 
 inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A0;
 inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_3;
+
+// TODO(jlebar): Where did these numbers come from?
 inline constexpr int BLOWER_HIGH = 142;
 inline constexpr int BLOWER_LOW = 130;
 

--- a/controller/include/pid.h
+++ b/controller/include/pid.h
@@ -23,7 +23,8 @@ limitations under the License.
 inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A5;
 inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_6;
 
-// TODO(jlebar): Where did these numbers come from?
+// TODO(jlebar): Remove these dummy values and instead use the state sent from
+// the GuiStatus object.
 inline constexpr int BLOWER_HIGH = 142;
 inline constexpr int BLOWER_LOW = 130;
 

--- a/controller/include/pid.h
+++ b/controller/include/pid.h
@@ -20,8 +20,8 @@ limitations under the License.
 #include "hal.h"
 #include "network_protocol.pb.h"
 
-inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A0;
-inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_3;
+inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A5;
+inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_6;
 
 // TODO(jlebar): Where did these numbers come from?
 inline constexpr int BLOWER_HIGH = 142;

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -104,14 +104,22 @@ enum class AnalogPinId {
   HAL_CONSTANT(A1),
   HAL_CONSTANT(A2),
   HAL_CONSTANT(A3),
+  HAL_CONSTANT(A4),
+  HAL_CONSTANT(A5),
   // https://github.com/arduino/ArduinoCore-avr/blob/master/variants/standard/pins_arduino.h
   // has 7 named analog pins, the largest of which, A7, has id 21.
   COUNT = 22
 };
 
-// ID of one of the digital pins that can be used as a PWM pin.
+// IDs of the digital pins that can be used for pulse-width modulation.
+// https://github.com/arduino/ArduinoCore-avr/blob/257ee3f/variants/standard/pins_arduino.h#L35
 enum class PwmPinId {
   PWM_3 = 3,
+  PWM_5 = 5,
+  PWM_6 = 6,
+  PWM_9 = 9,
+  PWM_10 = 10,
+  PWM_11 = 11,
 };
 
 // Singleton class which implements a hardware abstraction layer.

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -153,9 +153,14 @@ public:
   void test_setAnalogPin(AnalogPinId pin, int value);
 #endif
 
-  void analogWrite(PwmPinId pin, int value);
-
+  // TODO(jlebar): Make digital pin number strongly typed?  It's slightly
+  // tricky because the digital pin numbers are a superset of PWM pin numbers,
+  // and C++ doesn't support enum inheritance.
   void setDigitalPinMode(int pin, PinMode mode);
+  void setDigitalPinMode(PwmPinId pin, PinMode mode) {
+    setDigitalPinMode(static_cast<int>(pin), mode);
+  }
+  void analogWrite(PwmPinId pin, int value);
   void digitalWrite(int pin, VoltageLevel value);
 
   // Receives bytes from the GUI controller along the serial bus.

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -54,7 +54,14 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   uint16_t cyclecounter = 0;
   enum pid_fsm_state state = pid_fsm_state::reset;
 
-  // TODO(jlebar): Get rid of ramp rate; just go to the set pressure asap.
+  // The state machine drives PID to blow a trapezoid.  We start at the PEEP
+  // pressure, then gradually ramp the setpoint up to PIP.  Then we dwell there
+  // for a while, ramp down to PEEP, and dwell there for a bit.
+  //
+  // TODO(jlebar): Per Edwin, we should simplify this by removing the ramp-up
+  // and ramp-down states.  Instead, just modify the setpoint and let PID ramp
+  // us up/down.  The timescales for the ramp-up and ramp-down are short, and
+  // PID only moves us so fast anyway.
   switch (state) {
   case pid_fsm_state::reset: // reset
     cyclecounter = 0;
@@ -76,7 +83,6 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
     }
     break;
 
-    // TODO: Remove this, just use inspire (i.e. pip) pressure.
   case pid_fsm_state::plateau: // Inspiratory plateau
     cyclecounter++;
     // set command

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -47,12 +47,15 @@ void pid_init() {
 
   // Turn the PID on.
   myPID.SetMode(AUTOMATIC);
+
+  pinMode(static_cast<uint8_t>(BLOWERSPD_PIN), OUTPUT);
 }
 
 void pid_execute(const VentParams &params, SensorReadings *readings) {
   uint16_t cyclecounter = 0;
   enum pid_fsm_state state = pid_fsm_state::reset;
 
+  // TODO(jlebar): Get rid of ramp rate; just go to the set pressure asap.
   switch (state) {
   case pid_fsm_state::reset: // reset
     cyclecounter = 0;
@@ -74,6 +77,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
     }
     break;
 
+    // TODO: Remove this, just use inspire (i.e. pip) pressure.
   case pid_fsm_state::plateau: // Inspiratory plateau
     cyclecounter++;
     // set command

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -47,8 +47,7 @@ void pid_init() {
 
   // Turn the PID on.
   myPID.SetMode(AUTOMATIC);
-
-  pinMode(static_cast<uint8_t>(BLOWERSPD_PIN), OUTPUT);
+  Hal.setDigitalPinMode(BLOWERSPD_PIN, PinMode::HAL_OUTPUT);
 }
 
 void pid_execute(const VentParams &params, SensorReadings *readings) {


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Cosmetic tweaks to PID code.
1. Make PID functional with current design.
    
     - Switch patient pressure sensor to pin A5.
     - Add constants to HAL for PWM pins.
     - Switch blower speed to pin PWM 6.
     - Set the blower pin to output mode, otherwise we can write to it all
       we want, but nothing's gonna happen.
    
    I think it might be better to abstract some of the low-level "pins"
    logic into HAL, but this is a first step.
    
    Fixes https://github.com/RespiraWorks/VentilatorSoftware/issues/17
1. HAL-ify pid.cpp.
    
    Add and use overload for Hal.setDigitalPinMode.
1. Update comments per review.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #172 Cosmetic and functional improvements to pid.cpp 👈 **YOU ARE HERE**
1. #180 Simplify sensor calibration routine.
1. #183 Take higher-level args in HAL::analogRead().

</git-pr-chain>






