### PR TITLE
"Semantically-type" output pins.

### DIFF
--- a/controller/lib/core/control.cpp
+++ b/controller/lib/core/control.cpp
@@ -53,7 +53,6 @@ void pid_init() {
 
   // Turn the PID on.
   myPID.SetMode(AUTOMATIC);
-  Hal.setDigitalPinMode(BLOWERSPD_PIN, PinMode::HAL_OUTPUT);
 }
 
 void pid_execute(const VentParams &params, SensorReadings *readings) {
@@ -143,7 +142,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
   // int16_t sensorValue = get_pressure_reading(PressureSensors::SomeDPPin);
   Input = map(sensorValue, 0, 1023, 0, 255); // map to output scale
   myPID.Compute();                           // computer PID command
-  Hal.analogWrite(BLOWERSPD_PIN, static_cast<int>(Output)); // write output
+  Hal.analogWrite(PwmPin::BLOWER, static_cast<int>(Output)); // write output
 
   // Store sensor readings so they can eventually be sent to the GUI.
   // This pressure is just from the patient sensor, converted to the right

--- a/controller/lib/core/control.h
+++ b/controller/lib/core/control.h
@@ -19,8 +19,6 @@ limitations under the License.
 #include "network_protocol.pb.h"
 #include "pid.h"
 
-inline constexpr PwmPinId BLOWERSPD_PIN = PwmPinId::PWM_6;
-
 // TODO(jlebar): Remove these dummy values and instead use the state sent from
 // the GuiStatus object.
 inline constexpr int BLOWER_HIGH = 142;

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -32,6 +32,8 @@ static const float ROOT_OF_TWO_OVER_DENSITY_OF_AIR =
 
 // Arduino Nano ADC is 10 bit, default 5V Vref_P (~4.9 mV
 // per count) [V];
+//
+// TODO: Update this for STM32, see https://bit.ly/3aERr69.
 static const float ADC_LSB = 5.0f / 1024.0f;
 
 // Take this many samples from a sensor while zeroing it.

--- a/controller/lib/core/solenoid.cpp
+++ b/controller/lib/core/solenoid.cpp
@@ -18,10 +18,7 @@ limitations under the License.
 #include "hal.h"
 #include <stdint.h>
 
-// Solenoid output pin 5 TBC.
-static const int O_SOLENOID = 5;
-
-void solenoid_init() { Hal.setDigitalPinMode(O_SOLENOID, PinMode::HAL_OUTPUT); }
+void solenoid_init() {}
 
 void solenoid_open() {
   // TODO: The solenoid normally open/closed param shouldn't come from the GUI;


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. "Semantically-type" output pins.
    
    Instead of telling HAL to write to "pin X", we now tell HAL to write to
    the BLOWER/SOLENOID pin.
    
    This consolidates all of the "device X is attached to pin Y" logic into
    HAL, so that we can handle a different pinout on e.g. STM32.
    
    It also consolidates the setting of pins to OUTPUT into HAL.  We had a
    bug a few days ago where we were forgetting to set the blower to OUTPUT.
    But now HAL "owns" the notion that this pin is an output pin, so can
    reasonably do this for us, in a consolidated place.
    
    Also strongly-type the difference between "binary pins" that are always
    either high or low (e.g. our solenoid) and pins that we pulse-width
    modulate.  Of course any pin we PWM could also be set to all-high or
    all-low, but in practice we treat them differently and don't want to mix
    them up.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #189 "Semantically-type" output pins. 👈 **YOU ARE HERE**
1. #190 Clarify that HAL is not a mock.
1. #198 Fix ODR violation on map() function.
1. #193 Simplify blower PID state machine.
1. #194 Disable modernize-use-default-member-init clang-tidy warning
1. #195 Rename algorithm/alg -> stl/algorithm.h.
1. #197 Remove some unused options in network_protocol.proto.
1. #201 Add and use units library.
1. #202 Blacklist -misc-non-private-member-variables-in-classes clang-tidy check.
1. #196 Add stl/new.h.
1. #204 New blower FSM.
1. #203 Rejigger sensors constants.

</git-pr-chain>

















