### PR TITLE
Disable modernize-use-default-member-init clang-tidy warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,8 @@ Checks: >
   -readability-uppercase-literal-suffix,
   -bugprone-narrowing-conversions,
   -readability-isolate-declaration,
-  -readability-convert-member-functions-to-static
+  -readability-convert-member-functions-to-static,
+  -modernize-use-default-member-init,
 
 WarningsAsErrors: '*'
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Disable modernize-use-default-member-init clang-tidy warning
    
    This was complaining about
    
        enum class E {
          X,
          Y
        };
        class Foo {
          private:
            E val = E::X;
        };
    
    It suggested instead that I write it as `E val{};`, which seems far
    worse to me.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #194 Disable modernize-use-default-member-init clang-tidy warning 👈 **YOU ARE HERE**
1. #195 Rename algorithm/alg -> stl/algorithm.h.
1. #197 Remove some unused options in network_protocol.proto.
1. #201 Add and use units library.
1. #202 Blacklist -misc-non-private-member-variables-in-classes clang-tidy check.
1. #196 Add stl/new.h.
1. #204 New blower FSM.
1. #203 Rejigger sensors constants.

</git-pr-chain>















