### PR TITLE
Re-tune PID.

### DIFF
--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -27,28 +27,18 @@ static double Input;
 static double Output;
 
 // PID-tuning were chosen by following the Ziegler-Nichols method,
-// https://en.wikipedia.org/wiki/Ziegler%E2%80%93Nichols_method.
-//
-// Here's an achieved pressure vs. desired pressure trace collected on Alpha
-// build, 2020-05-01, with the following settings.
-//
-//   PEEP = 10 cm H2O,
-//   PIP = 30 cm H2O,
-//   RR = 10 breaths/min
-//   I:E = 2
-//
-// https://drive.google.com/file/d/13QyvO1ptUYYUAs8qT0dCyW9f1XZ8w7iw
+// https://en.wikipedia.org/wiki/Ziegler%E2%80%93Nichols_method
 //
 // Note that Ku and Tu only seem to work with this particular sample time.
 static constexpr Duration PID_SAMPLE_TIME = milliseconds(10);
-static constexpr float Ku = 600;
-static constexpr Duration Tu = seconds(2);
+static constexpr float Ku = 200;
+static constexpr Duration Tu = seconds(1.5);
 
-// "Classic PID" settings.  Wikipedia says to expect aggressive overshoot with
-// these params, but I don't observe any overshoot.
-static constexpr float Kp = 0.6 * Ku;
-static constexpr float Ki = 1.2 * Ku / Tu.seconds();
-static constexpr float Kd = 3 * Ku * Tu.seconds() / 40;
+// "No overshoot" settings from the Ziegler-Nichols Wikipedia page.  This
+// avoids overpressurizing the patient's lungs.
+static constexpr float Kp = 0.2 * Ku;
+static constexpr float Ki = 0.4 * Ku / Tu.seconds();
+static constexpr float Kd = Ku * Tu.seconds() / 15;
 
 // DIRECT means that increases in the output should result in increases in the
 // input.  DIRECT as opposed to REVERSE.


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Re-tune PID.
    
    Edwin added an output constriction to the device -- i.e. he reduced the
    diameter of the exhaust tube.  We then needed to re-tune PID.
    
    We also needed to re-tune because my previous experiments were done at a
    high PIP and PEEP, and this was causing the blower to max out.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #233 Re-tune PID. 👈 **YOU ARE HERE**
1. #234 Change default params in DEV_MODE_comms_handler.
1. #205 Clarify comment on sensor scaling factor.

</git-pr-chain>







