### PR TITLE
Take higher-level args in HAL::analogRead().

### DIFF
--- a/controller/include/pid.h
+++ b/controller/include/pid.h
@@ -20,7 +20,6 @@ limitations under the License.
 #include "hal.h"
 #include "network_protocol.pb.h"
 
-inline constexpr AnalogPinId DPSENSOR_PIN = AnalogPinId::HAL_A5;
 inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_6;
 
 // TODO(jlebar): Remove these dummy values and instead use the state sent from

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -29,13 +29,6 @@ class PressureSensors {
 public:
   PressureSensors() = delete;
 
-  // Patient pressure sensor pin
-  inline constexpr static AnalogPinId PATIENT_PIN = AnalogPinId::HAL_A0;
-  // Inhalation diff pressure sensor pin
-  inline constexpr static AnalogPinId INHALATION_PIN = AnalogPinId::HAL_A1;
-  // Exhalation diff pressure sensor pin
-  inline constexpr static AnalogPinId EXHALATION_PIN = AnalogPinId::HAL_A2;
-
   // min/max possible reading from MPXV5004GP [kPa]
   inline constexpr static float P_VAL_MIN = 0.0f;
   inline constexpr static float P_VAL_MAX = 3.92f;
@@ -56,49 +49,16 @@ public:
 
 void sensors_init();
 
-/*
- * @brief This method gets the specified calibrated sensor reading and performs
- * simple averaging if configured to do so.
- *
- * @param pinId the pressure sensor pin that a reading is desired from
- *
- * @return The specified pressure sensor calibrated reading in [kPa]
- */
-float get_pressure_reading(AnalogPinId pinId);
+// Gets gets the current pressure at the patient, in kPa.
+float get_patient_pressure_kpa();
 
-/*
- * @brief Method for setting the number of samples to use for average during
- * sensor zeroization.
- *
- * @param numAvgSamples the number of samples to use for averaging, between 1
- * and 32 inclusive
- */
-void set_zero_avg_samples(int numAvgSamples);
+// Gets the volumetric inflow (i.e. rate of air flowing into the patient), in
+// meters^3/sec.
+float get_volumetric_inflow_m3ps();
 
-/*
- * @brief Method for getting the number of samples in use for averaging during
- * sensor zeroization.
- *
- * @return A number between 1 and 32 inclusive.
- */
-int get_zero_avg_samples();
-
-/*
- * @brief Method for setting the number of samples to use for average during
- * sensor zeroization.
- *
- * @param numAvgSamples the number of samples to use for averaging, between 1
- * and 32 inclusive
- */
-void set_sensor_avg_samples(int numAvgSamples);
-
-/*
- * @brief Method for getting the number of samples in use for averaging during
- * calibrated sensor reads.
- *
- * @return A number between 1 and 32 inclusive.
- */
-int get_sensor_avg_samples();
+// Gets the volumetric outflow (i.e. rate of air flowing out of the patient),
+// in meters^3/sec.
+float get_volumetric_outflow_m3ps();
 
 /*
  * @brief Method implements Bernoulli's equation assuming the Venturi Effect.

--- a/controller/src/pid.cpp
+++ b/controller/src/pid.cpp
@@ -133,7 +133,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // Edwin says IRL that these pressure sensors should never return negative
   // values.
 
-  int sensorValue = Hal.analogRead(DPSENSOR_PIN); // read sensor
+  int sensorValue = Hal.analogRead(AnalogPin::PATIENT_PRESSURE); // read sensor
   // int16_t sensorValue = get_pressure_reading(PressureSensors::SomeDPPin);
   Input = map(sensorValue, 0, 1023, 0, 255); // map to output scale
   myPID.Compute();                           // computer PID command
@@ -143,8 +143,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // This pressure is just from the patient sensor, converted to the right
   // units.
   // Convert [kPa] to [cm H2O] in place
-  readings->pressure_cm_h2o =
-      get_pressure_reading(PressureSensors::PATIENT_PIN) * 10.1974f;
+  readings->pressure_cm_h2o = get_patient_pressure_kpa() * 10.1974f;
   // TODO(anyone): This value is to be the integration over time of the below
   // flow_ml_per_min. That is, you take the value calculated for flow_ml_per_min
   // and integrate it over time to get total volume at the current time. Don't
@@ -154,9 +153,6 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // into lungs, and negative is flow out of lungs.
   // Convert [meters^3/s] to [mL/min] in place
   readings->flow_ml_per_min =
-      (pressure_delta_to_volumetric_flow(
-           get_pressure_reading(PressureSensors::INHALATION_PIN)) -
-       pressure_delta_to_volumetric_flow(
-           get_pressure_reading(PressureSensors::EXHALATION_PIN))) *
-      1000.0f * 1000.0f * 60.0f;
+      (get_volumetric_inflow_m3ps() - get_volumetric_outflow_m3ps()) * 1000.0f *
+      1000.0f * 60.0f;
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Take higher-level args in HAL::analogRead().
    
    Instead of analogRead(AnalogPinId::HAL_A0), we now do
    analogRead(AnalogPin::PATIENT_PRESSURE).
    
    This way the pinout of the STM32 doesn't have to be identical to that of
    the Arduino.  I also think it's just easier to follow.
    
    It's a TODO to adopt this same strategy for everything else in HAL.
    
    I also made the sensor code higher level in the same way.  Instead of
    returning the raw pressure for each of the three sensors, we now return
    the absolute pressure for the one sensor that reads that, and the
    computed volumetric flow for the two sensors that (indirectly) measure
    this.
    
    Among other things, this makes it impossible to write the bug that I
    tried to introduce in
    https://github.com/RespiraWorks/VentilatorSoftware/pull/173.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #186 Take higher-level args in HAL::analogRead(). 👈 **YOU ARE HERE**
1. #187 Clarify that we're using MPXV5004DP pressure sensors everywhere.
1. #188 Blacklist readability-convert-member-functions-to-static clang-tidy check.
1. #189 "Semantically-type" output pins.
1. #190 Clarify that HAL is not a mock.

</git-pr-chain>




