### PR TITLE
Remove some unused options in network_protocol.proto.

### DIFF
--- a/common/generated_libs/network_protocol/network_protocol.pb.h
+++ b/common/generated_libs/network_protocol/network_protocol.pb.h
@@ -16,9 +16,7 @@ extern "C" {
 /* Enum definitions */
 typedef enum _VentMode {
     VentMode_OFF = 0,
-    VentMode_PRESSURE_CONTROL = 1,
-    VentMode_PRESSURE_ASSIST = 2,
-    VentMode_PRESSURE_SUPPORT = 3
+    VentMode_PRESSURE_CONTROL = 1
 } VentMode;
 
 typedef enum _AlarmKind {
@@ -42,7 +40,6 @@ typedef struct _SensorReadings {
 
 typedef struct _VentParams {
     VentMode mode;
-    uint32_t percent_inspiratory_o2;
     uint32_t peep_cm_h2o;
     uint32_t breaths_per_min;
     uint32_t pip_cm_h2o;
@@ -74,8 +71,8 @@ typedef struct _GuiStatus {
 
 /* Helper constants for enums */
 #define _VentMode_MIN VentMode_OFF
-#define _VentMode_MAX VentMode_PRESSURE_SUPPORT
-#define _VentMode_ARRAYSIZE ((VentMode)(VentMode_PRESSURE_SUPPORT+1))
+#define _VentMode_MAX VentMode_PRESSURE_CONTROL
+#define _VentMode_ARRAYSIZE ((VentMode)(VentMode_PRESSURE_CONTROL+1))
 
 #define _AlarmKind_MIN AlarmKind_RESPIRATORY_RATE_TOO_LOW
 #define _AlarmKind_MAX AlarmKind_TIDAL_VOLUME_TOO_HIGH
@@ -85,12 +82,12 @@ typedef struct _GuiStatus {
 /* Initializer values for message structs */
 #define GuiStatus_init_default                   {0, VentParams_init_default, 0, {Alarm_init_default, Alarm_init_default, Alarm_init_default, Alarm_init_default}}
 #define ControllerStatus_init_default            {0, VentParams_init_default, SensorReadings_init_default, 0, {Alarm_init_default, Alarm_init_default, Alarm_init_default, Alarm_init_default}}
-#define VentParams_init_default                  {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define VentParams_init_default                  {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define SensorReadings_init_default              {0, 0, 0}
 #define Alarm_init_default                       {0, _AlarmKind_MIN}
 #define GuiStatus_init_zero                      {0, VentParams_init_zero, 0, {Alarm_init_zero, Alarm_init_zero, Alarm_init_zero, Alarm_init_zero}}
 #define ControllerStatus_init_zero               {0, VentParams_init_zero, SensorReadings_init_zero, 0, {Alarm_init_zero, Alarm_init_zero, Alarm_init_zero, Alarm_init_zero}}
-#define VentParams_init_zero                     {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define VentParams_init_zero                     {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define SensorReadings_init_zero                 {0, 0, 0}
 #define Alarm_init_zero                          {0, _AlarmKind_MIN}
 
@@ -101,7 +98,6 @@ typedef struct _GuiStatus {
 #define SensorReadings_volume_ml_tag             2
 #define SensorReadings_flow_ml_per_min_tag       3
 #define VentParams_mode_tag                      1
-#define VentParams_percent_inspiratory_o2_tag    2
 #define VentParams_peep_cm_h2o_tag               3
 #define VentParams_breaths_per_min_tag           4
 #define VentParams_pip_cm_h2o_tag                5
@@ -144,7 +140,6 @@ X(a, STATIC,   REPEATED, MESSAGE,  controller_alarms,   4)
 
 #define VentParams_FIELDLIST(X, a) \
 X(a, STATIC,   REQUIRED, UENUM,    mode,              1) \
-X(a, STATIC,   REQUIRED, UINT32,   percent_inspiratory_o2,   2) \
 X(a, STATIC,   REQUIRED, UINT32,   peep_cm_h2o,       3) \
 X(a, STATIC,   REQUIRED, UINT32,   breaths_per_min,   4) \
 X(a, STATIC,   REQUIRED, UINT32,   pip_cm_h2o,        5) \
@@ -186,9 +181,9 @@ extern const pb_msgdesc_t Alarm_msg;
 #define Alarm_fields &Alarm_msg
 
 /* Maximum encoded size of messages (where known) */
-#define GuiStatus_size                           146
-#define ControllerStatus_size                    163
-#define VentParams_size                          73
+#define GuiStatus_size                           140
+#define ControllerStatus_size                    157
+#define VentParams_size                          67
 #define SensorReadings_size                      15
 #define Alarm_size                               13
 

--- a/common/generated_libs/network_protocol/network_protocol.proto
+++ b/common/generated_libs/network_protocol/network_protocol.proto
@@ -122,9 +122,10 @@ message ControllerStatus {
 message VentParams {
   required VentMode mode = 1;
 
-  required uint32 percent_inspiratory_o2 = 2; // FiO2 - frac inspiratory oxygen
-  required uint32 peep_cm_h2o = 3; // PEEP - positive end-expiratory pressure
+  // For more info on these terms, see
+  // https://github.com/RespiraWorks/VentilatorSoftware/wiki/Ventilator-Glossary
 
+  required uint32 peep_cm_h2o = 3; // PEEP - positive end-expiratory pressure
   required uint32 breaths_per_min = 4; // RR - respiratory rate
   required uint32 pip_cm_h2o = 5;      // PIP - peak inspiratory pressure
   required float inspiratory_expiratory_ratio = 6; // I:E
@@ -134,6 +135,10 @@ message VentParams {
 
   // TODO(jlebar): Is ml/min the correct unit for this?
   required uint32 expiratory_trigger_ml_per_min = 9; // V-trigger
+
+  // Notably missing here is FiO2 -- fraction of oxygen in inhaled air.
+  // Currently (2020-04-27) we anticipate this will be controlled externally,
+  // not within the ventilator.
 
   // Alarm if tidal volume falls outside this range.
   required uint32 alarm_lo_tidal_volume_ml = 10;
@@ -154,7 +159,6 @@ enum VentMode {
   //
   // Operational parameters:
   //
-  //   FiO2 - percent_inspiratory_o2
   //   PEEP - peep_cm_h2o
   //   RR   - breaths_per_min
   //   PIP  - pip_cm_h2o
@@ -173,7 +177,6 @@ enum VentMode {
   //
   // Operational parameters:
   //
-  //   FiO2      - percent_inspiratory_o2
   //   PEEP      - peep_cm_h2o
   //   min RR    - breaths_per_min (note, interpreted as a minimum here)
   //   PIP       - pip_cm_h2o
@@ -186,25 +189,11 @@ enum VentMode {
   //   alarm_hi_tidal_volume_ml
   //   alarm_hi_breaths_per_min
   //
-  PRESSURE_ASSIST = 2;
+  // TODO: Implement me!
+  // PRESSURE_ASSIST = 2;
 
-  // All inhalations and exhalations are triggered by the patient.
-  //
-  // Operational parameters:
-  //
-  //   FiO2      - percent_inspiratory_o2
-  //   PEEP      - peep_cm_h2o
-  //   PIP       - pip_cm_h2o
-  //   P-trigger - inspiratory_trigger_cm_h2o
-  //   V-trigger - expiratory_trigger_ml_per_min
-  //
-  // Alarm parameters:
-  //
-  //   alarm_lo_tidal_volume_ml
-  //   alarm_hi_tidal_volume_ml
-  //   alarm_lo_breaths_per_min
-  //   alarm_hi_breaths_per_min
-  PRESSURE_SUPPORT = 3;
+  // TODO: Implement me!
+  // ADAPTIVE_CONTROL_BREATH = 3;
 }
 
 message SensorReadings {

--- a/controller/test/comms/comms_test.cpp
+++ b/controller/test/comms/comms_test.cpp
@@ -12,8 +12,7 @@ TEST(CommTests, SendControllerStatus) {
   // comms_handler to send it.
   ControllerStatus s = ControllerStatus_init_zero;
   s.uptime_ms = 42;
-  s.active_params.mode = VentMode_PRESSURE_ASSIST;
-  s.active_params.percent_inspiratory_o2 = 60;
+  s.active_params.mode = VentMode_PRESSURE_CONTROL;
   s.active_params.peep_cm_h2o = 10;
   s.active_params.breaths_per_min = 15;
   s.active_params.pip_cm_h2o = 1;
@@ -49,8 +48,6 @@ TEST(CommTests, SendControllerStatus) {
   ASSERT_TRUE(pb_decode(&stream, ControllerStatus_fields, &sent));
   EXPECT_EQ(s.uptime_ms, sent.uptime_ms);
   EXPECT_EQ(s.active_params.mode, sent.active_params.mode);
-  EXPECT_EQ(s.active_params.percent_inspiratory_o2,
-            sent.active_params.percent_inspiratory_o2);
   EXPECT_EQ(s.active_params.peep_cm_h2o, sent.active_params.peep_cm_h2o);
   EXPECT_EQ(s.sensor_readings.pressure_cm_h2o,
             sent.sensor_readings.pressure_cm_h2o);
@@ -59,8 +56,7 @@ TEST(CommTests, SendControllerStatus) {
 TEST(CommTests, CommandRx) {
   GuiStatus s = GuiStatus_init_zero;
   s.uptime_ms = std::numeric_limits<uint32_t>::max() / 2;
-  s.desired_params.mode = VentMode_PRESSURE_ASSIST;
-  s.desired_params.percent_inspiratory_o2 = 60;
+  s.desired_params.mode = VentMode_PRESSURE_CONTROL;
   s.desired_params.peep_cm_h2o = 10;
   s.desired_params.breaths_per_min = 15;
   s.desired_params.pip_cm_h2o = 1;


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Remove some unused options in network_protocol.proto.
    
    - Remove FiO2 control.  Ethan said that he anticipates FiO2 will be
      controlled externally from the ventilator.
    
    - Remove PRESSURE_ASSIST / PRESSURE_SUPPORT ventilation modes.
    
      I am writing code that wants to switch() on ventilator modes, and
      getting rid of the unused modes means the switch() can cover all modes
      without a `default` case.  That way when we add a new mode, we'll get
      a compile error showing everything we have to change.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #197 Remove some unused options in network_protocol.proto. 👈 **YOU ARE HERE**
1. #201 Add and use units library.
1. #202 Blacklist -misc-non-private-member-variables-in-classes clang-tidy check.
1. #196 Add stl/new.h.
1. #204 New blower FSM.
1. #203 Rejigger sensors constants.

</git-pr-chain>

















