### PR TITLE
Blacklist readability-convert-member-functions-to-static clang-tidy check.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 # TODO(jkff): Re-enable google-readability-casting: it can be annoying, but it
 # can catch some nasty bugs. E.g. C-style casts happily cast a pointer to the
 # wrong type.
-Checks: '*,-*-magic-numbers,-hicpp-*,-cppcoreguidelines-*,-fuchsia-*,-clion-*,-cert-*,-readability-named-parameter,-llvm-header-guard,-google-readability-todo,-misc-unused-parameters,-*-braces-around-statements,-google-readability-casting,-readability-else-after-return,-modernize-use-auto,-modernize-use-trailing-return-type,-modernize-deprecated-headers,-llvm-include-order,-modernize-avoid-c-arrays,-readability-uppercase-literal-suffix,-bugprone-narrowing-conversions,-readability-isolate-declaration'
+Checks: '*,-*-magic-numbers,-hicpp-*,-cppcoreguidelines-*,-fuchsia-*,-clion-*,-cert-*,-readability-named-parameter,-llvm-header-guard,-google-readability-todo,-misc-unused-parameters,-*-braces-around-statements,-google-readability-casting,-readability-else-after-return,-modernize-use-auto,-modernize-use-trailing-return-type,-modernize-deprecated-headers,-llvm-include-order,-modernize-avoid-c-arrays,-readability-uppercase-literal-suffix,-bugprone-narrowing-conversions,-readability-isolate-declaration,-readability-convert-member-functions-to-static'
 WarningsAsErrors: '*'
 
 # TODO: Add naming style checks (readability-identifier-naming).


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Blacklist readability-convert-member-functions-to-static clang-tidy check.
    
    YCM was warning about this in HAL, where it was noisy.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #188 Blacklist readability-convert-member-functions-to-static clang-tidy check. 👈 **YOU ARE HERE**
1. #189 "Semantically-type" output pins.
1. #190 Clarify that HAL is not a mock.

</git-pr-chain>






