### PR TITLE
Fix flow calculation

### DIFF
--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -121,17 +121,19 @@ void set_sensor_avg_samples(int numAvgSamples);
 int get_sensor_avg_samples();
 
 /*
- * @brief Method implements Bernoulli's equation assuming the Venturi Effect.
+ * @brief Implements Bernoulli's equation assuming the Venturi Effect.
  * https://en.wikipedia.org/wiki/Venturi_effect
+ *
  * Solves for the volumetric flow rate since A1/A2, rho, and differential
  * pressure are known. Q = sqrt(2/rho) * (A1*A2) * 1/sqrt(A1^2-A2^2) *
  * sqrt(p1-p2); based on (p1 - p2) = (rho/2) * (v2^2 - v1^2); where A1 > A2
- * @param diffPressureInKiloPascals the differential pressure from a sensor in
- * [kPa]
+ *
+ * @param pressure_delta_kpa the differential pressure from a sensor in [kPa]
+ *
  * @return the volumetric flow in [meters^3/s]. Can be negative, indicating
  * direction of flow, depending on how the differential sensor is attached to
  * the venturi.
  */
-float pressure_delta_to_volumetric_flow(float diffPressureInKiloPascals);
+float pressure_delta_to_flow(float pressure_delta_kpa);
 
 #endif // SENSORS_H

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -139,18 +139,18 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // Convert [kPa] to [cm H2O] in place
   readings->pressure_cm_h2o =
       get_pressure_reading(PressureSensors::PATIENT_PIN) * 10.1974f;
+
   // TODO(anyone): This value is to be the integration over time of the below
   // flow_ml_per_min. That is, you take the value calculated for flow_ml_per_min
   // and integrate it over time to get total volume at the current time. Don't
   // think this necessarily has to be done on the controller though?
   readings->volume_ml = 0;
+
   // Flow rate is inhalation flow minus exhalation flow. Positive value is flow
   // into lungs, and negative is flow out of lungs.
-  // Convert [meters^3/s] to [mL/min] in place
-  readings->flow_ml_per_min =
-      (pressure_delta_to_volumetric_flow(
-           get_pressure_reading(PressureSensors::INHALATION_PIN)) -
-       pressure_delta_to_volumetric_flow(
-           get_pressure_reading(PressureSensors::EXHALATION_PIN))) *
-      1000.0f * 1000.0f * 60.0f;
+  float flow = // [m^3/s]
+      pressure_delta_to_volumetric_flow(
+          get_pressure_reading(PressureSensors::INHALATION_PIN) -
+          get_pressure_reading(PressureSensors::EXHALATION_PIN));
+  readings->flow_ml_per_min = flow * 1000.0f * 1000.0f * 60.0f;
 }

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -149,7 +149,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // Flow rate is inhalation flow minus exhalation flow. Positive value is flow
   // into lungs, and negative is flow out of lungs.
   float flow = // [m^3/s]
-      pressure_delta_to_volumetric_flow(
+      pressure_delta_to_flow(
           get_pressure_reading(PressureSensors::INHALATION_PIN) -
           get_pressure_reading(PressureSensors::EXHALATION_PIN));
   readings->flow_ml_per_min = flow * 1000.0f * 1000.0f * 60.0f;

--- a/controller/test/sensor_tests/SensorTests.cpp
+++ b/controller/test/sensor_tests/SensorTests.cpp
@@ -164,42 +164,42 @@ TEST(SensorTests, FullScaleReading) {
 // you update the expected values accordingly.
 TEST(SensorTests, TestPositiveVolumetricFlowCalculation) {
   sensors_init();
-  float volumFlow = pressure_delta_to_volumetric_flow(1.0f);
+  float volumFlow = pressure_delta_to_flow(1.0f);
   // 1 kPa differential pressure should result in 9.52e-4 [m^3/s] of Q
   EXPECT_NEAR(volumFlow, 9.52e-4f, COMPARISON_TOLERANCE_FLOW);
 }
 
 TEST(SensorTests, TestNegativeVolumetricFlowCalculation) {
   sensors_init();
-  float volumFlow = pressure_delta_to_volumetric_flow(-1.0f);
+  float volumFlow = pressure_delta_to_flow(-1.0f);
   // -1 kPa differential pressure should result in -9.52e-4 [m^3/s] of Q
   EXPECT_NEAR(volumFlow, -9.52e-4f, COMPARISON_TOLERANCE_FLOW);
 }
 
 TEST(SensorTests, TestZeroVolumetricFlowCalculation) {
   sensors_init();
-  float volumFlow = pressure_delta_to_volumetric_flow(0.0f);
+  float volumFlow = pressure_delta_to_flow(0.0f);
   // 0 kPa differential pressure should result in 0 [m^3/s] of Q
   EXPECT_NEAR(volumFlow, 0.0f, COMPARISON_TOLERANCE_FLOW);
 }
 
 TEST(SensorTests, TestNearZeroVolumetricFlowCalculation) {
   sensors_init();
-  float volumFlow = pressure_delta_to_volumetric_flow(1.0e-7f);
+  float volumFlow = pressure_delta_to_flow(1.0e-7f);
   // 1e-7 kPa differential pressure should result in 3.07e-7 [m^3/s] of Q
   EXPECT_NEAR(volumFlow, 3.07e-7f, COMPARISON_TOLERANCE_FLOW);
 }
 
 TEST(SensorTests, TestLargeVolumetricFlowCalculation) {
   sensors_init();
-  float volumFlow = pressure_delta_to_volumetric_flow(100.0f);
+  float volumFlow = pressure_delta_to_flow(100.0f);
   // 100 kPa differential pressure should result in 9.72e-3 [m^3/s] of Q
   EXPECT_NEAR(volumFlow, 9.72e-3f, COMPARISON_TOLERANCE_FLOW);
 }
 
 TEST(SensorTests, TestSmallVolumetricFlowCalculation) {
   sensors_init();
-  float volumFlow = pressure_delta_to_volumetric_flow(-100.0f);
+  float volumFlow = pressure_delta_to_flow(-100.0f);
   // -100 kPa differential pressure should result in -9.72e-3 [m^3/s] of Q
   EXPECT_NEAR(volumFlow, -9.72e-3f, COMPARISON_TOLERANCE_FLOW);
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix flow calculation.
    
    Instead of
    
      f(pressure_inhalation) - f(pressure_exhalation)
    
    it should be
    
      f(pressure_inhalation - pressure_exhalation),
    
    where f is pressure_delta_to_volumetric_flow.
    
    Sadly no unit tests yet, because pid.cpp can't be tested until the PID
    library it depends on is HAL-ified.
1. Rename some identifiers in sensors module.
    
    In the previous commit we identified a bug; we did f(x) - f(y) instead
    of f(x-y).  My guess is that maybe this was caused/exacerbated by a
    function name (that I suggested) being too long?  Try to shorten the
    name.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #172 Cosmetic and functional improvements to pid.cpp
1. 👉 #173 Fix flow calculation 👈 **YOU ARE HERE**

</git-pr-chain>

