### PR TITLE
Blacklist -misc-non-private-member-variables-in-classes clang-tidy check.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: >
   -readability-isolate-declaration,
   -readability-convert-member-functions-to-static,
   -modernize-use-default-member-init,
+  -misc-non-private-member-variables-in-classes,
 
 WarningsAsErrors: '*'
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Blacklist -misc-non-private-member-variables-in-classes clang-tidy check.
    
    This literally tries to enforce that every variable be private;
    protected is not allowed period.
    
    I sort of think this proves that we should go to a whitelist for
    clang-tidy checks.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #202 Blacklist -misc-non-private-member-variables-in-classes clang-tidy check. 👈 **YOU ARE HERE**
1. #196 Add stl/new.h.
1. #204 New blower FSM.
1. #203 Rejigger sensors constants.
1. #205 Clarify comment on sensor scaling factor.

</git-pr-chain>
















