### PR TITLE
Fix 16-bit overflow in Hal timer code.

### DIFF
--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -16,6 +16,8 @@ limitations under the License.
 #ifndef UNITS_H
 #define UNITS_H
 
+#include <stdint.h>
+
 // Wrappers for measurements of different physical quantities [1] (length,
 // time, etc.).
 //
@@ -54,8 +56,8 @@ limitations under the License.
 //   VolumetricFlow   cubic_m_per_sec(float)
 //   VolumetricFlow   ml_per_min(float)
 //   Duration         seconds(float)
-//   Duration         milliseconds(int)
-//   Time             millisSinceStartup(int)
+//   Duration         milliseconds(int64_t)
+//   Time             millisSinceStartup(int64_t)
 //
 // Values support addition and subtraction.  The laws for Duration and Time are
 // different than the other units:
@@ -73,8 +75,8 @@ namespace units_detail {
 
 // Represents a value of some physical quantity Q, e.g. length, pressure, time.
 //
-// The value is stored as type ValTy (e.g. float, int), and standard comparison
-// operators are available.
+// The value is stored as type ValTy (e.g. float, int64_t), and standard
+// comparison operators are available.
 //
 // The motivation for this base class is, if we don't, we have to type out the
 // comparison operators for each type.  I'm afraid of typo'ing them, as those
@@ -224,10 +226,10 @@ class Time;
 //  - seconds
 //  - milliseconds
 //
-// Native unit (implementation detail): miliseconds
-class Duration : public units_detail::Scalar<Duration, int> {
+// Native unit (implementation detail): int64_t miliseconds
+class Duration : public units_detail::Scalar<Duration, int64_t> {
 public:
-  [[nodiscard]] constexpr int milliseconds() const { return val_; }
+  [[nodiscard]] constexpr int64_t milliseconds() const { return val_; }
   [[nodiscard]] constexpr float seconds() const {
     return static_cast<float>(val_) / 1000;
   }
@@ -240,13 +242,13 @@ public:
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
 private:
-  constexpr friend Duration milliseconds(int millis);
+  constexpr friend Duration milliseconds(int64_t millis);
   constexpr friend Duration seconds(float secs);
 
-  using units_detail::Scalar<Duration, int>::Scalar;
+  using units_detail::Scalar<Duration, int64_t>::Scalar;
 };
 
-constexpr Duration milliseconds(int millis) { return Duration(millis); }
+constexpr Duration milliseconds(int64_t millis) { return Duration(millis); }
 constexpr Duration seconds(float secs) { return Duration(1000 * secs); }
 
 // Represents a point in time, relative to when the device started up.  See
@@ -257,10 +259,10 @@ constexpr Duration seconds(float secs) { return Duration(1000 * secs); }
 // Units:
 //  - milliseconds
 //
-// Native unit (implementation detail): miliseconds
-class Time : public units_detail::Scalar<Time, int> {
+// Native unit (implementation detail): int64_t miliseconds
+class Time : public units_detail::Scalar<Time, int64_t> {
 public:
-  [[nodiscard]] int millisSinceStartup() const { return val_; }
+  [[nodiscard]] int64_t millisSinceStartup() const { return val_; }
 
   constexpr friend Time operator+(const Time &a, const Duration &b);
   constexpr friend Time operator+(const Duration &a, const Time &b);
@@ -268,12 +270,12 @@ public:
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
 private:
-  constexpr friend Time millisSinceStartup(int millis);
+  constexpr friend Time millisSinceStartup(int64_t millis);
 
-  using units_detail::Scalar<Time, int>::Scalar;
+  using units_detail::Scalar<Time, int64_t>::Scalar;
 };
 
-constexpr Time millisSinceStartup(int millis) { return Time(millis); }
+constexpr Time millisSinceStartup(int64_t millis) { return Time(millis); }
 
 constexpr inline Duration operator+(const Duration &a, const Duration &b) {
   return Duration(a.val_ + b.val_);

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -130,7 +130,12 @@ public:
   void init();
 
   // Current time, strongly typed.  Prefer this over millis().
-  Time now() { return millisSinceStartup(millis()); }
+  Time now() {
+    // TODO: millis() is a uint32_t, which means it rolls over after about a
+    // month.  Use a routine that doesn't roll over, or detect and handle
+    // rollover.
+    return millisSinceStartup(millis());
+  }
 
   // Number of milliseconds that have passed since the board started running the
   // program.


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix 16-bit overflow in Hal timer code.
    
    `int` on Arduino is 16 bits wide, and 2^15ms is only about 30 seconds.
    Therefore a signed int overflows quite frequently!
    
    Fixed to be int64_t, as it should be.
    
    Fixes #224.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #231 Fix 16-bit overflow in Hal timer code. 👈 **YOU ARE HERE**
1. #232 First pass at tidal volume measurement.
1. #233 Re-tune PID.
1. #234 Change default params in DEV_MODE_comms_handler.
1. #205 Clarify comment on sensor scaling factor.

</git-pr-chain>






