### PR TITLE
Add instant number readout to displays

### DIFF
--- a/gui/main.qml
+++ b/gui/main.qml
@@ -19,6 +19,9 @@ Item
                 pressureView.series(0),
                 flowView.series(0),
                 tidalVolumeView.series(0));
+            pressureReadout.text = pressureView.series(0).at(pressureView.series(0).count-1).y.toFixed(2).toString()
+            flowReadout.text = flowView.series(0).at(flowView.series(0).count-1).y.toFixed(2).toString()
+            volumeReadout.text = tidalVolumeView.series(0).at(flowView.series(0).count-1).y.toFixed(2).toString()
         }
     }
 
@@ -97,6 +100,42 @@ Item
 
 
 
+    }
+
+    Text {
+        id: flowReadout
+        x: 901
+        y: 15
+        width: 62
+        height: 41
+        color: "green"
+        text: qsTr("0")
+        styleColor: "#ffffff"
+        font.pixelSize: 32
+    }
+
+    Text {
+        id: volumeReadout
+        x: 901
+        y: 202
+        width: 62
+        height: 63
+        color: "yellow"
+        text: qsTr("0")
+        styleColor: "#ffffff"
+        font.pixelSize: 32
+    }
+
+    Text {
+        id: pressureReadout
+        x: 901
+        y: 395
+        width: 62
+        height: 52
+        color: "#4f67ff"
+        text: qsTr("0")
+        styleColor: "#ffffff"
+        font.pixelSize: 32
     }
 
 }


### PR DESCRIPTION
Added instant number readout to displays. Fixes issue #8 
![image](https://user-images.githubusercontent.com/8761441/80923319-ecebd500-8d50-11ea-8c7e-8b5455aafbd8.png)
