### PR TITLE
Turn off fan immediately when state is switched to OFF.

### DIFF
--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -52,7 +52,9 @@ class OffFsm {
 public:
   OffFsm() = default;
   explicit OffFsm(const VentParams &) {}
-  BlowerSystemState desired_state() { return {kPa(0), ValveState::OPEN}; }
+  BlowerSystemState desired_state() {
+    return {.blower_enabled = false, kPa(0), ValveState::OPEN};
+  }
   bool finished() { return true; }
 };
 
@@ -73,9 +75,9 @@ public:
 
   BlowerSystemState desired_state() {
     if (Hal.now() < inspire_end_) {
-      return {inspire_pressure_, ValveState::CLOSED};
+      return {.blower_enabled = true, inspire_pressure_, ValveState::CLOSED};
     }
-    return {expire_pressure_, ValveState::OPEN};
+    return {.blower_enabled = true, expire_pressure_, ValveState::OPEN};
   }
 
   bool finished() { return Hal.now() > expire_end_; }

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -48,7 +48,17 @@ enum class ValveState {
 // Represents a state that the blower FSM wants us to achieve at a given point
 // in time.
 struct BlowerSystemState {
-  Pressure pressure;
+  // Is the blower on?
+  //
+  // Note: blower_enabled == false isn't the same as setpoint_pressure == 0:
+  //
+  //  - If blower_enabled is false, we shut down the fan immediately, whereas
+  //  - if setpoint_pressure == 0, PID spins down the fan to attempt to read 0
+  //    kPa measured patient pressure.
+  //
+  bool blower_enabled;
+
+  Pressure setpoint_pressure;
   ValveState expire_valve_state;
 };
 

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -78,9 +78,15 @@ void blower_pid_execute(const BlowerSystemState &desired_state,
 
   Pressure cur_pressure = get_patient_pressure();
 
-  Setpoint = desired_state.pressure.kPa();
+  Setpoint = desired_state.setpoint_pressure.kPa();
   Input = cur_pressure.kPa();
   myPID.Compute();
+
+  // If the blower is not enabled, immediately shut down the fan.  But for
+  // consistency, we still run the PID iteration above.
+  if (!desired_state.blower_enabled) {
+    Output = 0;
+  }
   Hal.analogWrite(PwmPin::BLOWER, static_cast<int>(Output));
 
   // fan_power is in range [0, 1].

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -120,7 +120,8 @@ static void controller_loop() {
     //   - Expiratory solenoid valve state (open/closed).
     BlowerSystemState desired_state =
         blower_fsm_desired_state(controller_status.active_params);
-    controller_status.fan_setpoint_cm_h2o = desired_state.pressure.cmH2O();
+    controller_status.fan_setpoint_cm_h2o =
+        desired_state.setpoint_pressure.cmH2O();
 
     blower_pid_execute(desired_state, &controller_status.sensor_readings,
                        &controller_status.fan_power);

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -31,7 +31,7 @@ public:
 TEST_F(BlowerFsmTest, InitiallyOff) {
   VentParams p = VentParams_init_zero;
   BlowerSystemState s = blower_fsm_desired_state(p);
-  EXPECT_FLOAT_EQ(s.pressure.cmH2O(), 0);
+  EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);
 }
 
@@ -39,7 +39,7 @@ TEST_F(BlowerFsmTest, StaysOff) {
   VentParams p = VentParams_init_zero;
   Hal.delay(1000);
   BlowerSystemState s = blower_fsm_desired_state(p);
-  EXPECT_FLOAT_EQ(s.pressure.cmH2O(), 0);
+  EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);
 }
 
@@ -48,17 +48,19 @@ TEST_F(BlowerFsmTest, StaysOff) {
 void testSequence(
     const std::vector<
         std::tuple<VentParams,
+                   /*blower_enabled*/ bool,
                    /*time_millis*/ int,
                    /*expected_setpoint_pressure*/ Pressure,
                    /*expected_expiratory_valve_state*/ ValveState>> &seq) {
-  for (const auto &[params, time_millis, expected_pressure,
+  for (const auto &[params, blower_enabled, time_millis, expected_pressure,
                     expected_valve_state] : seq) {
     Hal.delay(millisSinceStartup(time_millis) - Hal.now());
     SCOPED_TRACE("time = " + std::to_string(time_millis));
     EXPECT_EQ(time_millis, Hal.now().millisSinceStartup());
 
     BlowerSystemState s = blower_fsm_desired_state(params);
-    EXPECT_EQ(s.pressure.cmH2O(), expected_pressure.cmH2O());
+    EXPECT_EQ(s.blower_enabled, blower_enabled);
+    EXPECT_EQ(s.setpoint_pressure.cmH2O(), expected_pressure.cmH2O());
     EXPECT_EQ(s.expire_valve_state, expected_valve_state);
   }
 }
@@ -73,12 +75,30 @@ TEST_F(BlowerFsmTest, PressureControl) {
   p.pip_cm_h2o = 20;
 
   testSequence({
-      {p, 0, cmH2O(20), ValveState::CLOSED},
-      {p, 1000, cmH2O(20), ValveState::CLOSED},
-      {p, 1999, cmH2O(20), ValveState::CLOSED},
-      {p, 2001, cmH2O(10), ValveState::OPEN},
-      {p, 2999, cmH2O(10), ValveState::OPEN},
-      {p, 3001, cmH2O(20), ValveState::CLOSED},
+      {p, /*blower_enabled=*/true, 0, cmH2O(20), ValveState::CLOSED},
+      {p, /*blower_enabled=*/true, 1000, cmH2O(20), ValveState::CLOSED},
+      {p, /*blower_enabled=*/true, 1999, cmH2O(20), ValveState::CLOSED},
+      {p, /*blower_enabled=*/true, 2001, cmH2O(10), ValveState::OPEN},
+      {p, /*blower_enabled=*/true, 2999, cmH2O(10), ValveState::OPEN},
+      {p, /*blower_enabled=*/true, 3001, cmH2O(20), ValveState::CLOSED},
+  });
+}
+
+TEST_F(BlowerFsmTest, TurnOff) {
+  VentParams p_on = VentParams_init_zero;
+  p_on.mode = VentMode_PRESSURE_CONTROL;
+  // 20 breaths/min = 3s/breath.  I:E = 2 means 2s for inspire, 1s for expire.
+  p_on.breaths_per_min = 20;
+  p_on.inspiratory_expiratory_ratio = 2;
+  p_on.peep_cm_h2o = 10;
+  p_on.pip_cm_h2o = 20;
+
+  VentParams p_off = VentParams_init_zero;
+
+  testSequence({
+      {p_off, /*blower_enabled=*/false, 0, cmH2O(0), ValveState::OPEN},
+      {p_on, /*blower_enabled=*/true, 1000, cmH2O(20), ValveState::CLOSED},
+      {p_off, /*blower_enabled=*/false, 1001, cmH2O(0), ValveState::OPEN},
   });
 }
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Turn off fan immediately when state is switched to OFF.
    
    Rather than turning off the fan by setting the setpoint to 0 (and
    waiting for PID to spin down to approximately 0), shut off the fan
    entirely, do not pass go, etc.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #230 Turn off fan immediately when state is switched to OFF. 👈 **YOU ARE HERE**
1. #231 Fix 16-bit overflow in Hal timer code.
1. #232 First pass at tidal volume measurement.
1. #233 Re-tune PID.
1. #234 Change default params in DEV_MODE_comms_handler.
1. #205 Clarify comment on sensor scaling factor.

</git-pr-chain>





