### PR TITLE
Fix ODR violation on map() function.

### DIFF
--- a/controller/lib/core/control.cpp
+++ b/controller/lib/core/control.cpp
@@ -40,9 +40,11 @@ enum class pid_fsm_state {
   expire_dwell = 4,
 };
 
-// TODO: move this into a mathematical library
-// This function is originally from the Arduino library
-long map(long x, long in_min, long in_max, long out_min, long out_max) {
+// Rescales x from range [in_min, in_max] to [out_min, out_max] using integer
+// math.  (This is a replacement for Arduino map(), because we don't want to
+// include Arduino.h outside of hal.)
+static long rescale(long x, long in_min, long in_max, long out_min,
+                    long out_max) {
   return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 }
 
@@ -140,7 +142,7 @@ void pid_execute(const VentParams &params, SensorReadings *readings) {
 
   int sensorValue = Hal.analogRead(AnalogPin::PATIENT_PRESSURE); // read sensor
   // int16_t sensorValue = get_pressure_reading(PressureSensors::SomeDPPin);
-  Input = map(sensorValue, 0, 1023, 0, 255); // map to output scale
+  Input = rescale(sensorValue, 0, 1023, 0, 255); // map to output scale
   myPID.Compute();                           // computer PID command
   Hal.analogWrite(PwmPin::BLOWER, static_cast<int>(Output)); // write output
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix ODR violation on map() function.
    
    It's an ODR violation for us to define ::map function and also link
    against Arduino code, which defines the same function.
    
    `pio run -e nucleo` catches this and thankfully raises an error.  (ODR
    violations don't always raise an error.)
    
    Making it static doesn't work, it's still a conflict (though now `pio
    run`) still catches it.  Rename the function.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #198 Fix ODR violation on map() function. 👈 **YOU ARE HERE**
1. #193 Simplify blower PID state machine.
1. #194 Disable modernize-use-default-member-init clang-tidy warning
1. #195 Rename algorithm/alg -> stl/algorithm.h.
1. #197 Remove some unused options in network_protocol.proto.
1. #201 Add and use units library.
1. #202 Blacklist -misc-non-private-member-variables-in-classes clang-tidy check.
1. #196 Add stl/new.h.
1. #204 New blower FSM.
1. #203 Rejigger sensors constants.

</git-pr-chain>










