### PR TITLE
add pid library unit tests and fix issue seen with those unit tests

### DIFF
--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -46,7 +46,7 @@ PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
 
 PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
          double Kd, int ControllerDirection)
-    : PID::PID(Input, Output, Setpoint, Kp, Ki, Kd, P_ON_E, D_ON_E,
+    : PID::PID(Input, Output, Setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M,
                ControllerDirection) {}
 
 /* Compute()
@@ -60,15 +60,12 @@ bool PID::Compute() {
   if (!inAuto)
     return false;
   Time now = Hal.now();
-  Duration timeChange = now - lastTime;
-  if (timeChange >= SampleTime) {
-    // compute actual samples time-difference to take jitter into account in
-    // integral and derivative
-    double samplesTimeChangeSec = ((now - lastSampleTime) / 1000.0);
-    if (samplesTimeChangeSec <= 0) {
-      // something went wrong, assume sample time
-      samplesTimeChangeSec = (SampleTime / 1000.0);
-    }
+  Duration timeChange = (now - lastTime);
+  // compute actual samples time-difference to take jitter into account in
+  // integral and derivative
+  double samplesTimeChangeSec = (now - lastSampleTime).seconds();
+  // condition to update output : 1 sample time has passed and we have new data
+  if (timeChange >= SampleTime && samplesTimeChangeSec > 0) {
     /*Compute all the working error variables*/
     double input = *myInput;
     double error = *mySetpoint - input;

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -25,7 +25,7 @@ limitations under the License.
  *    reliable defaults, so we need to have the user set them.
  ***************************************************************************/
 PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
-         double Kd, int POn, int ControllerDirection)
+         double Kd, int POn, int DOn, int ControllerDirection) 
     : SampleTime(milliseconds(100)), lastTime(Hal.now() - SampleTime) {
   myOutput = Output;
   myInput = Input;
@@ -36,7 +36,7 @@ PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
                                 // the arduino pwm limits
 
   PID::SetControllerDirection(ControllerDirection);
-  PID::SetTunings(Kp, Ki, Kd, POn);
+  PID::SetTunings(Kp, Ki, Kd, POn, DOn);
 }
 
 /*Constructor (...)*********************************************************
@@ -46,7 +46,7 @@ PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
 
 PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
          double Kd, int ControllerDirection)
-    : PID::PID(Input, Output, Setpoint, Kp, Ki, Kd, P_ON_E,
+    : PID::PID(Input, Output, Setpoint, Kp, Ki, Kd, P_ON_E, D_ON_E,
                ControllerDirection) {}
 
 /* Compute()
@@ -72,7 +72,11 @@ bool PID::Compute() {
     /*Compute all the working error variables*/
     double input = *myInput;
     double error = *mySetpoint - input;
-    double dInput = ((input - lastInput) / samplesTimeChangeSec);
+    double dInput = 0.0;
+    // Compute dInput only if needed (P_ON_M or D_ON_M)
+    if (!pOnE || !dOnE) {
+      dInput = (input - lastInput);
+    }
     outputSum += (ki * error * samplesTimeChangeSec);
 
     /*Add Proportional on Measurement, if P_ON_M is specified*/
@@ -86,13 +90,20 @@ bool PID::Compute() {
 
     /*Add Proportional on Error, if P_ON_E is specified*/
     double output;
-    if (pOnE)
+    if (pOnE) {
       output = kp * error;
-    else
+    } else {
       output = 0;
-
-    /*Compute Rest of PID Output*/
-    output += outputSum - kd * dInput;
+    }
+    if (!dOnE) {
+      dInput /= samplesTimeChangeSec;
+      /*Compute Rest of PID Output*/
+      output += outputSum - kd * dInput;
+    } else {
+      double dError = (error - lastError) / samplesTimeChangeSec;
+      /*Compute Rest of PID Output*/
+      output += outputSum + kd * dError;
+    }
 
     if (output > outMax)
       output = outMax;
@@ -102,6 +113,7 @@ bool PID::Compute() {
 
     /*Remember some variables for next time*/
     lastInput = input;
+    lastError = error;
     lastTime += SampleTime; // this makes the PID able to somewhat "catch up"
     // when it looses a sample due to slow controller execution
     lastSampleTime = now;
@@ -115,12 +127,15 @@ bool PID::Compute() {
  * it's called automatically from the constructor, but tunings can also
  * be adjusted on the fly during normal operation
  ******************************************************************************/
-void PID::SetTunings(double Kp, double Ki, double Kd, int POn) {
+void PID::SetTunings(double Kp, double Ki, double Kd, int POn, int DOn) {
   if (Kp < 0 || Ki < 0 || Kd < 0)
     return;
 
   pOn = POn;
   pOnE = POn == P_ON_E;
+
+  dOn = DOn;
+  dOnE = DOn == D_ON_E;
 
   kp = Kp;
   ki = Ki;
@@ -134,10 +149,17 @@ void PID::SetTunings(double Kp, double Ki, double Kd, int POn) {
 }
 
 /* SetTunings(...)*************************************************************
- * Set Tunings using the last-rembered POn setting
+ * Set Tunings using the last-rembered  DOn setting
+ ******************************************************************************/
+void PID::SetTunings(double Kp, double Ki, double Kd, int POn) {
+  SetTunings(Kp, Ki, Kd, POn, dOn);
+}
+
+/* SetTunings(...)*************************************************************
+ * Set Tunings using the last-rembered POn and DOn setting
  ******************************************************************************/
 void PID::SetTunings(double Kp, double Ki, double Kd) {
-  SetTunings(Kp, Ki, Kd, pOn);
+  SetTunings(Kp, Ki, Kd, pOn, dOn);
 }
 
 /* SetSampleTime(...) *********************************************************
@@ -196,6 +218,7 @@ void PID::SetMode(int Mode) {
 void PID::Initialize() {
   outputSum = *myOutput;
   lastInput = *myInput;
+  lastError = *mySetpoint - *myInput;
   if (outputSum > outMax)
     outputSum = outMax;
   else if (outputSum < outMin)

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -62,11 +62,18 @@ bool PID::Compute() {
   Time now = Hal.now();
   Duration timeChange = now - lastTime;
   if (timeChange >= SampleTime) {
+    // compute actual samples time-difference to take jitter into account in
+    // integral and derivative
+    double samplesTimeChangeSec = ((now - lastSampleTime) / 1000.0);
+    if (samplesTimeChangeSec <= 0) {
+      // something went wrong, assume sample time
+      samplesTimeChangeSec = (SampleTime / 1000.0);
+    }
     /*Compute all the working error variables*/
     double input = *myInput;
     double error = *mySetpoint - input;
-    double dInput = (input - lastInput);
-    outputSum += (ki * error);
+    double dInput = ((input - lastInput) / samplesTimeChangeSec);
+    outputSum += (ki * error * samplesTimeChangeSec);
 
     /*Add Proportional on Measurement, if P_ON_M is specified*/
     if (!pOnE)
@@ -95,7 +102,9 @@ bool PID::Compute() {
 
     /*Remember some variables for next time*/
     lastInput = input;
-    lastTime = now;
+    lastTime += SampleTime; // this makes the PID able to somewhat "catch up"
+    // when it looses a sample due to slow controller execution
+    lastSampleTime = now;
     return true;
   } else
     return false;
@@ -113,14 +122,9 @@ void PID::SetTunings(double Kp, double Ki, double Kd, int POn) {
   pOn = POn;
   pOnE = POn == P_ON_E;
 
-  dispKp = Kp;
-  dispKi = Ki;
-  dispKd = Kd;
-
-  double SampleTimeInSec = SampleTime.seconds();
   kp = Kp;
-  ki = Ki * SampleTimeInSec;
-  kd = Kd / SampleTimeInSec;
+  ki = Ki;
+  kd = Kd;
 
   if (controllerDirection == REVERSE) {
     kp = (0 - kp);
@@ -141,9 +145,6 @@ void PID::SetTunings(double Kp, double Ki, double Kd) {
  ******************************************************************************/
 void PID::SetSampleTime(Duration NewSampleTime) {
   if (NewSampleTime > milliseconds(0)) {
-    double ratio = NewSampleTime.seconds() / SampleTime.seconds();
-    ki *= ratio;
-    kd /= ratio;
     SampleTime = NewSampleTime;
   }
 }
@@ -199,6 +200,8 @@ void PID::Initialize() {
     outputSum = outMax;
   else if (outputSum < outMin)
     outputSum = outMin;
+  lastTime = Hal.millis() - SampleTime;
+  lastSampleTime = lastTime;
 }
 
 /* SetControllerDirection(...)*************************************************
@@ -221,8 +224,9 @@ void PID::SetControllerDirection(int Direction) {
  * functions query the internal state of the PID.  they're here for display
  * purposes.  this are the functions the PID Front-end uses for example
  ******************************************************************************/
-double PID::GetKp() { return dispKp; }
-double PID::GetKi() { return dispKi; }
-double PID::GetKd() { return dispKd; }
+double PID::GetKp() { return kp; }
+double PID::GetKi() { return ki; }
+double PID::GetKd() { return kd; }
+int PID::GetSampleTime() { return SampleTime; }
 int PID::GetMode() { return inAuto ? AUTOMATIC : MANUAL; }
 int PID::GetDirection() { return controllerDirection; }

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -37,16 +37,17 @@ public:
 
   // commonly used functions
   // **************************************************************************
-  PID(double *, double *,
-      double *, // * constructor.  links the PID to the Input, Output, and
-      double, double, double, int, int,
-      int); //   Setpoint.  Initial tuning parameters are also set here.
-            //   (overload for specifying proportional and derivative modes)
+  PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
+      double Kd, bool POn, bool DOn, int ControllerDirection);
+  // * constructor.  links the PID to the Input, Output, and
+  //   Setpoint.  Initial tuning parameters are also set here.
+  //   (overload for specifying proportional and derivative modes)
 
-  PID(double *, double *,
-      double *, // * constructor.  links the PID to the Input, Output, and
-      double, double, double,
-      int); //   Setpoint.  Initial tuning parameters are also set here
+  PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
+      double Kd, int ControllerDirection);
+  // * constructor.  links the PID to the Input, Output, and
+  //   Setpoint.  Initial tuning parameters are also set here.
+  //   Uses default values DOn = D_ON_M and POn = P_ON_E
 
   void SetMode(int Mode); // * sets PID to either Manual (0) or Auto (non-0)
 
@@ -55,40 +56,38 @@ public:
                   //   calculation frequency can be set using SetMode
                   //   SetSampleTime respectively
 
-  void SetOutputLimits(
-      double,
-      double); // * clamps the output to a specific range. 0-255 by default, but
-               //   it's likely the user will want to change this depending on
-               //   the application
+  void SetOutputLimits(double Min, double Max);
+  // * clamps the output to a specific range. 0-255 by default, but
+  //   it's likely the user will want to change this depending on
+  //   the application
 
   // available but not commonly used functions
   // ********************************************************
-  void SetTunings(
-      double, double, // * While most users will set the tunings once in the
-      double);        //   constructor, this function gives the user the option
-               //   of changing tunings during runtime for Adaptive control
-  void SetTunings(double, double, // * overload for specifying proportional mode
-                  double, int);
+  void SetTunings(double Kp, double Ki, double Kd);
+  // * While most users will set the tunings once in the
+  //   constructor, this function gives the user the option
+  //   of changing tunings during runtime for Adaptive control
+  void SetTunings(double Kp, double Ki, double Kd, bool POn);
+  // * overload for specifying proportional mode
 
-  void SetTunings(double, double, // * overload for specifying derivative mode
-                  double, int, int);
+  void SetTunings(double Kp, double Ki, double Kd, bool POn, bool DOn);
+  // * overload for specifying proportional and derivative modes
 
-  void SetControllerDirection(
-      int); // * Sets the Direction, or "Action" of the controller. DIRECT
-            //   means the output will increase when error is positive. REVERSE
-            //   means the opposite.  it's very unlikely that this will be
-            //   needed once it is set in the constructor.
-
-  // Sets the frequency with which the PID calculation is performed.  Default
-  // is 100ms.
-  void SetSampleTime(Duration);
+  void SetControllerDirection(int Direction);
+  // * Sets the Direction, or "Action" of the controller. DIRECT
+  //   means the output will increase when error is positive. REVERSE
+  //   means the opposite.  it's very unlikely that this will be
+  //   needed once it is set in the constructor.
+  void SetSampleTime(Duration NewSampleTime);
+  // * sets the frequency, in Milliseconds, with which
+  //   the PID calculation is performed.  default is 100
 
   // Display functions
   // ****************************************************************
   double GetKp();     // These functions query the pid for interal values.
   double GetKi();     //  they were created mainly for the pid front-end,
   double GetKd();     // where it's important to know what is actually
-  int GetSampleTime();
+  Duration GetSampleTime();
   int GetMode();      //  inside the PID.
   int GetDirection(); //
 
@@ -100,18 +99,16 @@ private:
   double kd; // * (D)erivative Tuning Parameter
 
   int controllerDirection;
-  int pOn, dOn;
 
   double *myInput;  // * Pointers to the Input, Output, and Setpoint variables
   double *myOutput; //   This creates a hard link between the variables and the
-  double
-      *mySetpoint; //   PID, freeing the user from having to constantly tell us
-                   //   what these values are.  with pointers we'll just know.
+  double *mySetpoint; // PID, freeing the user from having to constantly tell
+                      // us what these values are.
 
-  Duration lastTime, lastSampleTime;
+  Duration nextSampleTime, lastUpdateTime;
   double outputSum, lastInput, lastError;
 
   double outMin, outMax;
-  bool inAuto, pOnE, dOnE;
+  bool inAuto, pOn, dOn;
 };
 #endif

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -37,50 +37,50 @@ public:
 
   // commonly used functions
   // **************************************************************************
-  PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
-      double Kd, bool POn, bool DOn, int ControllerDirection);
   // * constructor.  links the PID to the Input, Output, and
   //   Setpoint.  Initial tuning parameters are also set here.
   //   (overload for specifying proportional and derivative modes)
-
   PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
-      double Kd, int ControllerDirection);
+      double Kd, bool POnE, bool DOnE, int ControllerDirection);
+
   // * constructor.  links the PID to the Input, Output, and
   //   Setpoint.  Initial tuning parameters are also set here.
-  //   Uses default values DOn = D_ON_M and POn = P_ON_E
+  //   Uses default values DOnE = D_ON_M and POnE = P_ON_E
+  PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
+      double Kd, int ControllerDirection);
 
-  void SetMode(int Mode); // * sets PID to either Manual (0) or Auto (non-0)
+  // * sets PID to either Manual (0) or Auto (non-0)
+  void SetMode(int Mode);
 
-  bool Compute(); // * performs the PID calculation.  it should be
-                  //   called every time loop() cycles. ON/OFF and
-                  //   calculation frequency can be set using SetMode
-                  //   SetSampleTime respectively
+  // * performs the PID calculation.  it should be called every time loop()
+  // cycles. ON/OFF and calculation frequency can be set using SetMode
+  // SetSampleTime respectively
+  bool Compute();
 
-  void SetOutputLimits(double Min, double Max);
   // * clamps the output to a specific range. 0-255 by default, but
   //   it's likely the user will want to change this depending on
   //   the application
+  void SetOutputLimits(double Min, double Max);
 
   // available but not commonly used functions
   // ********************************************************
-  void SetTunings(double Kp, double Ki, double Kd);
   // * While most users will set the tunings once in the
   //   constructor, this function gives the user the option
   //   of changing tunings during runtime for Adaptive control
-  void SetTunings(double Kp, double Ki, double Kd, bool POn);
+  void SetTunings(double Kp, double Ki, double Kd);
   // * overload for specifying proportional mode
-
-  void SetTunings(double Kp, double Ki, double Kd, bool POn, bool DOn);
+  void SetTunings(double Kp, double Ki, double Kd, bool POnE);
   // * overload for specifying proportional and derivative modes
+  void SetTunings(double Kp, double Ki, double Kd, bool POnE, bool DOnE);
 
-  void SetControllerDirection(int Direction);
   // * Sets the Direction, or "Action" of the controller. DIRECT
   //   means the output will increase when error is positive. REVERSE
   //   means the opposite.  it's very unlikely that this will be
   //   needed once it is set in the constructor.
-  void SetSampleTime(Duration NewSampleTime);
+  void SetControllerDirection(int Direction);
   // * sets the frequency, in Milliseconds, with which
   //   the PID calculation is performed.  default is 100
+  void SetSampleTime(Duration NewSampleTime);
 
   // Display functions
   // ****************************************************************
@@ -88,8 +88,8 @@ public:
   double GetKi();     //  they were created mainly for the pid front-end,
   double GetKd();     // where it's important to know what is actually
   Duration GetSampleTime();
-  int GetMode();      //  inside the PID.
-  int GetDirection(); //
+  bool GetMode();      //  inside the PID.
+  bool GetDirection(); //
 
 private:
   void Initialize();
@@ -105,10 +105,11 @@ private:
   double *mySetpoint; // PID, freeing the user from having to constantly tell
                       // us what these values are.
 
-  Duration nextSampleTime, lastUpdateTime;
+  Duration SampleTime;
+  Time nextSampleTime, lastUpdateTime;
   double outputSum, lastInput, lastError;
 
   double outMin, outMax;
-  bool inAuto, pOn, dOn;
+  bool inAuto, pOnE, dOnE;
 };
 #endif

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -32,14 +32,16 @@ public:
 #define REVERSE 1
 #define P_ON_M 0
 #define P_ON_E 1
+#define D_ON_M 0
+#define D_ON_E 1
 
   // commonly used functions
   // **************************************************************************
   PID(double *, double *,
       double *, // * constructor.  links the PID to the Input, Output, and
-      double, double, double, int,
+      double, double, double, int, int,
       int); //   Setpoint.  Initial tuning parameters are also set here.
-            //   (overload for specifying proportional mode)
+            //   (overload for specifying proportional and derivative modes)
 
   PID(double *, double *,
       double *, // * constructor.  links the PID to the Input, Output, and
@@ -68,6 +70,9 @@ public:
   void SetTunings(double, double, // * overload for specifying proportional mode
                   double, int);
 
+  void SetTunings(double, double, // * overload for specifying derivative mode
+                  double, int, int);
+
   void SetControllerDirection(
       int); // * Sets the Direction, or "Action" of the controller. DIRECT
             //   means the output will increase when error is positive. REVERSE
@@ -95,7 +100,7 @@ private:
   double kd; // * (D)erivative Tuning Parameter
 
   int controllerDirection;
-  int pOn;
+  int pOn, dOn;
 
   double *myInput;  // * Pointers to the Input, Output, and Setpoint variables
   double *myOutput; //   This creates a hard link between the variables and the
@@ -104,9 +109,9 @@ private:
                    //   what these values are.  with pointers we'll just know.
 
   Duration lastTime, lastSampleTime;
-  double outputSum, lastInput;
+  double outputSum, lastInput, lastError;
 
   double outMin, outMax;
-  bool inAuto, pOnE;
+  bool inAuto, pOnE, dOnE;
 };
 #endif

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -83,15 +83,12 @@ public:
   double GetKp();     // These functions query the pid for interal values.
   double GetKi();     //  they were created mainly for the pid front-end,
   double GetKd();     // where it's important to know what is actually
+  int GetSampleTime();
   int GetMode();      //  inside the PID.
   int GetDirection(); //
 
 private:
   void Initialize();
-
-  double dispKp; // * we'll hold on to the tuning parameters in user-entered
-  double dispKi; //   format for display purposes
-  double dispKd; //
 
   double kp; // * (P)roportional Tuning Parameter
   double ki; // * (I)ntegral Tuning Parameter
@@ -106,8 +103,7 @@ private:
       *mySetpoint; //   PID, freeing the user from having to constantly tell us
                    //   what these values are.  with pointers we'll just know.
 
-  Duration SampleTime;
-  Time lastTime;
+  Duration lastTime, lastSampleTime;
   double outputSum, lastInput;
 
   double outMin, outMax;

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -35,11 +35,6 @@ static double setpoint;
 static double input;
 static double output;
 
-// default PID gains
-static float Kp;
-static float Ki;
-static float Kd;
-
 // PID Sample time (in milliseconds)
 static uint32_t sample_time = 100;
 
@@ -47,9 +42,9 @@ static uint32_t sample_time = 100;
 static const uint32_t max_task_jitter = 5;
 
 TEST(pidTest, Proportional) {
-  Kp = 0.9;
-  Ki = 0;
-  Kd = 0;
+  float Kp = 0.9;
+  float Ki = 0;
+  float Kd = 0;
   setpoint = 25;
   input = 10;
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
@@ -64,9 +59,9 @@ TEST(pidTest, Proportional) {
 }
 
 TEST(pidTest, Integral) {
-  Kp = 0;
-  Ki = 1.75;
-  Kd = 0;
+  float Kp = 0;
+  float Ki = 1.75;
+  float Kd = 0;
   // reset output to 0 since PID lib uses output to initalise its integral
   output = 0;
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
@@ -84,9 +79,9 @@ TEST(pidTest, Integral) {
 }
 
 TEST(pidTest, derivative) {
-  Kp = 0;
-  Ki = 0;
-  Kd = 2.5;
+  float Kp = 0;
+  float Ki = 0;
+  float Kd = 2.5;
   output = 0;
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
@@ -97,11 +92,11 @@ TEST(pidTest, derivative) {
 
   // delay and update input to create non-zero derivative
   Hal.delay(sample_time);
-  double derivative = input;
+  double previous_input = input;
   // output being in [0 255], create a negative derivative in order to have
   // a positive output
   input = 5;
-  derivative = (input - derivative) / sample_time * 1000.0;
+  double derivative = (input - previous_input) / sample_time * 1000.0;
 
   myPID.Compute();
   EXPECT_NEAR(output, derivative * -1 * Kd, output_TOLERANCE);
@@ -111,9 +106,9 @@ TEST(pidTest, TaskJitter) {
   // This test uses integral to check the effect of time between calls on the
   // PID output. Introducing jitter in call frequency and checking that the
   // integral takes this jitter into account.
-  Kp = 0;
-  Ki = 0.5;
-  Kd = 0;
+  float Kp = 0;
+  float Ki = 0.5;
+  float Kd = 0;
   output = 0;
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
@@ -141,9 +136,9 @@ TEST(pidTest, TaskJitter) {
 TEST(pidTest, SampleTimeChange) {
   // This test uses integral to check the effect of changing sample time
   // during execution of the PID
-  Kp = 0;
-  Ki = 1.1;
-  Kd = 0;
+  float Kp = 0;
+  float Ki = 1.1;
+  float Kd = 0;
   output = 0;
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
@@ -173,9 +168,9 @@ TEST(pidTest, SampleTimeChange) {
 TEST(pidTest, MissedSample) {
   // This test uses integral to check the effect of missing a sample in the
   // execution of PID
-  Kp = 0;
-  Ki = 0.2;
-  Kd = 0;
+  float Kp = 0;
+  float Ki = 0.2;
+  float Kd = 0;
   output = 0;
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -1,0 +1,202 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * module contributors: asmodai27
+ *
+ * The purpose of this module is to provide unit testing for the pid
+ * controller module.  Module is to be run on an x86 host and is not to be run
+ * on an Arduino platform.
+ */
+
+#include "hal.h"
+#include "pid.h"
+#include "types.h"
+#include "gtest/gtest.h"
+
+//@TODO: Adjust this tolerance... assumes the PWM is a 0-255 integer but that
+// may not be the case
+static const double output_TOLERANCE = 1;
+
+// PID
+static double setpoint;
+static double input;
+static double output;
+
+// default PID gains
+static float Kp;
+static float Ki;
+static float Kd;
+
+// PID Sample time (in milliseconds)
+static uint32_t sample_time = 100;
+
+// Maximum task jitter (assume 5 ms for now, will need adjuting)
+static const uint32_t max_task_jitter = 5;
+
+TEST(pidTest, Proportional) {
+  Kp = 0.9;
+  Ki = 0;
+  Kd = 0;
+  setpoint = 25;
+  input = 10;
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  myPID.SetSampleTime(sample_time);
+  myPID.SetMode(AUTOMATIC);
+  myPID.Compute();
+  // Ki and Kd = 0 therefore output = Kp*error, nothing more
+  EXPECT_NEAR(output, (setpoint - input) * Kp, output_TOLERANCE);
+  Hal.delay(sample_time);
+  myPID.Compute();
+  EXPECT_NEAR(output, (setpoint - input) * Kp, output_TOLERANCE);
+}
+
+TEST(pidTest, Integral) {
+  Kp = 0;
+  Ki = 1.75;
+  Kd = 0;
+  // reset output to 0 since PID lib uses output to initalise its integral
+  output = 0;
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  myPID.SetSampleTime(sample_time);
+  myPID.SetMode(AUTOMATIC);
+  myPID.Compute();
+  // on first call, integral = error*sample time, output = Ki*integral
+  EXPECT_NEAR(output, (setpoint - input) * sample_time / 1000.0 * Ki,
+              output_TOLERANCE);
+  Hal.delay(sample_time);
+  myPID.Compute();
+  // on second call, integral = error*2*sample time, output = Ki*integral
+  EXPECT_NEAR(output, (setpoint - input) * 2 * sample_time / 1000.0 * Ki,
+              output_TOLERANCE);
+}
+
+TEST(pidTest, derivative) {
+  Kp = 0;
+  Ki = 0;
+  Kd = 2.5;
+  output = 0;
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  myPID.SetSampleTime(sample_time);
+  myPID.SetMode(AUTOMATIC);
+  myPID.Compute();
+  // Expect no derivative on first call
+  EXPECT_NEAR(output, 0, output_TOLERANCE);
+
+  // delay and update input to create non-zero derivative
+  Hal.delay(sample_time);
+  double derivative = input;
+  // output being in [0 255], create a negative derivative in order to have
+  // a positive output
+  input = 5;
+  derivative = (input - derivative) / sample_time * 1000.0;
+
+  myPID.Compute();
+  EXPECT_NEAR(output, derivative * -1 * Kd, output_TOLERANCE);
+}
+
+TEST(pidTest, TaskJitter) {
+  // This test uses integral to check the effect of time between calls on the
+  // PID output. Introducing jitter in call frequency and checking that the
+  // integral takes this jitter into account.
+  Kp = 0;
+  Ki = 0.5;
+  Kd = 0;
+  output = 0;
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  myPID.SetSampleTime(sample_time);
+  myPID.SetMode(AUTOMATIC);
+  myPID.Compute();
+  // First task, with only Ki set, output = error*sample_time
+  double integral = (setpoint - input) * (sample_time / 1000.0);
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+  // Advance time with jitter
+  uint32_t dt = sample_time + max_task_jitter;
+  Hal.delay(dt);
+  myPID.Compute();
+  // Expect output to take jitter into account in integral
+  integral += (setpoint - input) * (dt / 1000.0);
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+  // Advance time and compensate previous jitter to have total time
+  // elapsed = 2*sample time
+  dt = sample_time - max_task_jitter;
+  Hal.delay(dt);
+  integral += (setpoint - input) * (dt / 1000.0);
+  myPID.Compute();
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+}
+
+TEST(pidTest, SampleTimeChange) {
+  // This test uses integral to check the effect of changing sample time
+  // during execution of the PID
+  Kp = 0;
+  Ki = 1.1;
+  Kd = 0;
+  output = 0;
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  myPID.SetSampleTime(sample_time);
+  myPID.SetMode(AUTOMATIC);
+  myPID.Compute();
+
+  // First task, with only Ki set, output = error*sample_time
+  double integral = (setpoint - input) * (sample_time / 1000.0);
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+  // Advance time
+  uint32_t dt = sample_time;
+  Hal.delay(dt);
+  myPID.Compute();
+  // Expect output to integrate this
+  integral += (setpoint - input) * (dt / 1000.0);
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+  // Change sample time and advance
+  sample_time = 50;
+  dt = sample_time;
+  myPID.SetSampleTime(sample_time);
+  Hal.delay(dt);
+  integral += (setpoint - input) * (dt / 1000.0);
+  myPID.Compute();
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+}
+
+TEST(pidTest, MissedSample) {
+  // This test uses integral to check the effect of missing a sample in the
+  // execution of PID
+  Kp = 0;
+  Ki = 0.2;
+  Kd = 0;
+  output = 0;
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  myPID.SetSampleTime(sample_time);
+  myPID.SetMode(AUTOMATIC);
+  myPID.Compute();
+
+  // First task, with only Ki set, output = error*sample_time
+  double integral = (setpoint - input) * (sample_time / 1000.0);
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+  // Advance time
+  uint32_t dt = 2 * sample_time;
+  Hal.delay(dt);
+  myPID.Compute();
+  // Expect output to integrate this
+  integral += (setpoint - input) * (dt / 1000.0);
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+  // Advance time a small amount to allow PID to catch up to missed sample
+  dt = max_task_jitter;
+  Hal.delay(dt);
+  integral += (setpoint - input) * (dt / 1000.0);
+  myPID.Compute();
+  // Expect output to have a new update
+  EXPECT_NEAR(output, integral * Ki, output_TOLERANCE);
+}


### PR DESCRIPTION
Functional changes I made to the PID library:
1. made it run when now > next multiple of sample time, instead of now > time of last call + sample time, in order to better approximate what we would get with a RTOS
2. made the integral/derivative use dt = now - "time of last call", instead of fixed sample time, as I said in the linked issue, if we want to have even better math, we could have the sensors timestamp their data and use dt = timestamp of current data - timestamp of previous data
3. added derivative on error mode, to make it possible to use like a regular PID, probably not useful, as per discussion with Edwin.

For an illustration of what points 1 and 2 do, see https://docs.google.com/presentation/d/19FcO7h6YPZx7-ondiH7kgkY8SAafKVgVLtLYb_zi43k/edit?usp=sharing