### PR TITLE
Modernizes the PID library

### DIFF
--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -252,6 +252,12 @@ private:
 constexpr Duration milliseconds(int64_t millis) { return Duration(millis); }
 constexpr Duration seconds(float secs) { return Duration(1000 * secs); }
 constexpr Duration minutes(float mins) { return seconds(mins * 60); }
+constexpr Duration operator*(int n, Duration d) {
+  return milliseconds(n * d.milliseconds());
+}
+constexpr Duration operator*(Duration d, int n) {
+  return milliseconds(n * d.milliseconds());
+}
 
 // Represents a point in time, relative to when the device started up.  See
 // details above.
@@ -270,6 +276,8 @@ public:
   constexpr friend Time operator+(const Duration &a, const Time &b);
   constexpr friend Time operator-(const Time &a, const Duration &b);
   constexpr friend Duration operator-(const Time &a, const Time &b);
+  inline Time &operator+=(const Duration &dt) { return *this = *this + dt; }
+  inline Time &operator-=(const Duration &dt) { return *this = *this - dt; }
 
 private:
   constexpr friend Time millisSinceStartup(int64_t millis);

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -42,8 +42,9 @@ static constexpr float Kd = Ku * Tu.seconds() / 15;
 
 // DIRECT means that increases in the output should result in increases in the
 // input.  DIRECT as opposed to REVERSE.
-static PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M,
-                 DIRECT);
+static PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd,
+                 ProportionalTerm::ON_ERROR, DifferentialTerm::ON_MEASUREMENT,
+                 ControlDirection::DIRECT);
 
 // TODO: VOLUME_INTEGRAL_INTERVAL was not chosen carefully.
 static constexpr Duration VOLUME_INTEGRAL_INTERVAL = milliseconds(5);

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -42,7 +42,8 @@ static constexpr float Kd = Ku * Tu.seconds() / 15;
 
 // DIRECT means that increases in the output should result in increases in the
 // input.  DIRECT as opposed to REVERSE.
-static PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, DIRECT);
+static PID myPID(&Input, &Output, &Setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M,
+                 DIRECT);
 
 // TODO: VOLUME_INTEGRAL_INTERVAL was not chosen carefully.
 static constexpr Duration VOLUME_INTEGRAL_INTERVAL = milliseconds(5);
@@ -57,9 +58,6 @@ void blower_pid_init() {
 
   // Our output is an 8-bit PWM.
   myPID.SetOutputLimits(0, 255);
-
-  // Turn the PID on.
-  myPID.SetMode(AUTOMATIC);
 }
 
 static void update_volume(SensorReadings *readings) {

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -88,13 +88,12 @@ void blower_pid_execute(const BlowerSystemState &desired_state,
   Pressure cur_pressure = get_patient_pressure();
 
   float pid_output =
-      myPID.Compute(/*input=*/cur_pressure.kPa(),
+      myPID.Compute(Hal.now(), /*input=*/cur_pressure.kPa(),
                     /*setpoint=*/desired_state.setpoint_pressure.kPa());
   // If the blower is not enabled, immediately shut down the fan.  But for
   // consistency, we still run the PID iteration above.
-  float output =
-      static_cast<int>(desired_state.blower_enabled ? pid_output : 0);
-  Hal.analogWrite(PwmPin::BLOWER, output);
+  float output = desired_state.blower_enabled ? pid_output : 0;
+  Hal.analogWrite(PwmPin::BLOWER, static_cast<int>(output));
 
   // fan_power is in range [0, 1].
   *fan_power = output / 255.f;

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -18,10 +18,8 @@ limitations under the License.
 
 #include "pid.h"
 #include "algorithm.h"
-#include "hal.h"
 
-float PID::Compute(float input, float setpoint) {
-  Time now = Hal.now();
+float PID::Compute(Time now, float input, float setpoint) {
   if (!initialized_) {
     last_input_ = input;
     last_error_ = setpoint - input;

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -20,10 +20,6 @@ limitations under the License.
 #include "pid.h"
 #include "hal.h"
 
-/*Constructor (...)*********************************************************
- *    The parameters specified here are those for for which we can't set up
- *    reliable defaults, so we need to have the user set them.
- ***************************************************************************/
 PID::PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
          float Kd, bool POnE, bool DOnE, int ControllerDirection)
     : SampleTime(milliseconds(100)), nextSampleTime(Hal.now()),
@@ -31,24 +27,13 @@ PID::PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
   myOutput = Output;
   myInput = Input;
   mySetpoint = Setpoint;
-  inAuto = false;
 
   // default output limit corresponds to the arduino pwm limits
   PID::SetOutputLimits(0, 255);
 
-  PID::SetControllerDirection(ControllerDirection);
+  controllerDirection = ControllerDirection;
   PID::SetTunings(Kp, Ki, Kd, POnE, DOnE);
 }
-
-/*Constructor (...)*********************************************************
- *    To allow backwards compatability for v1.1, or for people that just want
- *    to use Proportional on Error without explicitly saying so
- ***************************************************************************/
-
-PID::PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
-         float Kd, int ControllerDirection)
-    : PID::PID(Input, Output, Setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M,
-               ControllerDirection) {}
 
 /* Compute()
  *********************************************************************** This,
@@ -58,66 +43,60 @@ PID::PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
  *computed, false when nothing has been done.
  **********************************************************************************/
 bool PID::Compute() {
-  if (!inAuto)
-    return false;
   Time now = Hal.now();
   // compute actual samples time-difference to take jitter into account in
   // integral and derivative
   Duration effectiveSampleTime = (now - lastUpdateTime);
   float samplesTimeChangeSec = effectiveSampleTime.seconds();
   // condition to update output : 1 sample time has passed and we have new data
-  if (now >= nextSampleTime && samplesTimeChangeSec > 0) {
-    /*Compute all the working error variables*/
-    float input = *myInput;
-    float error = *mySetpoint - input;
-    float dInput = 0.0;
-    // Compute dInput only if needed (P_ON_M or D_ON_M)
-    if (pOnE == P_ON_M || dOnE == D_ON_M) {
-      dInput = (input - lastInput);
-    }
-    outputSum += (ki * error * samplesTimeChangeSec);
-
-    /*Add Proportional on Measurement, if P_ON_M is specified*/
-    if (pOnE == P_ON_M)
-      outputSum -= kp * dInput;
-
-    if (outputSum > outMax)
-      outputSum = outMax;
-    else if (outputSum < outMin)
-      outputSum = outMin;
-
-    /*Add Proportional on Error, if P_ON_E is specified*/
-    float output;
-    if (pOnE == P_ON_E) {
-      output = kp * error;
-    } else {
-      output = 0;
-    }
-    if (dOnE == D_ON_M) {
-      dInput /= samplesTimeChangeSec;
-      /*Compute Rest of PID Output*/
-      output += outputSum - kd * dInput;
-    } else { // dOnE==D_ON_E
-      float dError = (error - lastError) / samplesTimeChangeSec;
-      /*Compute Rest of PID Output*/
-      output += outputSum + kd * dError;
-    }
-
-    if (output > outMax)
-      output = outMax;
-    else if (output < outMin)
-      output = outMin;
-    *myOutput = output;
-
-    /*Remember some variables for next time*/
-    lastInput = input;
-    lastError = error;
-    lastUpdateTime = now;
-    // when should we expect to perform our next output calculation
-    nextSampleTime = nextSampleTime + SampleTime;
-    return true;
-  } else
+  if (now < nextSampleTime || samplesTimeChangeSec <= 0) {
     return false;
+  }
+  /*Compute all the working error variables*/
+  float input = *myInput;
+  float error = *mySetpoint - input;
+  float dInput = 0.0;
+  // Compute dInput only if needed (P_ON_M or D_ON_M)
+  if (pOnE == P_ON_M || dOnE == D_ON_M) {
+    dInput = (input - lastInput);
+  }
+  outputSum += (ki * error * samplesTimeChangeSec);
+
+  /*Add Proportional on Measurement, if P_ON_M is specified*/
+  if (pOnE == P_ON_M)
+    outputSum -= kp * dInput;
+
+  if (outputSum > outMax)
+    outputSum = outMax;
+  else if (outputSum < outMin)
+    outputSum = outMin;
+
+  /*Add Proportional on Error, if P_ON_E is specified*/
+  float output;
+  if (pOnE == P_ON_E) {
+    output = kp * error;
+  } else {
+    output = 0;
+  }
+  if (dOnE == D_ON_M) {
+    dInput /= samplesTimeChangeSec;
+    /*Compute Rest of PID Output*/
+    output += outputSum - kd * dInput;
+  } else { // dOnE==D_ON_E
+    float dError = (error - lastError) / samplesTimeChangeSec;
+    /*Compute Rest of PID Output*/
+    output += outputSum + kd * dError;
+  }
+
+  *myOutput = std::clamp(output, outMin, outMax);
+
+  /*Remember some variables for next time*/
+  lastInput = input;
+  lastError = error;
+  lastUpdateTime = now;
+  // when should we expect to perform our next output calculation
+  nextSampleTime = nextSampleTime + SampleTime;
+  return true;
 }
 
 /* SetTunings(...)*************************************************************
@@ -130,7 +109,6 @@ void PID::SetTunings(float Kp, float Ki, float Kd, bool POnE, bool DOnE) {
     return;
 
   pOnE = POnE;
-
   dOnE = DOnE;
 
   kp = Kp;
@@ -144,28 +122,15 @@ void PID::SetTunings(float Kp, float Ki, float Kd, bool POnE, bool DOnE) {
   }
 }
 
-/* SetTunings(...)*************************************************************
- * Set Tunings using the last-rembered  DOnE setting
- ******************************************************************************/
-void PID::SetTunings(float Kp, float Ki, float Kd, bool POnE) {
-  SetTunings(Kp, Ki, Kd, POnE, dOnE);
-}
-
-/* SetTunings(...)*************************************************************
- * Set Tunings using the last-rembered POnE and DOnE setting
- ******************************************************************************/
-void PID::SetTunings(float Kp, float Ki, float Kd) {
-  SetTunings(Kp, Ki, Kd, pOnE, dOnE);
-}
-
 /* SetSampleTime(...) *********************************************************
  * sets the period, in Milliseconds, at which the calculation is performed
  ******************************************************************************/
 void PID::SetSampleTime(Duration NewSampleTime) {
-  if (NewSampleTime > milliseconds(0)) {
-    nextSampleTime = nextSampleTime - SampleTime + NewSampleTime;
-    SampleTime = NewSampleTime;
+  if (NewSampleTime <= milliseconds(0)) {
+    return;
   }
+  nextSampleTime = nextSampleTime - SampleTime + NewSampleTime;
+  SampleTime = NewSampleTime;
 }
 
 /* SetOutputLimits(...)****************************************************
@@ -182,74 +147,6 @@ void PID::SetOutputLimits(float Min, float Max) {
   outMin = Min;
   outMax = Max;
 
-  if (inAuto) {
-    if (*myOutput > outMax)
-      *myOutput = outMax;
-    else if (*myOutput < outMin)
-      *myOutput = outMin;
-
-    if (outputSum > outMax)
-      outputSum = outMax;
-    else if (outputSum < outMin)
-      outputSum = outMin;
-  }
+  *myOutput = std::clamp(*myOutput, outMin, outMax);
+  outputSum = std::clamp(outputSum, outMin, outMax);
 }
-
-/* SetMode(...)****************************************************************
- * Allows the controller Mode to be set to manual (0) or Automatic (non-zero)
- * when the transition from manual to auto occurs, the controller is
- * automatically initialized
- ******************************************************************************/
-void PID::SetMode(int Mode) {
-  bool newAuto = (Mode == AUTOMATIC);
-  if (newAuto && !inAuto) { /*we just went from manual to auto*/
-    PID::Initialize();
-  }
-  inAuto = newAuto;
-}
-
-/* Initialize()****************************************************************
- *	does all the things that need to happen to ensure a bumpless transfer
- *  from manual to automatic mode.
- ******************************************************************************/
-void PID::Initialize() {
-  outputSum = *myOutput;
-  lastInput = *myInput;
-  lastError = *mySetpoint - *myInput;
-  if (outputSum > outMax)
-    outputSum = outMax;
-  else if (outputSum < outMin)
-    outputSum = outMin;
-  // next sample time in now
-  nextSampleTime = Hal.now();
-  // last call time defined as now - SampleTime to enable computation on first
-  // call (user should call Compute() immediately after SetMode(Auto))
-  lastUpdateTime = Hal.now() - SampleTime;
-}
-
-/* SetControllerDirection(...)*************************************************
- * The PID will either be connected to a DIRECT acting process (+Output leads
- * to +Input) or a REVERSE acting process(+Output leads to -Input.)  we need to
- * know which one, because otherwise we may increase the output when we should
- * be decreasing.  This is called from the constructor.
- ******************************************************************************/
-void PID::SetControllerDirection(int Direction) {
-  if (inAuto && Direction != controllerDirection) {
-    kp = (0 - kp);
-    ki = (0 - ki);
-    kd = (0 - kd);
-  }
-  controllerDirection = Direction;
-}
-
-/* Status Funcions*************************************************************
- * Just because you set the Kp=-1 doesn't mean it actually happened.  these
- * functions query the internal state of the PID.  they're here for display
- * purposes.  this are the functions the PID Front-end uses for example
- ******************************************************************************/
-float PID::GetKp() { return kp; }
-float PID::GetKi() { return ki; }
-float PID::GetKd() { return kd; }
-Duration PID::GetSampleTime() { return SampleTime; }
-bool PID::GetMode() { return inAuto ? AUTOMATIC : MANUAL; }
-bool PID::GetDirection() { return controllerDirection; }

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -86,3 +86,15 @@ float PID::Compute(Time now, float input, float setpoint) {
   last_output_ = stl::clamp(res, out_min_, out_max_);
   return last_output_;
 }
+
+void PID::Observe(Time now, float input, float setpoint, float actual_output) {
+  // All the observable variables are updated the same way as in Compute();
+  last_input_ = input;
+  last_error_ = setpoint - input;
+  last_update_time_ = now;
+  next_sample_time_ = now + sample_period_;
+  // Reset output_sum_ to actual_output so that the next Compute()
+  // will adjust it only slightly (as if it had been computed by a current
+  // Compute() call), avoiding a spike.
+  output_sum_ = stl::clamp(actual_output, out_min_, out_max_);
+}

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -52,6 +52,15 @@ public:
   // of the previous call, returns the last returned value.
   float Compute(Time now, float input, float setpoint);
 
+  // Call this instead of Compute in case on this step of the control loop
+  // you intend apply different control logic instead of the PID.
+  // "actual_output" contains the value of output you plan to act on.
+  //
+  // This is a variation on the "manual" mode:
+  // http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-onoff/
+  // http://brettbeauregard.com/blog/2011/04/improving-the-beginner%e2%80%99s-pid-initialization/
+  void Observe(Time now, float input, float setpoint, float actual_output);
+
 private:
   const float kp_; // * (P)roportional Tuning Parameter
   const float ki_; // * (I)ntegral Tuning Parameter

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -39,17 +39,15 @@ enum class ControlDirection {
 
 class PID {
 public:
-  // Constructs the PID linked to the Input, Output, and Setpoint,
-  // using the given parameters.
-  PID(float *input, float *output, float *setpoint, float kp, float ki,
-      float kd, ProportionalTerm p_term, DifferentialTerm d_term,
-      ControlDirection direction);
+  // Constructs the PID using the given parameters.
+  PID(float kp, float ki, float kd, ProportionalTerm p_term,
+      DifferentialTerm d_term, ControlDirection direction);
 
   // Performs one step of the PID calculation. Calculation frequency
   // can be set using SetSampleTime.
   // Returns false if this call was ignored due to being within sample time
   // of the previous call, otherwise true.
-  bool Compute();
+  bool Compute(float input, float setpoint, float *output);
 
   // Clamps the output to a specific range. 0-255 by default, but
   // it's likely the user will want to change this depending on
@@ -61,13 +59,6 @@ public:
   void SetSampleTime(Duration sample_time);
 
 private:
-  float
-      *const input_; // * Pointers to the Input, Output, and Setpoint variables
-  float
-      *const output_; // This creates a hard link between the variables and the
-  float *const setpoint_; // PID, freeing the user from having to constantly
-                          // tell us what these values are.
-
   const float kp_; // * (P)roportional Tuning Parameter
   const float ki_; // * (I)ntegral Tuning Parameter
   const float kd_; // * (D)erivative Tuning Parameter

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -82,6 +82,7 @@ private:
   float *setpoint_; // PID, freeing the user from having to constantly tell
                     // us what these values are.
 
+  bool initialized_ = false;
   Duration sample_time_;
   Time next_sample_time_;
   Time last_update_time_;

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -22,12 +22,24 @@ limitations under the License.
 
 #include "units.h"
 
-class PID {
+enum class ProportionalTerm {
+  PROPORTIONAL_ON_ERROR,
+  PROPORTIONAL_ON_MEASUREMENT,
+};
 
+enum class DifferentialTerm {
+  DIFFERENTIAL_ON_ERROR,
+  DIFFERENTIAL_ON_MEASUREMENT,
+};
+
+enum class ControlDirection {
+  DIRECT,
+  REVERSE,
+};
+
+class PID {
 public:
 // Constants used in some of the functions below
-#define AUTOMATIC 1
-#define MANUAL 0
 #define DIRECT 0
 #define REVERSE 1
 #define P_ON_M 0
@@ -35,65 +47,28 @@ public:
 #define D_ON_M 0
 #define D_ON_E 1
 
-  // commonly used functions
-  // **************************************************************************
-  // * constructor.  links the PID to the Input, Output, and
-  //   Setpoint.  Initial tuning parameters are also set here.
-  //   (overload for specifying proportional and derivative modes)
+  // Constructs the PID linked to the Input, Output, and Setpoint,
+  // using the given parameters.
   PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
       float Kd, bool POnE, bool DOnE, int ControllerDirection);
 
-  // * constructor.  links the PID to the Input, Output, and
-  //   Setpoint.  Initial tuning parameters are also set here.
-  //   Uses default values DOnE = D_ON_M and POnE = P_ON_E
-  PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
-      float Kd, int ControllerDirection);
-
-  // * sets PID to either Manual (0) or Auto (non-0)
-  void SetMode(int Mode);
-
-  // * performs the PID calculation.  it should be called every time loop()
-  // cycles. ON/OFF and calculation frequency can be set using SetMode
-  // SetSampleTime respectively
+  // Performs one step of the PID calculation. Calculation frequency
+  // can be set using SetSampleTime.
   bool Compute();
 
-  // * clamps the output to a specific range. 0-255 by default, but
-  //   it's likely the user will want to change this depending on
-  //   the application
+  // Clamps the output to a specific range. 0-255 by default, but
+  // it's likely the user will want to change this depending on
+  // the application.
   void SetOutputLimits(float Min, float Max);
 
-  // available but not commonly used functions
-  // ********************************************************
-  // * While most users will set the tunings once in the
-  //   constructor, this function gives the user the option
-  //   of changing tunings during runtime for Adaptive control
-  void SetTunings(float Kp, float Ki, float Kd);
-  // * overload for specifying proportional mode
-  void SetTunings(float Kp, float Ki, float Kd, bool POnE);
-  // * overload for specifying proportional and derivative modes
+  // Changes the PID parameters to the given values.
   void SetTunings(float Kp, float Ki, float Kd, bool POnE, bool DOnE);
 
-  // * Sets the Direction, or "Action" of the controller. DIRECT
-  //   means the output will increase when error is positive. REVERSE
-  //   means the opposite.  it's very unlikely that this will be
-  //   needed once it is set in the constructor.
-  void SetControllerDirection(int Direction);
-  // * sets the frequency, in Milliseconds, with which
-  //   the PID calculation is performed.  default is 100
+  // Sets the frequency, in Milliseconds, with which the PID calculation
+  // is performed.  Default is 100.
   void SetSampleTime(Duration NewSampleTime);
 
-  // Display functions
-  // ****************************************************************
-  float GetKp(); // These functions query the pid for interal values.
-  float GetKi(); //  they were created mainly for the pid front-end,
-  float GetKd(); // where it's important to know what is actually
-  Duration GetSampleTime();
-  bool GetMode();      //  inside the PID.
-  bool GetDirection(); //
-
 private:
-  void Initialize();
-
   float kp; // * (P)roportional Tuning Parameter
   float ki; // * (I)ntegral Tuning Parameter
   float kd; // * (D)erivative Tuning Parameter
@@ -110,6 +85,6 @@ private:
   float outputSum, lastInput, lastError;
 
   float outMin, outMax;
-  bool inAuto, pOnE, dOnE;
+  bool pOnE, dOnE;
 };
 #endif

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -49,8 +49,8 @@ public:
 
   // Constructs the PID linked to the Input, Output, and Setpoint,
   // using the given parameters.
-  PID(float *Input, float *Output, float *Setpoint, float Kp, float Ki,
-      float Kd, bool POnE, bool DOnE, int ControllerDirection);
+  PID(float *input, float *output, float *setpoint, float kp, float ki,
+      float kd, bool p_on_e, bool d_on_e, int controller_direction);
 
   // Performs one step of the PID calculation. Calculation frequency
   // can be set using SetSampleTime.
@@ -61,14 +61,14 @@ public:
   // Clamps the output to a specific range. 0-255 by default, but
   // it's likely the user will want to change this depending on
   // the application.
-  void SetOutputLimits(float Min, float Max);
+  void SetOutputLimits(float min, float max);
 
   // Changes the PID parameters to the given values.
-  void SetTunings(float Kp, float Ki, float Kd, bool POnE, bool DOnE);
+  void SetTunings(float kp, float ki, float kd, bool p_on_e, bool d_on_e);
 
   // Sets the frequency, in Milliseconds, with which the PID calculation
   // is performed.  Default is 100.
-  void SetSampleTime(Duration NewSampleTime);
+  void SetSampleTime(Duration sample_time);
 
 private:
   float kp_; // * (P)roportional Tuning Parameter
@@ -90,8 +90,9 @@ private:
   float last_input_;
   float last_error_;
 
-  float out_min_;
-  float out_max_;
+  // default output limit corresponds to the arduino pwm limits
+  float out_min_ = 0;
+  float out_max_ = 255;
   bool p_on_e_;
   bool d_on_e_;
 };

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -54,6 +54,8 @@ public:
 
   // Performs one step of the PID calculation. Calculation frequency
   // can be set using SetSampleTime.
+  // Returns false if this call was ignored due to being within sample time
+  // of the previous call, otherwise true.
   bool Compute();
 
   // Clamps the output to a specific range. 0-255 by default, but
@@ -69,22 +71,27 @@ public:
   void SetSampleTime(Duration NewSampleTime);
 
 private:
-  float kp; // * (P)roportional Tuning Parameter
-  float ki; // * (I)ntegral Tuning Parameter
-  float kd; // * (D)erivative Tuning Parameter
+  float kp_; // * (P)roportional Tuning Parameter
+  float ki_; // * (I)ntegral Tuning Parameter
+  float kd_; // * (D)erivative Tuning Parameter
 
-  int controllerDirection;
+  int controller_direction_;
 
-  float *myInput;    // * Pointers to the Input, Output, and Setpoint variables
-  float *myOutput;   // This creates a hard link between the variables and the
-  float *mySetpoint; // PID, freeing the user from having to constantly tell
-                     // us what these values are.
+  float *input_;    // * Pointers to the Input, Output, and Setpoint variables
+  float *output_;   // This creates a hard link between the variables and the
+  float *setpoint_; // PID, freeing the user from having to constantly tell
+                    // us what these values are.
 
-  Duration SampleTime;
-  Time nextSampleTime, lastUpdateTime;
-  float outputSum, lastInput, lastError;
+  Duration sample_time_;
+  Time next_sample_time_;
+  Time last_update_time_;
+  float output_sum_;
+  float last_input_;
+  float last_error_;
 
-  float outMin, outMax;
-  bool pOnE, dOnE;
+  float out_min_;
+  float out_max_;
+  bool p_on_e_;
+  bool d_on_e_;
 };
 #endif

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -50,7 +50,7 @@ public:
   // Performs one step of the PID calculation.
   // If this call was ignored due to being within sample time
   // of the previous call, returns the last returned value.
-  float Compute(float input, float setpoint);
+  float Compute(Time now, float input, float setpoint);
 
 private:
   const float kp_; // * (P)roportional Tuning Parameter

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -41,22 +41,16 @@ class PID {
 public:
   // Constructs the PID using the given parameters.
   PID(float kp, float ki, float kd, ProportionalTerm p_term,
-      DifferentialTerm d_term, ControlDirection direction);
+      DifferentialTerm d_term, ControlDirection direction, float output_min,
+      float output_max, Duration sample_period)
+      : kp_(kp), ki_(ki), kd_(kd), p_term_(p_term), d_term_(d_term),
+        direction_(direction), out_min_(output_min), out_max_(output_max),
+        sample_period_(sample_period) {}
 
-  // Performs one step of the PID calculation. Calculation frequency
-  // can be set using SetSampleTime.
-  // Returns false if this call was ignored due to being within sample time
-  // of the previous call, otherwise true.
-  bool Compute(float input, float setpoint, float *output);
-
-  // Clamps the output to a specific range. 0-255 by default, but
-  // it's likely the user will want to change this depending on
-  // the application.
-  void SetOutputLimits(float min, float max);
-
-  // Sets the frequency, in Milliseconds, with which the PID calculation
-  // is performed.  Default is 100.
-  void SetSampleTime(Duration sample_time);
+  // Performs one step of the PID calculation.
+  // If this call was ignored due to being within sample time
+  // of the previous call, returns the last returned value.
+  float Compute(float input, float setpoint);
 
 private:
   const float kp_; // * (P)roportional Tuning Parameter
@@ -67,16 +61,17 @@ private:
   const DifferentialTerm d_term_;
   const ControlDirection direction_;
 
-  // default output limit corresponds to the arduino pwm limits
-  float out_min_ = 0;
-  float out_max_ = 255;
+  const float out_min_;
+  const float out_max_;
+
+  const Duration sample_period_;
 
   bool initialized_ = false;
-  Duration sample_time_ = milliseconds(100);
   Time next_sample_time_ = millisSinceStartup(0);
   Time last_update_time_ = millisSinceStartup(0);
-  float output_sum_;
-  float last_input_;
-  float last_error_;
+  float output_sum_ = 0;
+  float last_input_ = 0;
+  float last_error_ = 0;
+  float last_output_ = 0;
 };
 #endif

--- a/controller/lib/stl/algorithm.h
+++ b/controller/lib/stl/algorithm.h
@@ -50,5 +50,10 @@ template <typename T> constexpr const T &max(const T &a, const T &b) {
   return a > b ? a : b;
 }
 
+template <typename T>
+constexpr const T &clamp(const T &v, const T &lo, const T &hi) {
+  return (v < lo) ? lo : (hi < v) ? hi : v;
+}
+
 } // namespace stl
 #endif // ALGORITHM_H

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -46,7 +46,7 @@ TEST(pidTest, Proportional) {
   Duration sample_time = milliseconds(100);
 
   // Create PID and run once
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
 
@@ -68,7 +68,7 @@ TEST(pidTest, Integral) {
   Duration sample_time = milliseconds(100);
 
   // Create PID and run once
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
 
@@ -222,7 +222,7 @@ TEST(pidTest, CallFasterThanSample) {
   float setpoint = 25;
   float input = setpoint - 10;
   Duration sample_time = milliseconds(100);
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
 
@@ -260,7 +260,7 @@ TEST(pidTest, TaskJitter) {
   float setpoint = 25;
   float input = setpoint - 10;
   Duration sample_time = milliseconds(100);
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
   // First task, with only Ki set, output = error*sample_time
@@ -292,7 +292,7 @@ TEST(pidTest, SampleTimeChange) {
   float setpoint = 25;
   float input = setpoint - 10;
   Duration sample_time = milliseconds(100);
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
 
@@ -324,7 +324,7 @@ TEST(pidTest, MissedSample) {
   float setpoint = 25;
   float input = setpoint - 10;
   Duration sample_time = milliseconds(100);
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
 
@@ -361,7 +361,7 @@ TEST(pidTest, OffOnCycle) {
   float setpoint = 25;
   float input = setpoint - 10;
   Duration sample_time = milliseconds(100);
-  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
+  PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
   myPID.Compute();
 
@@ -378,7 +378,7 @@ TEST(pidTest, OffOnCycle) {
   Kp = 0;
   Ki = 1;
   Kd = 0;
-  myPID.SetTunings(Kp, Ki, Kd);
+  myPID.SetTunings(Kp, Ki, Kd, P_ON_E, D_ON_M);
 
   float integral = (setpoint - input) * (sample_time.seconds());
 

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -21,283 +21,256 @@ limitations under the License.
  * on an Arduino platform.
  */
 
-#include "hal.h"
 #include "pid.h"
 #include "types.h"
 #include "gtest/gtest.h"
 
 // The PWM is a 0-255 integer, which means we can accept error of 1 in output
-static const float OUTPUT_TOLERANCE = 1;
+inline constexpr float OUTPUT_TOLERANCE = 1;
 
 // PID min/max output
-static const float MAX_OUTPUT = 255;
-static const float MIN_OUTPUT = 0;
+inline constexpr const float MAX_OUTPUT = 255;
+inline constexpr const float MIN_OUTPUT = 0;
 
 // Maximum task jitter (assume 5 ms for now, will need adjuting)
-static const Duration max_task_jitter = milliseconds(5);
+inline constexpr Duration max_task_jitter = milliseconds(5);
 
-TEST(pidTest, Proportional) {
-  float Kp = 0.9;
-  float Ki = 0;
-  float Kd = 0;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
+inline constexpr Time base = millisSinceStartup(10000);
+inline constexpr Duration sample_period = milliseconds(100);
+Time ticks(int num_ticks) { return base + num_ticks * sample_period; }
+
+#define EXPECT_OUTPUT(expected, actual)                                        \
+  EXPECT_NEAR(expected, actual, OUTPUT_TOLERANCE)
+
+TEST(PidTest, Proportional) {
+  const float Kp = 0.9;
+  const float setpoint = 25;
+  const float input = setpoint - 10;
 
   // Create PID and run once
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT, 0, 255,
-          sample_time);
+  PID pid(Kp, /*ki=*/0, /*kd=*/0, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  int t = 0;
 
   // Ki and Kd = 0 therefore output = Kp*error, nothing more
-  EXPECT_NEAR(pid.Compute(input, setpoint), (setpoint - input) * Kp,
-              OUTPUT_TOLERANCE);
-  Hal.delay(sample_time);
-  EXPECT_NEAR(pid.Compute(input, setpoint), (setpoint - input) * Kp,
-              OUTPUT_TOLERANCE);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint),
+                (setpoint - input) * Kp);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint),
+                (setpoint - input) * Kp);
 }
 
-TEST(pidTest, Integral) {
-  float Kp = 0;
-  float Ki = 1.75;
-  float Kd = 0;
-  const uint32_t MAX_ITERATIONS = 1000;
-  float output = 0;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
+TEST(PidTest, IntegralBasic) {
+  const float Ki = 1.75;
+  const float setpoint = 25;
+  const float input = setpoint - 10;
 
-  // Create PID and run once
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT, 0, 255,
-          sample_time);
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  int t = 0;
 
   // on first call, integral = error*sample time, output = Ki*integral
-  EXPECT_NEAR(pid.Compute(input, setpoint),
-              (setpoint - input) * sample_time.seconds() * Ki,
-              OUTPUT_TOLERANCE);
-
-  Hal.delay(sample_time);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint),
+                (setpoint - input) * sample_period.seconds() * Ki);
 
   // on second call, integral = error*2*sample time, output = Ki*integral
-  EXPECT_NEAR(pid.Compute(input, setpoint),
-              (setpoint - input) * 2 * sample_time.seconds() * Ki,
-              OUTPUT_TOLERANCE);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, setpoint),
+                (setpoint - input) * 2 * sample_period.seconds() * Ki);
+}
 
-  uint32_t cycles = MAX_ITERATIONS;
-  // test output and integral saturation to MAX
-  while (output < MAX_OUTPUT && cycles > 0) {
-    Hal.delay(sample_time);
-    output = pid.Compute(input, setpoint);
-    cycles--;
+TEST(PidTest, IntegralSaturationMax) {
+  const float Ki = 1.75;
+  const float setpoint = 25;
+  const float input = setpoint - 10;
+
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  int t = 0;
+
+  float output = 0;
+  for (int i = 0; i < 1000; ++i) {
+    output = pid.Compute(ticks(t++), input, setpoint);
+    if (output >= MAX_OUTPUT)
+      break;
   }
   EXPECT_EQ(output, MAX_OUTPUT);
-  // run a few times to make sure actual integral is bigger
+
   for (int i = 0; i < 10; i++) {
-    Hal.delay(sample_time);
-    pid.Compute(input, setpoint);
+    pid.Compute(ticks(t++), input, setpoint);
   }
+
   // make setpoint lower than input to de-saturate output
-  setpoint = input - 10;
+  const float low_setpoint = input - 10;
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, low_setpoint),
+                MAX_OUTPUT +
+                    (low_setpoint - input) * sample_period.seconds() * Ki);
+}
 
-  Hal.delay(sample_time);
+TEST(PidTest, IntegralSaturationMin) {
+  const float Ki = 1.75;
+  const float setpoint = 25;
+  const float input = setpoint + 10;
 
-  EXPECT_NEAR(pid.Compute(input, setpoint),
-              MAX_OUTPUT + (setpoint - input) * sample_time.seconds() * Ki,
-              OUTPUT_TOLERANCE);
+  // Create PID and run once
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  int t = 0;
 
-  // test output and integral saturation to MIN
-  cycles = MAX_ITERATIONS;
-  while (output > MIN_OUTPUT && cycles > 0) {
-    Hal.delay(sample_time);
-    output = pid.Compute(input, setpoint);
-    cycles--;
+  float output = 0;
+  for (int i = 0; i < 1000; ++i) {
+    output = pid.Compute(ticks(t++), input, setpoint);
+    if (output <= MIN_OUTPUT)
+      break;
   }
   EXPECT_EQ(output, MIN_OUTPUT);
 
   // run a few times to make sure actual integral is lower
   for (int i = 0; i < 10; i++) {
-    Hal.delay(sample_time);
-    pid.Compute(input, setpoint);
+    pid.Compute(ticks(t++), input, setpoint);
   }
 
   // make setpoint bigger than input again to de-saturate output
-  setpoint = input + 10;
+  float new_setpoint = input + 10;
 
-  Hal.delay(sample_time);
-
-  EXPECT_NEAR(pid.Compute(input, setpoint),
-              MIN_OUTPUT + (setpoint - input) * sample_time.seconds() * Ki,
-              OUTPUT_TOLERANCE);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input, new_setpoint),
+                MIN_OUTPUT +
+                    (new_setpoint - input) * sample_period.seconds() * Ki);
 }
 
-TEST(pidTest, derivativeOnMeasure) {
-  float Kp = 0;
-  float Ki = 0;
-  float Kd = 1.5;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT, 0, 255,
-          sample_time);
+// In the following tests we transition from (input1, setpoint1) to (input2,
+// setpoint2). Derivative on measure and on error should handle this transition
+// differently.
+TEST(PidTest, DerivativeOnMeasure) {
+  const float Kd = 1.5;
+  const float setpoint1 = 25;
+  const float input1 = setpoint1 - 10;
+  const float setpoint2 = 17;
+  const float input2 = setpoint2 - 13;
+  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::ON_MEASUREMENT,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  int t = 0;
+
   // Expect no derivative on first call
-  EXPECT_NEAR(pid.Compute(input, setpoint), 0, OUTPUT_TOLERANCE);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input1, setpoint1), 0);
 
-  // delay and update input to create non-zero derivative
-  float previous_input = input;
-  // output being in [0 255], create a negative input derivative to have a
-  // positive output (DifferentialTerm::ON_MEASUREMENT actually works with
-  // -1*Kd) to allow using the same parameters as DifferentialTerm::ON_ERROR)
-  input = input - 5;
-  float derivative = (input - previous_input) / sample_time.seconds();
-
-  Hal.delay(sample_time);
-  EXPECT_NEAR(pid.Compute(input, setpoint), -1 * derivative * Kd,
-              OUTPUT_TOLERANCE);
-
-  previous_input = input;
-  // no change in input, but change setpoint, which should have no effect on
-  // derivative (this mode uses derivative on measurement)
-  setpoint = setpoint + 5;
-  derivative = (input - previous_input) / sample_time.seconds();
-
-  Hal.delay(sample_time);
-  EXPECT_NEAR(pid.Compute(input, setpoint), -1 * derivative * Kd,
-              OUTPUT_TOLERANCE);
+  // Note that DifferentialTerm::ON_MEASUREMENT actually works with
+  // -1*Kd to allow using the same parameters as DifferentialTerm::ON_ERROR
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input2, setpoint2),
+                -1 * Kd * (input2 - input1) / sample_period.seconds());
 }
 
-TEST(pidTest, derivativeOnError) {
-  float Kp = 0;
-  float Ki = 0;
-  float Kd = 2.5;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR, DifferentialTerm::ON_ERROR,
-          ControlDirection::DIRECT, 0, 255, sample_time);
+TEST(PidTest, DerivativeOnError) {
+  const float Kd = 1.5;
+  const float setpoint1 = 25;
+  const float input1 = setpoint1 - 10;
+  const float setpoint2 = 17;
+  const float input2 = setpoint2 - 13;
+  PID pid(/*kp=*/0, /*ki=*/0, Kd, ProportionalTerm::ON_MEASUREMENT,
+          DifferentialTerm::ON_ERROR, ControlDirection::DIRECT, MIN_OUTPUT,
+          MAX_OUTPUT, sample_period);
+  int t = 0;
+
   // Expect no derivative on first call
-  EXPECT_NEAR(pid.Compute(input, setpoint), 0, OUTPUT_TOLERANCE);
-
-  // update input to create non-zero derivative
-  float previous_input = input;
-  float previous_setpoint = setpoint;
-  // output being in [0 255], create a negative input derivative in order to
-  // have a positive error derivative, and therefore a positive output
-  input = input - 5;
-  float derivative =
-      ((setpoint - input) - (previous_setpoint - previous_input)) /
-      sample_time.seconds();
-
-  Hal.delay(sample_time);
-  EXPECT_NEAR(pid.Compute(input, setpoint), derivative * Kd, OUTPUT_TOLERANCE);
-
-  previous_setpoint = setpoint;
-  previous_input = input;
-  // output being in [0 255], create a positive setpoint derivative in order to
-  // have a positive error derivative, and therefore a positive output
-  setpoint = setpoint + 5;
-  derivative = ((setpoint - input) - (previous_setpoint - previous_input)) /
-               sample_time.seconds();
-  Hal.delay(sample_time);
-  EXPECT_NEAR(pid.Compute(input, setpoint), derivative * Kd, OUTPUT_TOLERANCE);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input1, setpoint1), 0);
+  EXPECT_OUTPUT(pid.Compute(ticks(t++), input2, setpoint2),
+                Kd * ((setpoint2 - input2) - (setpoint1 - input1)) /
+                    sample_period.seconds());
 }
 
-TEST(pidTest, CallFasterThanSample) {
+TEST(PidTest, CallFasterThanSample) {
   // This test calls PID::Compute faster than sample time to check this has no
   // effect on output
-  float Kp = 5.5;
-  float Ki = 1.1;
-  float Kd = 1.5;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT, 0, 255,
-          sample_time);
+  const float setpoint = 25;
+  const float input = setpoint - 10;
+  PID pid(/*kp=*/5.5, /*ki=*/1.1, /*kd=*/1.5, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  int t = 0;
 
-  float last_output = pid.Compute(input, setpoint);
+  float last_output = pid.Compute(ticks(t), input, setpoint);
   // check that call with no time change has no effect
-  EXPECT_EQ(pid.Compute(input, setpoint), last_output);
+  EXPECT_EQ(pid.Compute(ticks(t), input, setpoint), last_output);
 
-  Time last_time = Hal.now();
-
+  // Run PID a few times in rapid succession and check output doesn't change
+  // unless a sample time has passed
+  Time next_sample = ticks(t) + sample_period;
   // chose dt to not be a divisor of SampleTime, for better coverage
   Duration dt = milliseconds(6);
-  // Run PID a few times with fast and check output doesn't change unless a
-  // sample time has passed
   for (int i = 0; i < 100; i++) {
-    Hal.delay(dt);
-    float output = pid.Compute(input, setpoint);
-    if (Hal.now() >= last_time + sample_time) {
+    Time now = ticks(t) + i * dt;
+    float output = pid.Compute(now, input, setpoint);
+    if (now >= next_sample) {
       last_output = output;
-      last_time = last_time + sample_time;
+      next_sample += sample_period;
     } else {
       EXPECT_EQ(output, last_output);
     }
   }
 }
 
-TEST(pidTest, TaskJitter) {
+TEST(PidTest, TaskJitter) {
   // This test uses integral to check the effect of time between calls on the
   // PID output. Introducing jitter in call frequency and checking that the
   // integral takes this jitter into account.
-  float Kp = 0;
-  float Ki = 0.5;
-  float Kd = 0;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT, 0, 255,
-          sample_time);
-  // First task, with only Ki set, output = error*sample_time
-  float integral = (setpoint - input) * sample_time.seconds();
-  EXPECT_NEAR(pid.Compute(input, setpoint), integral * Ki, OUTPUT_TOLERANCE);
+  const float Ki = 0.5;
+  const float setpoint = 25;
+  const float input = setpoint - 10;
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  Time now = base;
+
+  float integral = (setpoint - input) * sample_period.seconds();
+  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+
   // Advance time with jitter
-  Duration dt = sample_time + max_task_jitter;
-  Hal.delay(dt);
+  Duration dt_high = sample_period + max_task_jitter;
+  now += dt_high;
   // Expect output to take jitter into account in integral
-  integral += (setpoint - input) * (dt.seconds());
-  EXPECT_NEAR(pid.Compute(input, setpoint), integral * Ki, OUTPUT_TOLERANCE);
+  integral += (setpoint - input) * dt_high.seconds();
+  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+
   // Advance time and compensate previous jitter to have total time
   // elapsed = 2*sample time
-  dt = sample_time - max_task_jitter;
-  integral += (setpoint - input) * (dt.seconds());
-  Hal.delay(dt);
-  EXPECT_NEAR(pid.Compute(input, setpoint), integral * Ki, OUTPUT_TOLERANCE);
+  Duration dt_low = sample_period - max_task_jitter;
+  integral += (setpoint - input) * dt_low.seconds();
+  now += dt_low;
+  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
 }
 
-TEST(pidTest, MissedSample) {
+TEST(PidTest, MissedSample) {
   // This test uses integral to check the effect of missing a sample in the
   // execution of PID
-  float Kp = 0;
-  float Ki = 0.2;
-  float Kd = 0;
-  float setpoint = 25;
-  float input = setpoint - 10;
-  Duration sample_time = milliseconds(100);
-  PID pid(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
-          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT, 0, 255,
-          sample_time);
+  const float Ki = 0.2;
+  const float setpoint = 25;
+  const float input = setpoint - 10;
+  PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
+          DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
+          MIN_OUTPUT, MAX_OUTPUT, sample_period);
+  Time now = base;
 
-  // First task, with only Ki set, output = error*sample_time
-  float integral = (setpoint - input) * (sample_time.seconds());
-  EXPECT_NEAR(pid.Compute(input, setpoint), integral * Ki, OUTPUT_TOLERANCE);
+  float integral = (setpoint - input) * (sample_period.seconds());
+  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
+
   // Advance time
-  Duration dt = sample_time + sample_time;
-  Hal.delay(dt);
-  float output = pid.Compute(input, setpoint);
+  now += 2 * sample_period;
+  float output = pid.Compute(now, input, setpoint);
   // Expect output to integrate this
-  integral += (setpoint - input) * (dt.seconds());
-  EXPECT_NEAR(output, integral * Ki, OUTPUT_TOLERANCE);
+  integral += (setpoint - input) * 2 * sample_period.seconds();
+  EXPECT_OUTPUT(output, integral * Ki);
+
   // check that a new call without change in time has no effect, even if we
   // missed a sample
-  EXPECT_EQ(pid.Compute(input, setpoint), output);
+  EXPECT_EQ(pid.Compute(now, input, setpoint), output);
+
   // Advance time a small amount to allow PID to catch up to missed sample
-  dt = max_task_jitter;
-  Hal.delay(dt);
-  integral += (setpoint - input) * (dt.seconds());
+  Duration dt = max_task_jitter;
+  now += dt;
+  integral += (setpoint - input) * dt.seconds();
   // Expect output to have a new update
-  EXPECT_NEAR(pid.Compute(input, setpoint), integral * Ki, OUTPUT_TOLERANCE);
+  EXPECT_OUTPUT(pid.Compute(now, input, setpoint), integral * Ki);
 }

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -48,7 +48,6 @@ TEST(pidTest, Proportional) {
   // Create PID and run once
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
 
   // Ki and Kd = 0 therefore output = Kp*error, nothing more
@@ -71,7 +70,6 @@ TEST(pidTest, Integral) {
   // Create PID and run once
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
 
   // on first call, integral = error*sample time, output = Ki*integral
@@ -144,7 +142,6 @@ TEST(pidTest, derivativeOnMeasure) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_M, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
   // Expect no derivative on first call
   EXPECT_NEAR(output, 0, OUTPUT_TOLERANCE);
@@ -184,7 +181,6 @@ TEST(pidTest, derivativeOnError) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, P_ON_E, D_ON_E, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
   // Expect no derivative on first call
   EXPECT_NEAR(output, 0, OUTPUT_TOLERANCE);
@@ -228,7 +224,6 @@ TEST(pidTest, CallFasterThanSample) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
 
   float last_output = output;
@@ -267,7 +262,6 @@ TEST(pidTest, TaskJitter) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
   // First task, with only Ki set, output = error*sample_time
   float integral = (setpoint - input) * sample_time.seconds();
@@ -300,7 +294,6 @@ TEST(pidTest, SampleTimeChange) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
 
   // First task, with only Ki set, output = error*sample_time
@@ -333,7 +326,6 @@ TEST(pidTest, MissedSample) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
 
   // First task, with only Ki set, output = error*sample_time
@@ -371,7 +363,6 @@ TEST(pidTest, OffOnCycle) {
   Duration sample_time = milliseconds(100);
   PID myPID(&input, &output, &setpoint, Kp, Ki, Kd, DIRECT);
   myPID.SetSampleTime(sample_time);
-  myPID.SetMode(AUTOMATIC);
   myPID.Compute();
 
   // Run PID a few times to have output in the middle of the range
@@ -382,24 +373,12 @@ TEST(pidTest, OffOnCycle) {
 
   float last_output = output;
 
-  // turn PID OFF
-  myPID.SetMode(MANUAL);
-
-  // Run PID a few times and check output doesn't change
-  for (int i = 0; i < 10; i++) {
-    Hal.delay(sample_time);
-    myPID.Compute();
-    EXPECT_EQ(output, last_output);
-  }
-
   // change PID gains to make output easier to predict (this also tests
   // SetTunings function while we are at it)
   Kp = 0;
   Ki = 1;
   Kd = 0;
   myPID.SetTunings(Kp, Ki, Kd);
-  // turn PID back ON
-  myPID.SetMode(AUTOMATIC);
 
   float integral = (setpoint - input) * (sample_time.seconds());
 


### PR DESCRIPTION
Brings it in accordance with common best practices for C++ APIs, implementation and naming / style:
- Gets rid of some useless, redundant and error-prone APIs, e.g. the "manual" mode in which the PID does nothing at all (just ignore its output, if you don't want it to do anything!), and ways to change settings that shouldn't be changed
- Passes inputs explicitly to Compute() instead of requiring the caller to store them in (most likely) a static variable
- Uses strongly typed enums for configuration modes instead of ints and (accidentally inverted) booleans
- Consistent naming

The benefit of this as a whole is - less error-prone, less intimidatingly-looking for others who might have to make changes, less "broken windows" in our code.

No functional changes.

Still remains to refactor tests to look nicer, as an actual trajectory + expected output at each step - but that's for a separate PR.