### PR TITLE
Set explicit cwd in .ycm_extra_conf.py

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -49,6 +49,11 @@ import ycm_core
 DIR_OF_THIS_SCRIPT = os.path.abspath(os.path.dirname(__file__))
 SOURCE_EXTENSIONS = [".cpp", ".cxx", ".cc", ".c", ".m", ".mm"]
 
+# I am unclear on what is the working directory used when this script is
+# invoked; it seems to change?  For our purposes, the working directory should
+# be the location of the script itself.
+os.chdir(DIR_OF_THIS_SCRIPT)
+
 
 def pio_pkg_dir(pkg):
     return os.path.join(os.environ["HOME"], ".platformio/packages", pkg)


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Set explicit cwd in .ycm_extra_conf.py.
    
    I don't understand what YCM is doing, but it seems like the
    .ycm_extra_conf.py is invoked from different working directories, but
    YCM expects the include paths always to be relative to the script's
    directory.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #178 Set explicit cwd in .ycm_extra_conf.py 👈 **YOU ARE HERE**
1. #172 Cosmetic and functional improvements to pid.cpp
1. #180 Simplify sensor calibration routine.

</git-pr-chain>


