### PR TITLE
Clarify that we're using MPXV5004DP pressure sensors everywhere.

### DIFF
--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -79,7 +79,8 @@ void sensors_init() {
   // TODO: Is 20ms the right amount of time?  We're basing it on the data sheet
   // for MPXV7002, https://www.nxp.com/docs/en/data-sheet/MPXV7002.pdf table 1,
   // last entry.  But we're not acutally using that pressure sensor, we're
-  // using MPXV500<x>!  20ms is probably fine, but we should verify.
+  // using MPXV5004DP!  The 5004DP datasheet doesn't say anything about a
+  // startup time.  20ms is probably fine, but we should verify.
   //
   // TODO: This is unsafe if/when the controller starts up while connected to a
   // patient!  Calibration is valid only if the physical system is quiescent,

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -99,14 +99,12 @@ enum class PinMode : uint8_t {
 enum class VoltageLevel : uint8_t { HAL_CONSTANT(HIGH), HAL_CONSTANT(LOW) };
 
 enum class AnalogPin {
-  // PATIENT_PRESSURE is an MPXV5004 sensor, reading an absolute pressure
-  // value at the patient.
+  // MPXV5004DP pressure sensors.
   //
-  // {INFLOW,OUTFLOW}_PRESSURE_DIFF are MPXV5004 sensors, reading a pressure
-  // differential across a venturi.  They let us measure volumetric flow into
-  // and out of the patient.
+  // PATIENT_PRESSURE reads an absolute pressure value at the patient.
   //
-  // Details at https://bit.ly/3bFwhpP
+  // {INFLOW,OUTFLOW}_PRESSURE_DIFF, read a differential across a venturi.
+  // They let us measure volumetric flow into and out of the patient.
   PATIENT_PRESSURE,
   INFLOW_PRESSURE_DIFF,
   OUTFLOW_PRESSURE_DIFF,


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Clarify that we're using MPXV5004DP pressure sensors everywhere.
    
    Previously we were using the V7002 for some of our sensors.
    
    No code changes are needed -- and we can actually test this! -- because
    the only difference between the two from our perspective is that they
    give different voltages for zero pressure.  Our code dynamically finds
    the zero value *anyway*, so it doesn't make a difference.
    
    I'm still looking for the canonical place that will list exactly what
    parts we're using, etc.  We'll be able to link to that from HAL once we
    have it.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #192 Clarify that we're using MPXV5004DP pressure sensors everywhere. 👈 **YOU ARE HERE**
1. #188 Blacklist readability-convert-member-functions-to-static clang-tidy check.
1. #189 "Semantically-type" output pins.
1. #190 Clarify that HAL is not a mock.

</git-pr-chain>
