### PR TITLE
Include common code in gui Docker build context, fixes #251

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,11 +65,11 @@ jobs:
             docker buildx create --name gui
             docker buildx use gui
             docker buildx inspect --bootstrap
-            cd ~/project/gui && docker buildx build --platform linux/arm64 . -t respiraworks/gui:$CIRCLE_SHA1 --load
+            cd ~/project/ && docker buildx build --platform linux/arm64 -t respiraworks/gui:$CIRCLE_SHA1 --load -f gui/Dockerfile .
       - run:
           name: Run tests
           command: |
-            docker run -i respiraworks/gui:$CIRCLE_SHA1 ./test.sh
+            docker run -i respiraworks/gui:$CIRCLE_SHA1 gui/test.sh
 
 workflows:
   commit:

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -1,3 +1,5 @@
+# Important: this Dockerfile requires that the repo root be build context (in order to include the common code)
+
 FROM arm64v8/debian:buster
 
 RUN apt-get update && \
@@ -21,5 +23,5 @@ RUN apt-get update && \
     exit 0
 
 COPY . .
-RUN bash ./build.sh
+RUN bash gui/build.sh
 CMD ["bash"]

--- a/gui/test.sh
+++ b/gui/test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 Xvfb :1 &
-DISPLAY=:1 ./build/ProjectVentilatorGUI -d
-DISPLAY=:1 ./build/ProjectVentilatorGUI -h
+DISPLAY=:1 ./gui/build/ProjectVentilatorGUI -h


### PR DESCRIPTION
Squashed commit of the following:

commit f0fbed4f956b4df5a3924f8caba25921ba06ba25
Author: Tom Slankard <tom.slankard@here.com>
Date:   Tue May 5 18:17:20 2020 -0700

    Issue 252: Attempt to fix failing gui-build-image due to missing common code in the build context 3

commit f1d63b9ec3eebf1fb83da5249530868e973e9b58
Author: Tom Slankard <tom.slankard@here.com>
Date:   Tue May 5 17:53:16 2020 -0700

    Attempt to fix failing gui-build-image due to missing common code in the build context 2

commit 1b834ea195e131e41ec6072956971197e30453ee
Author: Tom Slankard <tom.slankard@here.com>
Date:   Tue May 5 17:41:53 2020 -0700

    Attempt to fix failing gui-build-image due to missing common code in the build context