### PR TITLE
Fix up Time/Duration handling.

### DIFF
--- a/controller/lib/core/alarm.cpp
+++ b/controller/lib/core/alarm.cpp
@@ -62,9 +62,9 @@ void alarm_add(const char *data) {
   alarm_t alarm;
   if (!stack_full()) {
     // No point spending time doing these operations if the stack is full
-    
+
     //TODO work in progress, move alarm code to nanopb transport
-    alarm.timestamp = Hal.millis();
+    alarm.timestamp = Hal.now().millisSinceStartup();
 
     // Copy alarm data
     for (uint8_t idx = 0; idx < ALARM_DATALEN; idx++) {
@@ -91,8 +91,8 @@ int32_t alarm_read(uint32_t *timestamp, char *data) {
   return_status = stack_peek(&alarm);
 
   if (return_status == VC_STATUS_SUCCESS) {
-    
-    //TODO work in progress move alarm code to nanopb 
+
+    // TODO work in progress move alarm code to nanopb
     *timestamp = alarm->timestamp;
 
     for (uint8_t idx = 0; idx < ALARM_DATALEN; idx++) {

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -53,7 +53,7 @@ void blower_pid_init() {
   Setpoint = 0;
   Input = 0;
   Output = 0;
-  myPID.SetSampleTime(PID_SAMPLE_TIME.milliseconds());
+  myPID.SetSampleTime(PID_SAMPLE_TIME);
 
   // Our output is an 8-bit PWM.
   myPID.SetOutputLimits(0, 255);

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -102,7 +102,7 @@ void sensors_init() {
   // It seems that we'll need to save calibration readings to non-volatile
   // memory and provide operators with a way to shut off the device's blowers,
   // open any necessary valves, and recalibrate.
-  Hal.delay(20);
+  Hal.delay(milliseconds(20));
 
   auto set_zero_level = [](Sensor s) {
     int sum = 0;

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -25,7 +25,8 @@ limitations under the License.
  *    reliable defaults, so we need to have the user set them.
  ***************************************************************************/
 PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
-         double Kd, int POn, int ControllerDirection) {
+         double Kd, int POn, int ControllerDirection)
+    : SampleTime(milliseconds(100)), lastTime(Hal.now() - SampleTime) {
   myOutput = Output;
   myInput = Input;
   mySetpoint = Setpoint;
@@ -34,12 +35,8 @@ PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
   PID::SetOutputLimits(0, 255); // default output limit corresponds to
                                 // the arduino pwm limits
 
-  SampleTime = 100; // default Controller Sample Time is 0.1 seconds
-
   PID::SetControllerDirection(ControllerDirection);
   PID::SetTunings(Kp, Ki, Kd, POn);
-
-  lastTime = Hal.millis() - SampleTime;
 }
 
 /*Constructor (...)*********************************************************
@@ -62,8 +59,8 @@ PID::PID(double *Input, double *Output, double *Setpoint, double Kp, double Ki,
 bool PID::Compute() {
   if (!inAuto)
     return false;
-  unsigned long now = Hal.millis();
-  unsigned long timeChange = (now - lastTime);
+  Time now = Hal.now();
+  Duration timeChange = now - lastTime;
   if (timeChange >= SampleTime) {
     /*Compute all the working error variables*/
     double input = *myInput;
@@ -120,7 +117,7 @@ void PID::SetTunings(double Kp, double Ki, double Kd, int POn) {
   dispKi = Ki;
   dispKd = Kd;
 
-  double SampleTimeInSec = ((double)SampleTime) / 1000;
+  double SampleTimeInSec = SampleTime.seconds();
   kp = Kp;
   ki = Ki * SampleTimeInSec;
   kd = Kd / SampleTimeInSec;
@@ -142,12 +139,12 @@ void PID::SetTunings(double Kp, double Ki, double Kd) {
 /* SetSampleTime(...) *********************************************************
  * sets the period, in Milliseconds, at which the calculation is performed
  ******************************************************************************/
-void PID::SetSampleTime(int NewSampleTime) {
-  if (NewSampleTime > 0) {
-    double ratio = (double)NewSampleTime / (double)SampleTime;
+void PID::SetSampleTime(Duration NewSampleTime) {
+  if (NewSampleTime > milliseconds(0)) {
+    double ratio = NewSampleTime.seconds() / SampleTime.seconds();
     ki *= ratio;
     kd /= ratio;
-    SampleTime = (unsigned long)NewSampleTime;
+    SampleTime = NewSampleTime;
   }
 }
 

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -20,6 +20,8 @@ limitations under the License.
 #define PID_H
 #define LIBRARY_VERSION 1.2.1
 
+#include "units.h"
+
 class PID {
 
 public:
@@ -71,9 +73,10 @@ public:
             //   means the output will increase when error is positive. REVERSE
             //   means the opposite.  it's very unlikely that this will be
             //   needed once it is set in the constructor.
-  void
-  SetSampleTime(int); // * sets the frequency, in Milliseconds, with which
-                      //   the PID calculation is performed.  default is 100
+
+  // Sets the frequency with which the PID calculation is performed.  Default
+  // is 100ms.
+  void SetSampleTime(Duration);
 
   // Display functions
   // ****************************************************************
@@ -103,10 +106,10 @@ private:
       *mySetpoint; //   PID, freeing the user from having to constantly tell us
                    //   what these values are.  with pointers we'll just know.
 
-  unsigned long lastTime;
+  Duration SampleTime;
+  Time lastTime;
   double outputSum, lastInput;
 
-  unsigned long SampleTime;
   double outMin, outMax;
   bool inAuto, pOnE;
 };

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -105,7 +105,7 @@ static void DEV_MODE_comms_handler() {
 
 static void controller_loop() {
   while (true) {
-    controller_status.uptime_ms = Hal.millis();
+    controller_status.uptime_ms = Hal.now().millisSinceStartup();
 
 #ifndef NO_GUI_DEV_MODE
     comms_handler(controller_status, &gui_status);

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -37,7 +37,7 @@ TEST_F(BlowerFsmTest, InitiallyOff) {
 
 TEST_F(BlowerFsmTest, StaysOff) {
   VentParams p = VentParams_init_zero;
-  Hal.delay(1000);
+  Hal.delay(milliseconds(1000));
   BlowerSystemState s = blower_fsm_desired_state(p);
   EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);

--- a/controller/test/comms/comms_test.cpp
+++ b/controller/test/comms/comms_test.cpp
@@ -90,7 +90,7 @@ TEST(CommTests, CommandRx) {
     comms_handler(controller_status_ignored, &received);
     // We use a timeout for framing packets, so we have to advance the time,
     // otherwise we'll never think the packet is complete!
-    Hal.delay(1);
+    Hal.delay(milliseconds(1));
   }
   EXPECT_EQ(s.uptime_ms, received.uptime_ms);
   EXPECT_EQ(s.desired_params.mode, received.desired_params.mode);


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix up Time/Duration handling.
    
    - Make Time an int64 and handle clock overflow.
    - Remove weakly-typed Hal::millis() and Hal::delay(int32) functions.
    - Fix up code so that it all uses strongly-typed functions.
    
    The main motivation is handling timer overflow properly.  As we saw in
    https://github.com/RespiraWorks/VentilatorSoftware/issues/224, overflow
    can be very serious!

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #238 Fix up Time/Duration handling. 👈 **YOU ARE HERE**
1. #205 Clarify comment on sensor scaling factor.

</git-pr-chain>







