### PR TITLE
Introduces GUI plumbing for keeping track of controller history.

### DIFF
--- a/gui/ProjectVentilatorGUI.pro
+++ b/gui/ProjectVentilatorGUI.pro
@@ -2,8 +2,11 @@ QT += core quick charts
 CONFIG += c++17
 DEFINES += QT_DEPRECATED_WARNINGS
 
-SOURCES += *.cpp
-HEADERS += *.h
+SOURCES += $$files("*.cpp")
+SOURCES += $$files("$$PWD/../common/**/*.c")
+HEADERS += $$files("*.h")
+HEADERS += $$files("$$PWD/../common/**/*.h")
+INCLUDEPATH += $$PWD/../common/third_party/nanopb
 RESOURCES += qml.qrc Logo.png
 DISTFILES += Logo.png
 TRANSLATIONS += ProjectVentilatorGUI_es_GT.ts

--- a/gui/ScopeView.qml
+++ b/gui/ScopeView.qml
@@ -56,15 +56,16 @@ ChartView
 
     ValueAxis
     {
-        id: axisX
-        min: 0
-        max: 1000
+        id: timeAxis
+        titleText: "Seconds ago"
+        min: -30
+        max: 0
         labelsColor: chartView.color
     }
 
     ValueAxis
     {
-        id: axisY
+        id: valueAxis
         min: -1.5
         max: 1.5
         labelsColor: chartView.color
@@ -74,18 +75,11 @@ ChartView
     {
         id: lineSeries
         name: chartView.name
-        axisX: axisX
-        axisY: axisY
+        axisX: timeAxis
+        axisY: valueAxis
         color: chartView.color
         pointLabelsColor: chartView.color
         width: 1
         useOpenGL: true
-    }
-
-    function createAxis(min, max)
-    {
-        // The following creates a ValueAxis object that can be then set as a x or y axis for a series
-        return Qt.createQmlObject("import QtQuick 2.0; import QtCharts 2.0; ValueAxis { min: "
-                                  + min + "; max: " + max + " }", chartView);
     }
 }

--- a/gui/chrono.h
+++ b/gui/chrono.h
@@ -1,0 +1,19 @@
+// Shorthands for the very verbose types and functions from std::chrono.
+#ifndef CHRONO_H
+#define CHRONO_H
+
+#include <chrono>
+
+using DurationMs = std::chrono::milliseconds;
+using SteadyClock = std::chrono::steady_clock;
+using SteadyInstant = std::chrono::time_point<SteadyClock>;
+
+// Given two time points a, b, computes a - b as a DurationMs.
+// The name is clunky but unambiguous as to which is subtracted
+// from which.
+template <typename TimePointT>
+DurationMs TimeAMinusB(TimePointT a, TimePointT b) {
+  return std::chrono::duration_cast<DurationMs>(a - b);
+}
+
+#endif // CHRONO_H

--- a/gui/connected_device.h
+++ b/gui/connected_device.h
@@ -1,0 +1,42 @@
+#ifndef CONNECTED_DEVICE_H
+#define CONNECTED_DEVICE_H
+
+#include "../common/generated_libs/network_protocol/network_protocol.pb.h"
+#include <functional>
+
+// Represents a connection to the device running the controller.
+class ConnectedDevice {
+public:
+  virtual ~ConnectedDevice() = default;
+
+  // Sends the GuiStatus to the controller. May block.
+  virtual void SendGuiStatus(const GuiStatus &gui_status) = 0;
+  // Reads a ControllerStatus from the controller. May block.
+  // TODO: Make sure both functions can't block indefinitely.
+  virtual void ReceiveControllerStatus(ControllerStatus *controller_status) = 0;
+};
+
+// A fake version of ConnectedDevice backed by a lambda for testing.
+class FakeConnectedDevice : public ConnectedDevice {
+public:
+  FakeConnectedDevice(std::function<void(const GuiStatus &)> send_fn,
+                      std::function<void(ControllerStatus *)> receive_fn)
+      : send_fn_(send_fn), receive_fn_(receive_fn) {}
+  ~FakeConnectedDevice() = default;
+
+  void SendGuiStatus(const GuiStatus &gui_status) override {
+    send_fn_(gui_status);
+  }
+  void ReceiveControllerStatus(ControllerStatus *controller_status) override {
+    receive_fn_(controller_status);
+  }
+
+private:
+  std::function<void(const GuiStatus &)> send_fn_;
+  std::function<void(ControllerStatus *)> receive_fn_;
+};
+
+// TODO: Define a subclass of ConnectedDevice that talks to a real device
+// over the serial port.
+
+#endif // CONNECTED_DEVICE_H

--- a/gui/controller_history.h
+++ b/gui/controller_history.h
@@ -1,0 +1,48 @@
+#ifndef CONTROLLER_HISTORY_H
+#define CONTROLLER_HISTORY_H
+
+#include "../common/generated_libs/network_protocol/network_protocol.pb.h"
+#include "chrono.h"
+
+#include <deque>
+
+// Maintains a history of recent ControllerStatus-es sufficient
+// for rendering the UI.
+//
+// Non-thread-safe, needs external synchronization.
+class ControllerHistory {
+public:
+  // Initializes the history to keep a window of given duration -
+  // meaning, if the oldest point is more than this much older than
+  // the point being added, it gets kicked out.
+  //
+  // TODO: Consider limiting also the total number of items, e.g. by
+  // evicting items in the middle to maintain the overall thing more
+  // or less uniformly sampled in time. This is harder to do efficiently
+  // though.
+  ControllerHistory(DurationMs window) : window_(window) {}
+
+  // Appends a ControllerStatus obtained at a given time point in GUI time.
+  // We cannot use the controller's uptime, because if controller restarts,
+  // uptime will appear to go backwards.
+  // For a similar reason we also must use specifically a steady clock
+  // (clock that never goes backwards) - as opposed to, say, the system clock.
+  void Append(SteadyInstant gui_now, const ControllerStatus &status) {
+    history_.push_back({gui_now, status});
+    // Kick out points that are too old.
+    while (!history_.empty() &&
+           gui_now - std::get<0>(history_.front()) > window_) {
+      history_.pop_front();
+    }
+  }
+
+  std::vector<std::tuple<SteadyInstant, ControllerStatus>> GetHistory() {
+    return {history_.begin(), history_.end()};
+  }
+
+private:
+  DurationMs window_;
+  std::deque<std::tuple<SteadyInstant, ControllerStatus>> history_;
+};
+
+#endif // CONTROLLER_HISTORY_H

--- a/gui/gui_state_container.h
+++ b/gui/gui_state_container.h
@@ -1,0 +1,67 @@
+#ifndef GUI_STATE_CONTAINER_H
+#define GUI_STATE_CONTAINER_H
+
+#include "chrono.h"
+#include "controller_history.h"
+
+#include <mutex>
+
+// A thread-safe container for readable and writable state
+// of the GUI.
+//
+// The rest of the GUI must bind itself to accessors and mutators
+// of this class - e.g. render graphs from GetControllerStatusHistory(),
+// and when a parameter is changed in the UI, call a mutator on this
+// object.
+//
+// In other words, this is essentially an MVC "Model".
+//
+// GUI rendering and callbacks happen asynchronously to interaction
+// with the controller, so thread safety is important, and it is easiest
+// to centralize it in the current class, simply protecting everything
+// by a single mutex.
+class GuiStateContainer {
+public:
+  // Initializes the state container to keep the history of controller
+  // statuses in a given time window.
+  GuiStateContainer(DurationMs history_window)
+      : startup_time_(SteadyClock::now()), history_(history_window) {}
+
+  // Returns when the GUI started up.
+  SteadyInstant GetStartupTime() { return startup_time_; }
+
+  // Adds a data point of controller status to the history.
+  void AppendHistory(const ControllerStatus &status) {
+    std::unique_lock<std::mutex> l(mu_);
+    history_.Append(SteadyClock::now(), status);
+  }
+
+  // Returns the current GuiStatus to be sent to the controller.
+  GuiStatus GetGuiStatus() {
+    std::unique_lock<std::mutex> l(mu_);
+    return gui_status_;
+  }
+
+  // TODO: Add mutators of GuiStatus when there are any UI elements
+  // that change parameters.
+
+  // Returns the recent history of ControllerStatus.
+  std::vector<std::tuple<SteadyInstant, ControllerStatus>>
+  GetControllerStatusHistory() {
+    std::unique_lock<std::mutex> l(mu_);
+    return history_.GetHistory();
+  }
+
+private:
+  const SteadyInstant startup_time_;
+
+  std::mutex mu_;
+  // TODO: Use thread safety annotations here and throughout the project.
+  // https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+  // They only work with clang, so we'll need a wrapper macro to have them
+  // be no-ops on gcc.
+  GuiStatus gui_status_ = GuiStatus_init_zero;
+  ControllerHistory history_;
+};
+
+#endif // GUI_STATE_CONTAINER_H

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1,5 +1,11 @@
 #include "datasource.h"
 
+#include "chrono.h"
+#include "connected_device.h"
+#include "controller_history.h"
+#include "gui_state_container.h"
+#include "periodic_closure.h"
+
 #include <QCommandLineParser>
 #include <QtCore/QDir>
 #include <QtQml/QQmlContext>
@@ -7,6 +13,8 @@
 #include <QtQuick/QQuickView>
 #include <QtWidgets/QApplication>
 #include <cmath>
+#include <iostream>
+#include <memory>
 
 int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
@@ -24,20 +32,72 @@ int main(int argc, char *argv[]) {
   parser.addOption(startupOnlyOption);
   parser.process(app);
 
-  auto generate_data = []() -> std::vector<std::tuple<float, float>> {
+  GuiStateContainer state_container(
+      /*history_window=*/DurationMs(30000));
+  auto startup_time = state_container.GetStartupTime();
+
+  std::unique_ptr<ConnectedDevice> device =
+      std::make_unique<FakeConnectedDevice>(
+          [&](const GuiStatus &gui_status) {
+            // For now, completely ignore gui_status.
+            (void)gui_status;
+          },
+          [&](ControllerStatus *controller_status) {
+            // Fill the status with fake data.
+            controller_status->uptime_ms =
+                TimeAMinusB(SteadyClock::now(), startup_time).count();
+            auto *sensors = &controller_status->sensor_readings;
+            sensors->pressure_cm_h2o =
+                sin(controller_status->uptime_ms * 0.001);
+            sensors->volume_ml = 0;
+            sensors->flow_ml_per_min = 0;
+          });
+
+  // TODO: Bind the readable aspects of state_container to UI elements
+  // TODO: Bind the writable aspects of state_container to parameters set in the
+  // UI
+
+  // TODO: Figure out whether asynchronously and periodically sending GUI status
+  // and receiving controller status is the right thing to do here.
+  PeriodicClosure send_gui_status(DurationMs(10), [&] {
+    device->SendGuiStatus(state_container.GetGuiStatus());
+  });
+  send_gui_status.Start();
+
+  PeriodicClosure maintain_history(DurationMs(10), [&] {
+    ControllerStatus controller_status;
+    device->ReceiveControllerStatus(&controller_status);
+    state_container.AppendHistory(controller_status);
+  });
+  maintain_history.Start();
+
+  auto generate_pressure = [&]() -> std::vector<std::tuple<float, float>> {
+    // TODO: If this is invoked several times for several different graphs,
+    // they will be slightly misaligned, because each gets its own value of
+    // "now". This will stop being a problem once the TODO below about filling
+    // in all 3 graphs at the same time is addressed.
+    auto now = SteadyClock::now();
+
+    // TODO: This makes a copy of the status history, and then it's copied
+    // one more time into the DataSource. We should reduce the amount of copying
+    // and allocation churn.
     std::vector<std::tuple<float, float>> res;
-    for (int i = 0; i < 1000; ++i) {
-      res.push_back({i, sin(0.01 * i)});
+    for (const auto &[time, controller_status] :
+         state_container.GetControllerStatusHistory()) {
+      int neg_millis_ago = TimeAMinusB(time, now).count();
+      res.push_back({neg_millis_ago * 0.001,
+                     controller_status.sensor_readings.pressure_cm_h2o});
     }
     return res;
   };
 
-  // This will need to be a source coming from the arduino
-  DataSource pressureDataSource(generate_data);
-  // This will need to be a source coming from the arduino
-  DataSource volumeDataSource(generate_data);
-  // This data source will be calulated from pressure and volume on the pi
-  DataSource flowDataSource(generate_data);
+  // TODO: Create lambdas for volume and flow as well
+  // TODO: Throw away DataSource and make something nicer that can
+  // fill in all 3 graphs with a single scan over GetControllerStatusHistory()
+  // instead of 3 scans.
+  DataSource pressureDataSource(generate_pressure);
+  DataSource volumeDataSource(generate_pressure);
+  DataSource flowDataSource(generate_pressure);
 
   QQuickView mainView;
   mainView.setTitle(QStringLiteral("Ventilator"));

--- a/gui/periodic_closure.cpp
+++ b/gui/periodic_closure.cpp
@@ -1,0 +1,45 @@
+#include "periodic_closure.h"
+
+#include <iostream>
+
+void PeriodicClosure::Start() {
+  loop_thread_ = std::thread(&PeriodicClosure::Loop, this);
+}
+
+void PeriodicClosure::Stop() {
+  if (!loop_thread_.joinable()) {
+    // Already stopped.
+    return;
+  }
+
+  {
+    std::unique_lock<std::mutex> l(mu_);
+    stop_requested_ = true;
+  }
+  // notify_one() should be called without holding the mutex.
+  stop_requested_cv_.notify_one();
+  loop_thread_.join();
+}
+
+void PeriodicClosure::Loop() {
+  while (true) {
+    fn_();
+
+    auto next_run = SteadyClock::now() + interval_;
+    std::unique_lock<std::mutex> l(mu_);
+    while (true) {
+      if (stop_requested_) {
+        // We're done.
+        return;
+      }
+      if (stop_requested_cv_.wait_until(l, next_run) ==
+          std::cv_status::timeout) {
+        // Time for the next run.
+        break;
+      } else {
+        // Either Stop() was called, or a spurious wake-up happened.
+        // The next iteration of this loop will tell.
+      }
+    }
+  }
+}

--- a/gui/periodic_closure.h
+++ b/gui/periodic_closure.h
@@ -1,0 +1,53 @@
+#ifndef PERIODIC_CLOSURE_H
+#define PERIODIC_CLOSURE_H
+
+#include "chrono.h"
+
+#include <condition_variable>
+#include <functional>
+#include <thread>
+
+// Executes a given lambda with a given interval between finishing one execution
+// and scheduling the next one. The interval is a lower bound.
+//
+// TODO: This class desperately needs unit tests, testing e.g.:
+//  - The closure is invoked with about the given interval
+//  - The closure is never invoked after Stop() completes
+//  - Stop() works correctly whether it's called while the closure runs or not
+//  - What happens if you never call Start()
+//  - etc.
+class PeriodicClosure {
+public:
+  // Initializes a PeriodicClosure to run the given lambda with a given
+  // interval.
+  //
+  // Note that you have to explicitly call Start().
+  PeriodicClosure(DurationMs interval, std::function<void()> fn)
+      : interval_(interval), fn_(std::move(fn)) {}
+
+  // Calls Stop().
+  ~PeriodicClosure() { Stop(); }
+
+  // Begins periodically running the given lambda.
+  void Start();
+  // Signals that periodical execution must cease, and waits for it to cease.
+  // After this completes, the lambda will never execute again.
+  // Blocks, but normally only for as long as it takes the lambda to complete,
+  // i.e. if the lambda is quick, this will return soon even if interval is
+  // large.
+  void Stop();
+
+private:
+  void Loop();
+
+  const DurationMs interval_;
+  const std::function<void()> fn_;
+
+  std::thread loop_thread_;
+
+  std::mutex mu_;
+  bool stop_requested_ = false;
+  std::condition_variable stop_requested_cv_;
+};
+
+#endif // PERIODIC_CLOSURE_H


### PR DESCRIPTION
This is part of issue #4 .

- Tweaks the QT project file to make nanopb and the generated protocol headers available
- Introduces a `ConnectedDevice` abstraction for exchanging state with a device. In this PR we add a fake, but @Miceuz , as a follow up, can make an implementation that uses the serial port and talks to the real controller.
- Introduces `ControllerHistory` that keeps track of the last N seconds of `ControllerStatus` protos
- Introduces `PeriodicClosure` that runs a lambda on a schedule, so we can e.g. get the next controller status every 10ms (I don't know what is an appropriate period).
- Introduces `GuiStateContainer` which will contain, in a thread-safe way, everything that the UI elements may need to read or write. It will be up to the UI to bind itself to components of `GuiStateContainer`.
- In `main.cpp`, wires these things together and puts them on the graphs. Currently I just put the same fake pressure data on all three graphs. Future PRs will have to do this the right way.

This PR unblocks the other GUI issues: #5 #6 #8 #9, as well as the rest of #4.

FYI: @rwilbur @lee-matthews @Miceuz @burnhamd 