### PR TITLE
Launch openbox as pi user (assuming auto login enabled)

### DIFF
--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -39,20 +39,8 @@
     apt:
       name: menu
 
-  - name: Set default boot to GUI
+  - name: Set pi user's .xsession
     lineinfile:
-      dest: /etc/rc.local
-      insertbefore: 'exit 0'
-      line: 'startx &'
-
-  - name: Disable default boot to Xsession
-    lineinfile:
-      dest: /etc/X11/xinit/xinitrc
-      regexp: '. /etc/X11/Xsession'
-      line: '#. /etc/X11/Xsession'
-
-  - name: Set default boot to OpenBox
-    lineinfile:
-      dest: /etc/X11/xinit/xinitrc
-      insertafter: '#. /etc/X11/Xsession'
+      dest: /home/pi/.xsession
       line: 'exec openbox-session'
+      create: yes

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -32,7 +32,7 @@
   - name: Run Docker convenience script
     shell: sh get-docker.sh
 
-  - name: Adding user pi to docker group  
+  - name: Adding user pi to docker group
     shell: usermod -aG docker pi
 
   - name: Install Debian menu for Openbox


### PR DESCRIPTION
This change modifies the RPi image so that when auto-login is enabled, Openbox will be run as the `pi` user. This makes interaction between Docker and X11 a little easier, and will be necessary to tighten up the system permissions in production.