### PR TITLE
Removes alarms and binds params directly to GuiStateContainer

### DIFF
--- a/gui/ProjectVentilatorGUI.pro
+++ b/gui/ProjectVentilatorGUI.pro
@@ -7,8 +7,8 @@ SOURCES += $$files("$$PWD/../common/**/*.c")
 HEADERS += $$files("*.h")
 HEADERS += $$files("$$PWD/../common/**/*.h")
 INCLUDEPATH += $$PWD/../common/third_party/nanopb
-RESOURCES += qml.qrc Logo.png
-DISTFILES += Logo.png
+RESOURCES += qml.qrc images/Logo.png
+DISTFILES += images/Logo.png
 TRANSLATIONS += ProjectVentilatorGUI_es_GT.ts
 
 # Default rules for deployment.

--- a/gui/controller_history.h
+++ b/gui/controller_history.h
@@ -36,8 +36,15 @@ public:
     }
   }
 
-  std::vector<std::tuple<SteadyInstant, ControllerStatus>> GetHistory() {
+  std::vector<std::tuple<SteadyInstant, ControllerStatus>> GetHistory() const {
     return {history_.begin(), history_.end()};
+  }
+
+  ControllerStatus GetLastStatus() const {
+    if (history_.empty()) {
+      return ControllerStatus_init_zero;
+    }
+    return std::get<1>(history_.back());
   }
 
 private:

--- a/gui/gui_state_container.h
+++ b/gui/gui_state_container.h
@@ -34,13 +34,15 @@
 // with the controller, so thread safety is important, and it is easiest
 // to centralize it in the current class, simply protecting everything
 // by a single mutex.
-class GuiStateContainer {
+class GuiStateContainer : public QObject {
+  Q_OBJECT;
 
 public:
   // Initializes the state container to keep the history of controller
   // statuses in a given time window.
-GuiStateContainer(DurationMs history_window)
-      : startup_time_(SteadyClock::now()), history_(history_window) {}
+  GuiStateContainer(DurationMs history_window, QObject *parent = nullptr)
+      : QObject(parent), startup_time_(SteadyClock::now()),
+        history_(history_window) {}
 
   // Returns when the GUI started up.
   SteadyInstant GetStartupTime() { return startup_time_; }
@@ -67,179 +69,72 @@ GuiStateContainer(DurationMs history_window)
     return history_.GetHistory();
   }
 
+  Q_PROPERTY(quint32 rr READ get_rr WRITE set_rr NOTIFY params_changed)
+  Q_PROPERTY(quint32 peep READ get_peep WRITE set_peep NOTIFY params_changed)
+  Q_PROPERTY(quint32 pip READ get_pip WRITE set_pip NOTIFY params_changed)
+  Q_PROPERTY(qreal ier READ get_ier WRITE set_ier NOTIFY params_changed)
+
+signals:
+  void params_changed();
+
 private:
+  quint32 get_rr() const {
+    std::unique_lock<std::mutex> l(mu_);
+    return gui_status_.desired_params.breaths_per_min;
+  }
+  void set_rr(quint32 value) {
+    {
+      std::unique_lock<std::mutex> l(mu_);
+      gui_status_.desired_params.breaths_per_min = value;
+    }
+    params_changed();
+  }
+
+  quint32 get_peep() const {
+    std::unique_lock<std::mutex> l(mu_);
+    return gui_status_.desired_params.peep_cm_h2o;
+  }
+  void set_peep(quint32 value) {
+    {
+      std::unique_lock<std::mutex> l(mu_);
+      gui_status_.desired_params.peep_cm_h2o = value;
+    }
+    params_changed();
+  }
+
+  quint32 get_pip() const {
+    std::unique_lock<std::mutex> l(mu_);
+    return gui_status_.desired_params.pip_cm_h2o;
+  }
+  void set_pip(quint32 value) {
+    {
+      std::unique_lock<std::mutex> l(mu_);
+      gui_status_.desired_params.pip_cm_h2o = value;
+    }
+    params_changed();
+  }
+
+  qreal get_ier() const {
+    std::unique_lock<std::mutex> l(mu_);
+    return gui_status_.desired_params.inspiratory_expiratory_ratio;
+  }
+  void set_ier(qreal value) {
+    {
+      std::unique_lock<std::mutex> l(mu_);
+      gui_status_.desired_params.inspiratory_expiratory_ratio = value;
+    }
+    params_changed();
+  }
+
   const SteadyInstant startup_time_;
 
-  std::mutex mu_;
+  mutable std::mutex mu_;
   // TODO: Use thread safety annotations here and throughout the project.
   // https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
   // They only work with clang, so we'll need a wrapper macro to have them
   // be no-ops on gcc.
   GuiStatus gui_status_ = GuiStatus_init_zero;
   ControllerHistory history_;
-};
-
-class GuiStateInterface : public QObject{
-   Q_OBJECT
-public:
-    explicit GuiStateInterface (QObject* parent = 0) : QObject(parent) {}
-
-    // Respiratory Rate
-
-    Q_INVOKABLE void rr_inc(){
-      rr_++;
-    }
-
-    Q_INVOKABLE void rr_dec(){
-      if(rr_ > 0) rr_--;
-    }
-
-    Q_INVOKABLE quint32 rr_val(){
-      return rr_;
-    }
-
-    Q_INVOKABLE quint32 rr_default(){
-      return RR_DEFAULT;
-    }
-
-    // PIP
-
-    Q_INVOKABLE void pip_inc(){
-      pip_++;
-    }
-
-    Q_INVOKABLE void pip_dec(){
-      if(pip_ > 0) pip_--;
-    }
-
-    Q_INVOKABLE quint32 pip_val(){
-      return pip_;
-    }
-
-    Q_INVOKABLE quint32 pip_default(){
-      return PIP_DEFAULT;
-    }
-
-    // PEEP
-
-    Q_INVOKABLE void peep_inc(){
-      peep_++;
-    }
-
-    Q_INVOKABLE void peep_dec(){
-      if(peep_ > 0) peep_--;
-    }
-
-    Q_INVOKABLE quint32 peep_val(){
-      return peep_;
-    }
-
-    Q_INVOKABLE quint32 peep_default(){
-      return PEEP_DEFAULT;
-    }
-
-    // I:E ratio
-
-    Q_INVOKABLE void ier_inc(){
-      if(ier_ < 1.5) ier_+=0.1;
-    }
-
-    Q_INVOKABLE void ier_dec(){
-      if(ier_ > 1.1) ier_-=0.1;
-    }
-
-    Q_INVOKABLE double ier_val(){
-      return ier_;
-    }
-
-    Q_INVOKABLE double ier_default(){
-      return IER_DEFAULT;
-    }
-
-    /*  Alarms */
-
-    // RR High Alarm
-
-    Q_INVOKABLE void rrAlarmHigh_inc(){
-      rrAlarmHigh_++;
-    }
-
-    Q_INVOKABLE void rrAlarmHigh_dec(){
-      if(rrAlarmHigh_ > 0) rrAlarmHigh_--;
-    }
-
-    Q_INVOKABLE quint32 rrAlarmHigh_val(){
-      return rrAlarmHigh_;
-    }
-
-    Q_INVOKABLE quint32 rrAlarmHigh_default(){
-      return RR_ALARM_HIGH_DEFAULT;
-    }
-
-    // RR Low Alarm
-
-    Q_INVOKABLE void rrAlarmLow_inc(){
-      rrAlarmLow_++;
-    }
-
-    Q_INVOKABLE void rrAlarmLow_dec(){
-      if(rrAlarmLow_ > 0) rrAlarmLow_--;
-    }
-
-    Q_INVOKABLE quint32 rrAlarmLow_val(){
-      return rrAlarmLow_;
-    }
-
-    Q_INVOKABLE quint32 rrAlarmLow_default(){
-      return RR_ALARM_LOW_DEFAULT;
-    }
-
-    // TV High Alarm
-
-    Q_INVOKABLE void tvAlarmHigh_inc(){
-      tvAlarmHigh_++;
-    }
-
-    Q_INVOKABLE void tvAlarmHigh_dec(){
-      if(tvAlarmHigh_ > 0) tvAlarmHigh_--;
-    }
-
-    Q_INVOKABLE quint32 tvAlarmHigh_val(){
-      return tvAlarmHigh_;
-    }
-
-    Q_INVOKABLE quint32 tvAlarmHigh_default(){
-      return TV_ALARM_HIGH_DEFAULT;
-    }
-
-    // RR Low Alarm
-
-    Q_INVOKABLE void tvAlarmLow_inc(){
-      tvAlarmLow_++;
-    }
-
-    Q_INVOKABLE void tvAlarmLow_dec(){
-      if(tvAlarmLow_ > 0) tvAlarmLow_--;
-    }
-
-    Q_INVOKABLE quint32 tvAlarmLow_val(){
-      return tvAlarmLow_;
-    }
-
-    Q_INVOKABLE quint32 tvAlarmLow_default(){
-      return TV_ALARM_LOW_DEFAULT;
-    }
-
-
-private:
-quint32 rr_ = RR_DEFAULT;
-quint32 peep_ = PEEP_DEFAULT;
-quint32 pip_ = PIP_DEFAULT;
-double ier_ = IER_DEFAULT;
-quint32 rrAlarmHigh_ = RR_ALARM_HIGH_DEFAULT;
-quint32 rrAlarmLow_ = RR_ALARM_LOW_DEFAULT;
-quint32 tvAlarmHigh_ = TV_ALARM_HIGH_DEFAULT;
-quint32 tvAlarmLow_ = TV_ALARM_LOW_DEFAULT;
 };
 
 #endif // GUI_STATE_CONTAINER_H

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -20,11 +20,10 @@
 
 int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
-  QApplication::setOverrideCursor(Qt::BlankCursor);
 
   app.setWindowIcon(QIcon(":/images/Logo.png"));
 
-  qmlRegisterType<GuiStateInterface>("com.myself", 1, 0, "GuiStateInterface");
+  qmlRegisterAnonymousType<GuiStateContainer>("com.respiraworks", 1);
 
   QCommandLineParser parser;
   parser.setApplicationDescription("Ventilator GUI application");
@@ -39,7 +38,7 @@ int main(int argc, char *argv[]) {
   parser.process(app);
 
   GuiStateContainer state_container(
-      /*history_window=*/DurationMs(30000)); 
+      /*history_window=*/DurationMs(30000));
   auto startup_time = state_container.GetStartupTime();
 
   std::unique_ptr<ConnectedDevice> device =
@@ -113,12 +112,13 @@ int main(int argc, char *argv[]) {
   mainView.rootContext()->setContextProperty("volumeDataSource",
                                              &volumeDataSource);
   mainView.rootContext()->setContextProperty("flowDataSource", &flowDataSource);
+  mainView.rootContext()->setContextProperty("guiState", &state_container);
 
   mainView.setSource(QUrl("qrc:/main.qml"));
   mainView.setResizeMode(QQuickView::SizeRootObjectToView);
   mainView.setColor(QColor("#000000"));
 
-  mainView.showFullScreen();
+  mainView.show();
 
   if (parser.isSet(startupOnlyOption)) {
     return EXIT_SUCCESS;

--- a/gui/main.qml
+++ b/gui/main.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.11
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.4
-import com.myself 1.0
 
 Item
 {
@@ -21,10 +20,6 @@ Item
             flowDataSource.update(flowView.series(0));
 
         }
-    }
-
-    GuiStateInterface {
-       id: guiStateInterface
     }
 
     Rectangle {
@@ -97,7 +92,7 @@ Item
                         y: 39
                         width: 60
                         height: 44
-                        text: Number(guiStateInterface.rr_default());
+                        text: Number(guiState.rr);
                         horizontalAlignment: Text.AlignHCenter
                         font.family: "Times New Roman"
                         font.weight: Font.DemiBold
@@ -125,10 +120,7 @@ Item
                         font.bold: true
                         focusPolicy: Qt.ClickFocus
 
-                        onClicked: {
-                            guiStateInterface.rr_inc();
-                            breathsPerMinuteVal.text =  Number(guiStateInterface.rr_val());
-                            }
+                        onClicked: { guiState.rr++; }
                     }
 
                     RoundButton {
@@ -142,10 +134,7 @@ Item
                         focusPolicy: Qt.NoFocus
                         font.bold: true
 
-                        onClicked: {
-                            guiStateInterface.rr_dec();
-                            breathsPerMinuteVal.text =  Number(guiStateInterface.rr_val());
-                            }
+                        onClicked: { guiState.rr--; }
                     }
 
                 }
@@ -164,7 +153,7 @@ Item
                         y: 39
                         width: 60
                         height: 44
-                        text:  Number(guiStateInterface.peep_default());
+                        text:  Number(guiState.peep);
                         horizontalAlignment: Text.AlignHCenter
                         font.weight: Font.DemiBold
                         font.family: "Times New Roman"
@@ -193,10 +182,7 @@ Item
                         focusPolicy: Qt.NoFocus
                         font.bold: true
 
-                        onClicked: {
-                            guiStateInterface.peep_inc();
-                            peepVal.text =  Number(guiStateInterface.peep_val());
-                        }
+                        onClicked: { guiState.peep++; }
                     }
 
                     RoundButton {
@@ -210,10 +196,7 @@ Item
                         font.bold: true
                         focusPolicy: Qt.NoFocus
 
-                        onClicked: {
-                            guiStateInterface.peep_dec();
-                            peepVal.text =  Number(guiStateInterface.peep_val());
-                        }
+                        onClicked: { guiState.peep--; }
                     }
                     Layout.minimumWidth: 150
                     Layout.topMargin: 10
@@ -234,7 +217,7 @@ Item
                         y: 39
                         width: 60
                         height: 44
-                        text:  Number(guiStateInterface.pip_default());
+                        text:  Number(guiState.pip);
                         horizontalAlignment: Text.AlignHCenter
                         font.weight: Font.DemiBold
                         font.family: "Times New Roman"
@@ -263,10 +246,7 @@ Item
                         font.bold: true
                         focusPolicy: Qt.NoFocus
 
-                        onClicked: {
-                            guiStateInterface.pip_inc();
-                            pipVal.text =  Number(guiStateInterface.pip_val());
-                        }
+                        onClicked: { guiState.pip++; }
                     }
 
                     RoundButton {
@@ -280,10 +260,7 @@ Item
                         focusPolicy: Qt.NoFocus
                         font.bold: true
 
-                        onClicked: {
-                            guiStateInterface.pip_dec();
-                            pipVal.text =  Number(guiStateInterface.pip_val());
-                        }
+                        onClicked: { guiState.pip--; }
                     }
                     Layout.minimumWidth: 150
                     Layout.topMargin: 10
@@ -304,7 +281,7 @@ Item
                         y: 39
                         width: 60
                         height: 44
-                        text:  Number(guiStateInterface.ier_default());
+                        text:  Number(guiState.ier, 'g', 1).toFixed(1)
                         horizontalAlignment: Text.AlignHCenter
                         font.weight: Font.DemiBold
                         font.family: "Times New Roman"
@@ -333,11 +310,7 @@ Item
                         font.bold: true
                         focusPolicy: Qt.NoFocus
 
-                        onClicked: {
-                            guiStateInterface.ier_inc();
-                            ierVal.text =  Number(guiStateInterface.ier_val(), 'g', 1).toFixed(1);
-                            //console.log("Increase :" + ierVal.text);
-                        }
+                        onClicked: { guiState.ier += 0.1; }
                     }
 
                     RoundButton {
@@ -351,10 +324,7 @@ Item
                         focusPolicy: Qt.NoFocus
                         font.bold: true
 
-                        onClicked: {
-                            guiStateInterface.ier_dec();
-                            ierVal.text =  Number(guiStateInterface.ier_val(), 'g', 1).toFixed(1);
-                        }
+                        onClicked: { guiState.ier -= 0.1; }
                     }
 
                     Layout.minimumWidth: 150
@@ -413,304 +383,6 @@ Item
 
 
             }
-
-            ColumnLayout {
-                id: columnLayout2
-                width: 100
-                height: 100
-
-                Text {
-                    id: element2
-                    text: qsTr("Alarms")
-                    Layout.fillWidth: true
-                    font.bold: true
-                    verticalAlignment: Text.AlignVCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    font.pixelSize: 22
-                }
-
-
-                Rectangle {
-                    id: rrAlarmHigh
-                    color: "#466eeb"
-                    radius: 10
-
-                    Text {
-                        id: rrAlarmHighVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text:  Number(guiStateInterface.rrAlarmHigh_default());
-                        font.weight: Font.DemiBold
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.family: "Times New Roman"
-                        font.pixelSize: 38
-                    }
-
-                    Text {
-                        id: element1
-                        x: 45
-                        y: 13
-                        text: qsTr("RR High")
-                        font.bold: true
-                        font.pixelSize: 17
-                    }
-
-                    RoundButton {
-                        id: rrAlarmHighInc
-                        x: 110
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("+")
-                        font.bold: true
-                        focusPolicy: Qt.ClickFocus
-                        font.family: "Courier"
-
-                        onClicked: {
-                            guiStateInterface.rrAlarmHigh_inc();
-                            rrAlarmHighVal.text =  Number(guiStateInterface.rrAlarmHigh_val());
-                            }
-                    }
-
-                    RoundButton {
-                        id: rrAlarmHighDec
-                        x: 9
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("-")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.rrAlarmHigh_dec();
-                            rrAlarmHighVal.text =  Number(guiStateInterface.rrAlarmHigh_val());
-                            }
-                    }
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-                }
-
-                Rectangle {
-                    id: rrAlarmLow
-                    color: "#466eeb"
-                    radius: 10
-                    Text {
-                        id: rrAlarmLowVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text: Number(guiStateInterface.rrAlarmLow_default());
-                        font.weight: Font.DemiBold
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.family: "Times New Roman"
-                        font.pixelSize: 38
-                    }
-
-                    Text {
-                        id: element4
-                        x: 45
-                        y: 13
-                        text: qsTr("RR Low")
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.pixelSize: 17
-                    }
-
-                    RoundButton {
-                        id: rrAlarmLowInc
-                        x: 110
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("+")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.rrAlarmLow_inc();
-                            rrAlarmLowVal.text =  Number(guiStateInterface.rrAlarmLow_val());
-                            }
-                    }
-
-                    RoundButton {
-                        id: rrAlarmLowDec
-                        x: 9
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("-")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.rrAlarmLow_dec();
-                            rrAlarmLowVal.text =  Number(guiStateInterface.rrAlarmLow_val());
-                            }
-                    }
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-                }
-
-                Rectangle {
-                    id: tvAlarmHigh
-                    color: "#466eeb"
-                    radius: 10
-                    Text {
-                        id: tvAlarmHighVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text: Number(guiStateInterface.tvAlarmHigh_default());
-                        font.weight: Font.DemiBold
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.family: "Times New Roman"
-                        font.pixelSize: 38
-                    }
-
-                    Text {
-                        id: element6
-                        x: 44
-                        y: 13
-                        text: qsTr("TV High")
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.pixelSize: 17
-                    }
-
-                    RoundButton {
-                        id: tvAlarmHighInc
-                        x: 110
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("+")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.tvAlarmHigh_inc();
-                            tvAlarmHighVal.text =  Number(guiStateInterface.tvAlarmHigh_val());
-                            }
-                    }
-
-                    RoundButton {
-                        id: tvAlarmHighDec
-                        x: 9
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("-")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.tvAlarmHigh_dec();
-                            tvAlarmHighVal.text =  Number(guiStateInterface.tvAlarmHigh_val());
-                            }
-                    }
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-                }
-
-                Rectangle {
-                    id: tvAlarmLow
-                    color: "#466eeb"
-                    radius: 10
-                    Text {
-                        id: tvAlarmLowVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text: Number(guiStateInterface.tvAlarmLow_default());
-                        font.weight: Font.DemiBold
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.family: "Times New Roman"
-                        font.pixelSize: 38
-                    }
-
-                    Text {
-                        id: element54
-                        x: 45
-                        y: 13
-                        text: qsTr("TV Low")
-                        font.bold: true
-                        horizontalAlignment: Text.AlignHCenter
-                        font.pixelSize: 17
-                    }
-
-                    RoundButton {
-                        id: tvAlarmLowInc
-                        x: 110
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("+")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.tvAlarmLow_inc();
-                            tvAlarmLowVal.text =  Number(guiStateInterface.tvAlarmLow_val());
-                            }
-                    }
-
-                    RoundButton {
-                        id: tvAlarmLowDec
-                        x: 9
-                        y: 45
-                        width: 30
-                        height: 30
-                        text: qsTr("-")
-                        checkable: false
-                        font.bold: true
-                        focusPolicy: Qt.NoFocus
-
-                        onClicked: {
-                            guiStateInterface.tvAlarmLow_dec();
-                            tvAlarmLowVal.text =  Number(guiStateInterface.tvAlarmLow_val());
-                            }
-                    }
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-                }
-
-
-                Layout.maximumHeight: 65356
-                Layout.minimumWidth: 200
-                Layout.fillWidth: true
-                Layout.maximumWidth: 6553
-                Layout.fillHeight: true
-            }
-
-
         }
 
         RowLayout {
@@ -720,20 +392,7 @@ Item
             Layout.minimumHeight: 50
             Layout.maximumHeight: 65535
         }
-
-
-
-
-
-
-
     }
-
-
-
-
-
-
 }
 
 /*##^##
@@ -741,91 +400,6 @@ Designer {
     D{i:2;anchors_height:93;anchors_width:185}D{i:3;anchors_height:600;anchors_width:839;anchors_x:157;anchors_y:0}
 }
 ##^##*/
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 /*##^## Designer {
     D{i:2;anchors_height:200;anchors_width:200}
 }

--- a/gui/main.qml
+++ b/gui/main.qml
@@ -383,6 +383,123 @@ Item
 
 
             }
+
+            ColumnLayout {
+                id: sensorReadouts
+                width: 100
+                height: 100
+                Layout.maximumHeight: 65356
+                Layout.maximumWidth: 6553
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                Layout.minimumWidth: 200
+
+                Rectangle {
+                    id: pressureReadout
+                    color: "#466eeb"
+                    radius: 10
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumHeight: 100
+                    Layout.rightMargin: 10
+
+                    Text {
+                        id: pressureVal
+                        x: 45
+                        y: 39
+                        width: 60
+                        height: 44
+                        text: Number(guiState.pressureReadout, 'g', 1).toFixed(1);
+                        horizontalAlignment: Text.AlignHCenter
+                        font.family: "Times New Roman"
+                        font.weight: Font.DemiBold
+                        font.bold: true
+                        font.pixelSize: 38
+                    }
+
+                    Text {
+                        x: 3
+                        y: 13
+                        text: qsTr("Pressure (cm H2O)")
+                        font.bold: true
+                        font.pixelSize: 17
+                    }
+                    Layout.minimumWidth: 150
+                    Layout.topMargin: 10
+                    Layout.leftMargin: 10
+                }
+
+                Rectangle {
+                    id: flowReadout
+                    color: "#466eeb"
+                    radius: 10
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumHeight: 100
+                    Layout.rightMargin: 10
+
+                    Text {
+                        id: flowVal
+                        x: 45
+                        y: 39
+                        width: 60
+                        height: 44
+                        text: Number(guiState.flowReadout, 'g', 1).toFixed(1);
+                        horizontalAlignment: Text.AlignHCenter
+                        font.weight: Font.DemiBold
+                        font.family: "Times New Roman"
+                        font.pixelSize: 38
+                        font.bold: true
+                    }
+
+                    Text {
+                        x: 23
+                        y: 13
+                        text: qsTr("Flow (mL/min)")
+                        horizontalAlignment: Text.AlignHCenter
+                        font.pixelSize: 17
+                        font.bold: true
+                    }
+
+                    Layout.minimumWidth: 150
+                    Layout.topMargin: 10
+                    Layout.leftMargin: 10
+                }
+
+                Rectangle {
+                    id: tvReadout
+                    color: "#466eeb"
+                    radius: 10
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumHeight: 100
+                    Layout.rightMargin: 10
+
+                    Text {
+                        id: tvVal
+                        x: 45
+                        y: 39
+                        width: 60
+                        height: 44
+                        text:  Number(guiState.tvReadout);
+                        horizontalAlignment: Text.AlignHCenter
+                        font.weight: Font.DemiBold
+                        font.family: "Times New Roman"
+                        font.pixelSize: 38
+                        font.bold: true
+                    }
+
+                    Text {
+                        x: 41
+                        y: 13
+                        text: qsTr("TV (mL)")
+                        horizontalAlignment: Text.AlignHCenter
+                        font.pixelSize: 17
+                        font.bold: true
+                    }
+
+                    Layout.minimumWidth: 150
+                    Layout.topMargin: 10
+                    Layout.leftMargin: 10
+                }
+            }
         }
 
         RowLayout {


### PR DESCRIPTION
Removes alarms (because we don't support them yet, so for now it's just more code to modify) and binds params directly to GuiStateContainer, getting rid of GuiStateInterface. 

I also used QT's property mechanism instead of inc/dec functions.