### PR TITLE
Take higher-level args in HAL::analogRead().

### DIFF
--- a/controller/include/pid.h
+++ b/controller/include/pid.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include "hal.h"
 #include "network_protocol.pb.h"
 
-inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A5;
 inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_6;
 
 // TODO(jlebar): Remove these dummy values and instead use the state sent from

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -34,54 +34,43 @@ static const float ROOT_OF_TWO_OVER_DENSITY_OF_AIR =
 // per count) [V];
 static const float ADC_LSB = 5.0f / 1024.0f;
 
-// zero calibration values for the different pressure sensors.
-static int sensorZeroVals[static_cast<int>(AnalogPinId::COUNT)] = {0};
+// Take this many samples from a sensor while zeroing it.
+// TODO: Tune this value.
+static constexpr int SENSOR_SAMPLES_FOR_INIT = 4;
 
-// number of samples to perform averaging over during sensor zeroization
-static int zeroingAvgSize = 4;
-// number of samples to perform averaging over during calibrated sensor reads
-static int sensorAvgSize = 2;
+// Take this many samples from a sensor while reading it.
+// TODO: Tune this value.
+static constexpr int SENSOR_SAMPLES_FOR_READ = 2;
 
-void set_zero_avg_samples(int numAvgSamples) {
-  if (numAvgSamples < 1 || numAvgSamples > 32) {
-    return;
+namespace {
+enum Sensor {
+  PATIENT_PRESSURE,
+  INFLOW_PRESSURE_DIFF,
+  OUTFLOW_PRESSURE_DIFF,
+};
+
+// Keep this in sync with the Sensors enum!
+constexpr int NUM_SENSORS = 3;
+
+} // anonymous namespace
+
+static float sensorZeroVals[NUM_SENSORS];
+
+AnalogPin pin_for(Sensor s) {
+  switch (s) {
+  case PATIENT_PRESSURE:
+    return AnalogPin::PATIENT_PRESSURE;
+  case INFLOW_PRESSURE_DIFF:
+    return AnalogPin::INFLOW_PRESSURE_DIFF;
+  case OUTFLOW_PRESSURE_DIFF:
+    return AnalogPin::OUTFLOW_PRESSURE_DIFF;
   }
-  zeroingAvgSize = numAvgSamples;
+  // Switch above covers all cases.
+  __builtin_unreachable();
 }
 
-int get_zero_avg_samples() { return zeroingAvgSize; }
-
-void set_sensor_avg_samples(int numAvgSamples) {
-  if (numAvgSamples < 1 || numAvgSamples > 32) {
-    return;
-  }
-  sensorAvgSize = numAvgSamples;
-}
-
-int get_sensor_avg_samples() { return sensorAvgSize; }
-
-static float diameterOfCircleToArea(float diameter) {
+static float diameter_to_area(float diameter) {
   return static_cast<float>(M_PI) / 4.0f * diameter * diameter;
-}
-
-/*
- * @brief This method gets the zero pressure readings from the specified sensor
- * and averages them according to zeroingAvgSize. Called from zero_sensors(),
- * not for external use as zero_sensors() ensures correct system configuration.
- *
- * @param pressureSensor the sensor from the pressureSensor enum that a reading
- * is desired from
- *
- * @return The averaged sensor zero reading in ADC counts for the specified
- * pressureSensor enum member
- */
-static int get_raw_sensor_zero_reading(AnalogPinId pinId) {
-  int runningSum = 0;
-  for (int i = 0; i < zeroingAvgSize; i++) {
-    runningSum += Hal.analogRead(pinId);
-  }
-  // disregarding remainder because that's in the noise floor anyway
-  return runningSum / zeroingAvgSize;
 }
 
 void sensors_init() {
@@ -95,41 +84,55 @@ void sensors_init() {
   //    long enough; even it if is, we'd need to prove it.
   //
   //  - On the other hand, we can't wait a lot *longer* than 20ms because the
-  //    controller and GUI both have watchdogs that will restart the controller
-  //    if it hangs, and this sleep looks like a hang.
+  //    controller watchdog and (putative) GUI watchdog may reset the
+  //    controller if it hangs, and this sleep looks like a hang.
   //
   // It seems that we'll need to save calibration readings to non-volatile
   // memory and provide operators with a way to shut off the device's blowers,
   // open any necessary valves, and recalibrate.
   Hal.delay(20);
-  sensorZeroVals[static_cast<int>(PressureSensors::PATIENT_PIN)] =
-      get_raw_sensor_zero_reading(PressureSensors::PATIENT_PIN);
-  sensorZeroVals[static_cast<int>(PressureSensors::INHALATION_PIN)] =
-      get_raw_sensor_zero_reading(PressureSensors::INHALATION_PIN);
-  sensorZeroVals[static_cast<int>(PressureSensors::EXHALATION_PIN)] =
-      get_raw_sensor_zero_reading(PressureSensors::EXHALATION_PIN);
+
+  auto set_zero_level = [](Sensor s) {
+    int sum = 0;
+    for (int i = 0; i < SENSOR_SAMPLES_FOR_INIT; i++) {
+      sum += Hal.analogRead(pin_for(s));
+    }
+    sensorZeroVals[s] = static_cast<float>(sum) / SENSOR_SAMPLES_FOR_INIT;
+  };
+  set_zero_level(PATIENT_PRESSURE);
+  set_zero_level(INFLOW_PRESSURE_DIFF);
+  set_zero_level(OUTFLOW_PRESSURE_DIFF);
 }
 
-//@TODO: Add alarms if sensor value is out of expected range?
-float get_pressure_reading(AnalogPinId pinId) {
-  int runningSum = 0;
-  for (int i = 0; i < sensorAvgSize; i++) {
-    runningSum +=
-        (Hal.analogRead(pinId) - sensorZeroVals[static_cast<int>(pinId)]);
+// Reads a sensor, returning its value in kPa.
+//
+// @TODO: Add alarms if sensor value is out of expected range?
+static float read_sensor(Sensor s) {
+  int sum = 0;
+  for (int i = 0; i < SENSOR_SAMPLES_FOR_READ; i++) {
+    sum += Hal.analogRead(pin_for(s)) - sensorZeroVals[s];
   }
-  // disregarding remainder because that's in the noise floor anyway
-  runningSum /= sensorAvgSize;
   // Sensitivity of all pressure sensors is 1 V/kPa; no division needed.
-  return ((float)runningSum * ADC_LSB);
+  return static_cast<float>(sum) / SENSOR_SAMPLES_FOR_READ * ADC_LSB;
+}
+
+float get_patient_pressure_kpa() { return read_sensor(PATIENT_PRESSURE); }
+
+float get_volumetric_inflow_m3ps() {
+  return pressure_delta_to_volumetric_flow(read_sensor(INFLOW_PRESSURE_DIFF));
+}
+
+float get_volumetric_outflow_m3ps() {
+  return pressure_delta_to_volumetric_flow(read_sensor(OUTFLOW_PRESSURE_DIFF));
 }
 
 float pressure_delta_to_volumetric_flow(float diffPressureInKiloPascals) {
   // TODO(jlebar): Make these constexpr once we have a C++ standard library
   // PortArea must be larger than the ChokeArea [meters^2]
   float venturiPortArea =
-      diameterOfCircleToArea(PressureSensors::DEFAULT_VENTURI_PORT_DIAM);
+      diameter_to_area(PressureSensors::DEFAULT_VENTURI_PORT_DIAM);
   float venturiChokeArea =
-      diameterOfCircleToArea(PressureSensors::DEFAULT_VENTURI_CHOKE_DIAM);
+      diameter_to_area(PressureSensors::DEFAULT_VENTURI_CHOKE_DIAM);
   //[meters^4]
   float venturiAreaProduct = venturiPortArea * venturiChokeArea;
   // Equivalent to 1/sqrt(A1^2 - A2^2) guaranteed never to have a negative

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -29,13 +29,6 @@ class PressureSensors {
 public:
   PressureSensors() = delete;
 
-  // Patient pressure sensor pin
-  inline constexpr static AnalogPinId PATIENT_PIN = AnalogPinId::HAL_A0;
-  // Inhalation diff pressure sensor pin
-  inline constexpr static AnalogPinId INHALATION_PIN = AnalogPinId::HAL_A1;
-  // Exhalation diff pressure sensor pin
-  inline constexpr static AnalogPinId EXHALATION_PIN = AnalogPinId::HAL_A2;
-
   // min/max possible reading from MPXV5004GP [kPa]
   inline constexpr static float P_VAL_MIN = 0.0f;
   inline constexpr static float P_VAL_MAX = 3.92f;
@@ -56,49 +49,16 @@ public:
 
 void sensors_init();
 
-/*
- * @brief This method gets the specified calibrated sensor reading and performs
- * simple averaging if configured to do so.
- *
- * @param pinId the pressure sensor pin that a reading is desired from
- *
- * @return The specified pressure sensor calibrated reading in [kPa]
- */
-float get_pressure_reading(AnalogPinId pinId);
+// Gets gets the current pressure at the patient, in kPa.
+float get_patient_pressure_kpa();
 
-/*
- * @brief Method for setting the number of samples to use for average during
- * sensor zeroization.
- *
- * @param numAvgSamples the number of samples to use for averaging, between 1
- * and 32 inclusive
- */
-void set_zero_avg_samples(int numAvgSamples);
+// Gets the volumetric inflow (i.e. rate of air flowing into the patient), in
+// meters^3/sec.
+float get_volumetric_inflow_m3ps();
 
-/*
- * @brief Method for getting the number of samples in use for averaging during
- * sensor zeroization.
- *
- * @return A number between 1 and 32 inclusive.
- */
-int get_zero_avg_samples();
-
-/*
- * @brief Method for setting the number of samples to use for average during
- * sensor zeroization.
- *
- * @param numAvgSamples the number of samples to use for averaging, between 1
- * and 32 inclusive
- */
-void set_sensor_avg_samples(int numAvgSamples);
-
-/*
- * @brief Method for getting the number of samples in use for averaging during
- * calibrated sensor reads.
- *
- * @return A number between 1 and 32 inclusive.
- */
-int get_sensor_avg_samples();
+// Gets the volumetric outflow (i.e. rate of air flowing out of the patient),
+// in meters^3/sec.
+float get_volumetric_outflow_m3ps();
 
 /*
  * @brief Method implements Bernoulli's equation assuming the Venturi Effect.

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -52,6 +52,7 @@ limitations under the License.
 #endif
 
 #include <deque>
+#include <map>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -97,18 +98,18 @@ enum class PinMode : uint8_t {
 // Usage: VoltageLevel::HAL_HIGH, HAL_LOW
 enum class VoltageLevel : uint8_t { HAL_CONSTANT(HIGH), HAL_CONSTANT(LOW) };
 
-// ID of an analog pin.
-// Usage: AnalogPinId::HAL_A0 etc.
-enum class AnalogPinId {
-  HAL_CONSTANT(A0),
-  HAL_CONSTANT(A1),
-  HAL_CONSTANT(A2),
-  HAL_CONSTANT(A3),
-  HAL_CONSTANT(A4),
-  HAL_CONSTANT(A5),
-  // https://github.com/arduino/ArduinoCore-avr/blob/master/variants/standard/pins_arduino.h
-  // has 7 named analog pins, the largest of which, A7, has id 21.
-  COUNT = 22
+enum class AnalogPin {
+  // PATIENT_PRESSURE is an MPXV5004 sensor, reading an absolute pressure
+  // value at the patient.
+  //
+  // {INFLOW,OUTFLOW}_PRESSURE_DIFF are MPXV5004 sensors, reading a pressure
+  // differential across a venturi.  They let us measure volumetric flow into
+  // and out of the patient.
+  //
+  // Details at https://bit.ly/3bFwhpP
+  PATIENT_PRESSURE,
+  INFLOW_PRESSURE_DIFF,
+  OUTFLOW_PRESSURE_DIFF,
 };
 
 // IDs of the digital pins that can be used for pulse-width modulation.
@@ -146,11 +147,16 @@ public:
   // analogRead() reads the value of an analog input pin. analogWrite() writes
   // to a PWM pin - some of the digital pins are PWM pins.
 
+  // Reads from analog sensor.
+  //
+  // On Arduino, the analog-to-digital converter has 10 bits of precision, so
+  // you get a number in the range [0, 1024).
+  //
   // In test mode, will return the last value set via test_setAnalogPin.
-  int analogRead(AnalogPinId pin);
+  int analogRead(AnalogPin pin);
 
 #ifdef TEST_MODE
-  void test_setAnalogPin(AnalogPinId pin, int value);
+  void test_setAnalogPin(AnalogPin pin, int value);
 #endif
 
   // TODO(jlebar): Make digital pin number strongly typed?  It's slightly
@@ -241,9 +247,8 @@ private:
   // Instance variables used when mocking HAL.
 
   uint32_t millis_ = 0;
-  // Arduino Uno has 6 analog input pins and 14 digital input/output pins.
-  // Source: https://store.arduino.cc/usa/arduino-uno-rev3
-  int analog_pin_values_[6] = {0};
+
+  std::map<AnalogPin, int> analog_pin_values_;
 
   VoltageLevel digital_pin_values_[14] = {VoltageLevel::HAL_LOW};
   // The default pin mode on Arduino is INPUT.
@@ -285,8 +290,20 @@ inline void HalApi::init() {
 }
 inline uint32_t HalApi::millis() { return ::millis(); }
 inline void HalApi::delay(uint32_t ms) { ::delay(ms); }
-inline int HalApi::analogRead(AnalogPinId pin) {
-  return ::analogRead(static_cast<int>(pin));
+inline int HalApi::analogRead(AnalogPin pin) {
+  int raw_pin = [&] {
+    switch (pin) {
+    case AnalogPin::PATIENT_PRESSURE:
+      return A0;
+    case AnalogPin::INFLOW_PRESSURE_DIFF:
+      return A1;
+    case AnalogPin::OUTFLOW_PRESSURE_DIFF:
+      return A2;
+    }
+    // Switch above covers all cases (and gcc enforces this).
+    __builtin_unreachable();
+  }();
+  return ::analogRead(raw_pin);
 }
 inline void HalApi::setDigitalPinMode(int pin, PinMode mode) {
   ::pinMode(pin, static_cast<uint8_t>(mode));
@@ -343,11 +360,11 @@ inline void HalApi::watchdog_handler() {
 
 inline uint32_t HalApi::millis() { return millis_; }
 inline void HalApi::delay(uint32_t ms) { millis_ += ms; }
-inline int HalApi::analogRead(AnalogPinId pin) {
-  return analog_pin_values_[static_cast<int>(pin)];
+inline int HalApi::analogRead(AnalogPin pin) {
+  return analog_pin_values_.at(pin);
 }
-inline void HalApi::test_setAnalogPin(AnalogPinId pin, int value) {
-  analog_pin_values_[static_cast<int>(pin)] = value;
+inline void HalApi::test_setAnalogPin(AnalogPin pin, int value) {
+  analog_pin_values_[pin] = value;
 }
 inline void HalApi::setDigitalPinMode(int pin, PinMode mode) {
   digital_pin_modes_[pin] = mode;

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -133,7 +133,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // Edwin says IRL that these pressure sensors should never return negative
   // values.
 
-  int sensorValue = Hal.analogRead(DPSENSOR_PIN); // read sensor
+  int sensorValue = Hal.analogRead(AnalogPin::PATIENT_PRESSURE); // read sensor
   // int16_t sensorValue = get_pressure_reading(PressureSensors::SomeDPPin);
   Input = map(sensorValue, 0, 1023, 0, 255); // map to output scale
   myPID.Compute();                           // computer PID command
@@ -143,8 +143,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // This pressure is just from the patient sensor, converted to the right
   // units.
   // Convert [kPa] to [cm H2O] in place
-  readings->pressure_cm_h2o =
-      get_pressure_reading(PressureSensors::PATIENT_PIN) * 10.1974f;
+  readings->pressure_cm_h2o = get_patient_pressure_kpa() * 10.1974f;
   // TODO(anyone): This value is to be the integration over time of the below
   // flow_ml_per_min. That is, you take the value calculated for flow_ml_per_min
   // and integrate it over time to get total volume at the current time. Don't
@@ -154,9 +153,6 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // into lungs, and negative is flow out of lungs.
   // Convert [meters^3/s] to [mL/min] in place
   readings->flow_ml_per_min =
-      (pressure_delta_to_volumetric_flow(
-           get_pressure_reading(PressureSensors::INHALATION_PIN)) -
-       pressure_delta_to_volumetric_flow(
-           get_pressure_reading(PressureSensors::EXHALATION_PIN))) *
-      1000.0f * 1000.0f * 60.0f;
+      (get_volumetric_inflow_m3ps() - get_volumetric_outflow_m3ps()) * 1000.0f *
+      1000.0f * 60.0f;
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Take higher-level args in HAL::analogRead().
    
    Instead of analogRead(AnalogPinId::HAL_A0), we now do
    analogRead(AnalogPin::PATIENT_PRESSURE).
    
    This way the pinout of the STM32 doesn't have to be identical to that of
    the Arduino.  I also think it's just easier to follow.
    
    It's a TODO to adopt this same strategy for everything else in HAL.
    
    I also made the sensor code higher level in the same way.  Instead of
    returning the raw pressure for each of the three sensors, we now return
    the absolute pressure for the one sensor that reads that, and the
    computed volumetric flow for the two sensors that (indirectly) measure
    this.
    
    Among other things, this makes it impossible to write the bug that I
    tried to introduce in
    https://github.com/RespiraWorks/VentilatorSoftware/pull/173.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #172 Cosmetic and functional improvements to pid.cpp
1. #180 Simplify sensor calibration routine.
1. 👉 #183 Take higher-level args in HAL::analogRead(). 👈 **YOU ARE HERE**

</git-pr-chain>
