### PR TITLE
Explicitly set the output limits in our blower PID.

### DIFF
--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -25,7 +25,7 @@ static double Input;
 static double Output;
 
 // Configure the PID
-// TODO: Tune these params.
+// TODO(#207): Tune these params.
 static constexpr float Kp = 2;
 static constexpr float Ki = 8;
 static constexpr float Kd = 0;
@@ -39,10 +39,14 @@ void blower_pid_init() {
   Input = 0;
   Output = 0;
 
+  // Our output is an 8-bit PWM.
+  myPID.SetOutputLimits(0, 255);
+
+  // TODO(#207): Tune this.
+  myPID.SetSampleTime(100); // ms
+
   // Turn the PID on.
   myPID.SetMode(AUTOMATIC);
-
-  // TODO: PID updates at 100ms by default, which is probably too slow for us?
 }
 
 void blower_pid_execute(Pressure setpoint, SensorReadings *readings,


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Explicitly set the output limits in our blower PID.
    
    No functional change; the default output limits were already 0-255.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #216 Explicitly set the output limits in our blower PID. 👈 **YOU ARE HERE**
1. #217 Control the solenoid from the Blower FSM.
1. #218 Add NO_GUI_DEV_MODE, for running the controller without a GUI.
1. #205 Clarify comment on sensor scaling factor.
1. #219 Tune PID.

</git-pr-chain>





