### PR TITLE
Include common code in gui Docker build context, fixes #251

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            docker run -i respiraworks/gui:$CIRCLE_SHA1 ./test.sh
+            docker run -i respiraworks/gui:$CIRCLE_SHA1 gui/test.sh
 
 workflows:
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
             docker buildx create --name gui
             docker buildx use gui
             docker buildx inspect --bootstrap
-            cd ~/project/gui && docker buildx build --platform linux/arm64 . -t respiraworks/gui:$CIRCLE_SHA1 --load
+            cd ~/project/ && docker buildx build --platform linux/arm64 -t respiraworks/gui:$CIRCLE_SHA1 --load -f gui/Dockerfile .
       - run:
           name: Run tests
           command: |

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -1,3 +1,5 @@
+# Important: this Dockerfile requires that the repo root be build context (in order to include the common code)
+
 FROM arm64v8/debian:buster
 
 RUN apt-get update && \
@@ -21,5 +23,5 @@ RUN apt-get update && \
     exit 0
 
 COPY . .
-RUN bash ./build.sh
+RUN bash gui/build.sh
 CMD ["bash"]

--- a/gui/test.sh
+++ b/gui/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 Xvfb :1 &
-DISPLAY=:1 ./build/ProjectVentilatorGUI -d
-DISPLAY=:1 ./build/ProjectVentilatorGUI -h
+DISPLAY=:1 ./gui/build/ProjectVentilatorGUI -h


### PR DESCRIPTION
This issue fix the failing gui-build-image CircleCI build, see #251 

Note, the branch is named incorrectly as issue 252, my bad.

https://app.circleci.com/pipelines/github/RespiraWorks/VentilatorSoftware/614/workflows/7a9edc26-9499-48c2-b03a-2ce509ebeca4