### PR TITLE
issue263: refactor computation to allow integration in Modellica

### DIFF
--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -33,6 +33,7 @@ limitations under the License.
 //   - Length (e.g. meters)
 //   - Pressure (e.g. kPa)
 //   - Volumetric flow (e.g. m^3/s)
+//   - Volume (e.g. m^3)
 //   - Elapsed time since startup (ms)
 //   - Duration, aka time interval (ms)
 //
@@ -55,6 +56,8 @@ limitations under the License.
 //   Length           millimeters(float)
 //   VolumetricFlow   cubic_m_per_sec(float)
 //   VolumetricFlow   ml_per_min(float)
+//   Volume           cubic_m(float)
+//   Volume           ml(float)
 //   Duration         seconds(float)
 //   Duration         milliseconds(int64_t)
 //   Time             millisSinceStartup(int64_t)
@@ -201,6 +204,31 @@ constexpr VolumetricFlow cubic_m_per_sec(float m3ps) {
 constexpr VolumetricFlow ml_per_min(float ml_per_min) {
   return VolumetricFlow(ml_per_min / (1000.0f * 1000.0f * 60.0f));
 }
+
+// Represents volume.
+//
+// Precision: float.
+//
+// Units:
+//
+//   - meters^3
+//   - mL
+//
+// Native unit (implementation detail): meters^3
+class Volume : public units_detail::ArithScalar<Volume, float> {
+public:
+  [[nodiscard]] constexpr float cubic_m() { return val_; }
+  [[nodiscard]] constexpr float ml() { return val_ * 1000.0f * 1000.0f; }
+
+private:
+  constexpr friend Volume cubic_m(float m3);
+  constexpr friend Volume ml(float ml);
+
+  using units_detail::ArithScalar<Volume, float>::ArithScalar;
+};
+
+constexpr Volume cubic_m(float m3) { return Volume(m3); }
+constexpr Volume ml(float ml) { return Volume(ml / (1000.0f * 1000.0f)); }
 
 // Time and Duration classes.
 //

--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -1,0 +1,33 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This module is responsible for passing the actuator commands to Hal to
+// generate the actual electrical signals.
+
+#include "actuators.h"
+
+void actuators_execute(ActuatorsState desired_state) {
+  // Open/close the solenoid as appropriate.
+  // Our solenoid is "normally open", so low voltage means open and high
+  // voltage means closed.  Hardware spec: https://bit.ly/3aERr69
+  Hal.digitalWrite(BinaryPin::SOLENOID,
+                   desired_state.expire_valve_state == ValveState::OPEN
+                       ? VoltageLevel::HAL_LOW
+                       : VoltageLevel::HAL_HIGH);
+  // set blower PWM
+  // TODO: create PWM limits in HAL (255) and use this instead
+  Hal.analogWrite(PwmPin::BLOWER,
+                  static_cast<int>(desired_state.fan_power * 255));
+}

--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 
 #include "actuators.h"
 
-void actuators_execute(ActuatorsState desired_state) {
+ActuatorsState actuators_execute(ActuatorsState desired_state) {
   // Open/close the solenoid as appropriate.
   // Our solenoid is "normally open", so low voltage means open and high
   // voltage means closed.  Hardware spec: https://bit.ly/3aERr69
@@ -30,4 +30,5 @@ void actuators_execute(ActuatorsState desired_state) {
   // TODO: create PWM limits in HAL (255) and use this instead
   Hal.analogWrite(PwmPin::BLOWER,
                   static_cast<int>(desired_state.fan_power * 255));
+  return desired_state;
 }

--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -13,12 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This module is responsible for passing the actuator commands to Hal to
-// generate the actual electrical signals.
-
 #include "actuators.h"
 
-ActuatorsState actuators_execute(ActuatorsState desired_state) {
+void actuators_execute(const ActuatorsState &desired_state) {
   // Open/close the solenoid as appropriate.
   // Our solenoid is "normally open", so low voltage means open and high
   // voltage means closed.  Hardware spec: https://bit.ly/3aERr69
@@ -30,5 +27,4 @@ ActuatorsState actuators_execute(ActuatorsState desired_state) {
   // TODO: create PWM limits in HAL (255) and use this instead
   Hal.analogWrite(PwmPin::BLOWER,
                   static_cast<int>(desired_state.fan_power * 255));
-  return desired_state;
 }

--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -26,5 +26,5 @@ void actuators_execute(const ActuatorsState &desired_state) {
   // set blower PWM
   // TODO: create PWM limits in HAL (255) and use this instead
   Hal.analogWrite(PwmPin::BLOWER,
-                  static_cast<int>(desired_state.fan_power * 255));
+                  static_cast<int>(desired_state.fan_power * 255.0f));
 }

--- a/controller/lib/core/actuators.h
+++ b/controller/lib/core/actuators.h
@@ -13,20 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This module is responsible for passing the actuator commands to Hal to
+// generate the actual electrical signals.
+
 #ifndef ACTUATORS_H
 #define ACTUATORS_H
 
 #include "blower_fsm.h"
 #include "hal.h"
 
-typedef struct _ActuatorsState {
-  ValveState expire_valve_state;
-  float fan_power;
-} ActuatorsState;
+struct ActuatorsState {
+  float fan_setpoint_cm_h2o = 0.0;
+  ValveState expire_valve_state = ValveState::CLOSED;
+  float fan_power = 0.0;
+};
 
-#define ActuatorsState_init_zero                                               \
-  { ValveState::OPEN, 0.0 }
-
-ActuatorsState actuators_execute(ActuatorsState desired_state);
+void actuators_execute(const ActuatorsState &desired_state);
 
 #endif // ACTUATORS_H

--- a/controller/lib/core/actuators.h
+++ b/controller/lib/core/actuators.h
@@ -1,0 +1,32 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef ACTUATORS_H
+#define ACTUATORS_H
+
+#include "blower_fsm.h"
+#include "hal.h"
+
+typedef struct _ActuatorsState {
+  ValveState expire_valve_state;
+  float fan_power;
+} ActuatorsState;
+
+#define ActuatorsState_init_zero                                               \
+  { ValveState::OPEN, 0.0 }
+
+void actuators_execute(ActuatorsState desired_state);
+
+#endif // ACTUATORS_H

--- a/controller/lib/core/actuators.h
+++ b/controller/lib/core/actuators.h
@@ -27,6 +27,6 @@ typedef struct _ActuatorsState {
 #define ActuatorsState_init_zero                                               \
   { ValveState::OPEN, 0.0 }
 
-void actuators_execute(ActuatorsState desired_state);
+ActuatorsState actuators_execute(ActuatorsState desired_state);
 
 #endif // ACTUATORS_H

--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -15,7 +15,6 @@ limitations under the License.
 
 #include "blower_fsm.h"
 
-#include "hal.h"
 #include "new.h"
 #include "units.h"
 

--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -70,8 +70,7 @@ public:
   explicit PressureControlFsm(Time now, const VentParams &params)
       : inspire_pressure_(cmH2O(static_cast<float>(params.pip_cm_h2o))),
         expire_pressure_(cmH2O(static_cast<float>(params.peep_cm_h2o))),
-        start_time_(now),
-        inspire_end_(start_time_ + inspire_duration(params)),
+        start_time_(now), inspire_end_(start_time_ + inspire_duration(params)),
         expire_end_(inspire_end_ + expire_duration(params)) {}
 
   BlowerSystemState desired_state(Time now) {

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -66,6 +66,6 @@ void blower_fsm_init();
 
 // Gets the state that the the blower system should (ideally) deliver right
 // now.
-BlowerSystemState blower_fsm_desired_state(const VentParams &params);
+BlowerSystemState blower_fsm_desired_state(Time now, const VentParams &params);
 
 #endif // BLOWER_FSM_H

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -46,20 +46,23 @@ static PID myPID(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
 void blower_pid_init() {
 }
 
-float blower_pid_execute(Time now, const BlowerSystemState &desired_state,
-                         float current_pressure_cm_h2o) {
-
+float blower_pid_compute_fan_power(Time now,
+                                   const BlowerSystemState &desired_state,
+                                   const SensorReadings &sensor_readings) {
   // If the blower is not enabled, immediately shut down the fan.  But for
   // consistency, we still run the PID iteration above.
   float output;
   if (desired_state.blower_enabled) {
-    output = myPID.Compute(now, /*input=*/cmH2O(current_pressure_cm_h2o).kPa(),
-                           /*setpoint=*/desired_state.setpoint_pressure.kPa());
+    output =
+        myPID.Compute(/*time=*/now,
+                      /*input=*/cmH2O(sensor_readings.pressure_cm_h2o).kPa(),
+                      /*setpoint=*/desired_state.setpoint_pressure.kPa());
   } else {
     output = 0;
-    myPID.Observe(now, /*input=*/cmH2O(current_pressure_cm_h2o).kPa(),
+    myPID.Observe(/*time=*/now,
+                  /*input=*/cmH2O(sensor_readings.pressure_cm_h2o).kPa(),
                   /*setpoint=*/desired_state.setpoint_pressure.kPa(),
-                  /*actual_output=*/output);
+                  /*output=*/output);
   }
 
   // fan_power is in range [0, 1].

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -46,35 +46,22 @@ static PID myPID(Kp, Ki, Kd, ProportionalTerm::ON_ERROR,
 void blower_pid_init() {
 }
 
-float blower_pid_execute(const BlowerSystemState &desired_state,
+float blower_pid_execute(Time now, const BlowerSystemState &desired_state,
                          float current_pressure_cm_h2o) {
 
-<<<<<<< HEAD
   // If the blower is not enabled, immediately shut down the fan.  But for
   // consistency, we still run the PID iteration above.
   float output;
   if (desired_state.blower_enabled) {
-    output = myPID.Compute(Hal.now(), /*input=*/cur_pressure.kPa(),
+    output = myPID.Compute(now, /*input=*/cmH2O(current_pressure_cm_h2o).kPa(),
                            /*setpoint=*/desired_state.setpoint_pressure.kPa());
   } else {
     output = 0;
-    myPID.Observe(Hal.now(), /*input=*/cur_pressure.kPa(),
+    myPID.Observe(now, /*input=*/cmH2O(current_pressure_cm_h2o).kPa(),
                   /*setpoint=*/desired_state.setpoint_pressure.kPa(),
                   /*actual_output=*/output);
   }
-  Hal.analogWrite(PwmPin::BLOWER, static_cast<int>(output));
-=======
-  float pid_output =
-      myPID.Compute(/*input=*/cmH2O(current_pressure_cm_h2o).kPa(),
-                    /*setpoint=*/desired_state.setpoint_pressure.kPa());
-
-  // If the blower is not enabled, immediately shut down the fan.  But for
-  // consistency, we still run the PID iteration above.
-  if (!desired_state.blower_enabled) {
-    pid_output = 0;
-  }
->>>>>>> first step to isolate computational part of the controller:
 
   // fan_power is in range [0, 1].
-  return pid_output / 255.f;
+  return output / 255.f;
 }

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -14,13 +14,8 @@ limitations under the License.
 */
 
 #include "blower_pid.h"
-
+#include "pid.h"
 #include <math.h>
-
-#include "comms.h"
-#include "hal.h"
-#include "sensors.h"
-#include "types.h"
 
 // PID-tuning were chosen by following the Ziegler-Nichols method,
 // https://en.wikipedia.org/wiki/Ziegler%E2%80%93Nichols_method

--- a/controller/lib/core/blower_pid.h
+++ b/controller/lib/core/blower_pid.h
@@ -29,7 +29,7 @@ void blower_pid_init();
 //
 // Puts readings from e.g. the pressure sensor into `readings`, and puts the
 // current fan power (range [0-1]) into `fan_power`.
-void blower_pid_execute(const BlowerSystemState &desired_state,
-                        SensorReadings *readings, float *fan_power);
+float blower_pid_execute(const BlowerSystemState &desired_state,
+                         float current_pressure_cm_h2o);
 
 #endif // BLOWER_PID_H

--- a/controller/lib/core/blower_pid.h
+++ b/controller/lib/core/blower_pid.h
@@ -16,9 +16,7 @@ limitations under the License.
 #define BLOWER_PID_H
 
 #include "blower_fsm.h"
-#include "hal.h"
 #include "network_protocol.pb.h"
-#include "pid.h"
 #include "units.h"
 
 void blower_pid_init();

--- a/controller/lib/core/blower_pid.h
+++ b/controller/lib/core/blower_pid.h
@@ -29,7 +29,7 @@ void blower_pid_init();
 //
 // Puts readings from e.g. the pressure sensor into `readings`, and puts the
 // current fan power (range [0-1]) into `fan_power`.
-float blower_pid_execute(const BlowerSystemState &desired_state,
+float blower_pid_execute(Time now, const BlowerSystemState &desired_state,
                          float current_pressure_cm_h2o);
 
 #endif // BLOWER_PID_H

--- a/controller/lib/core/blower_pid.h
+++ b/controller/lib/core/blower_pid.h
@@ -23,13 +23,12 @@ limitations under the License.
 
 void blower_pid_init();
 
-// Runs one step of the blower_pid module, which is responsible for spinning
-// the blower to attempt to achieve the given setpoint pressure and
-// opening/closing the expire solenoid.
+// Computes the fan power necessary to match pressure setpoint in desired state
+// by running the necessary step of the pid with input = current pressure
+// fan power represents the necessary power between 0 (Off) and 1 (full power)
 //
-// Puts readings from e.g. the pressure sensor into `readings`, and puts the
-// current fan power (range [0-1]) into `fan_power`.
-float blower_pid_execute(Time now, const BlowerSystemState &desired_state,
-                         float current_pressure_cm_h2o);
+float blower_pid_compute_fan_power(Time now,
+                                   const BlowerSystemState &desired_state,
+                                   const SensorReadings &sensor_readings);
 
 #endif // BLOWER_PID_H

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -181,6 +181,7 @@ VolumetricFlow pressure_delta_to_flow(Pressure delta) {
 
 Volume integrate_flow(VolumetricFlow flow) {
   // volume integral computation data
+  // TODO: make TV a static class with those variables as attributes
   static Time last_flow_measurement_time = millisSinceStartup(0);
   static VolumetricFlow last_flow = cubic_m_per_sec(0);
   static Volume volume = ml(0);

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -208,19 +208,10 @@ Volume integrate_flow(VolumetricFlow flow) {
 }
 
 SensorReadings get_sensor_readings() {
-  SensorReadings readings;
-  Pressure cur_pressure = get_patient_pressure();
-  // Store sensor readings so they can eventually be sent to the GUI.
-  // This pressure is just from the patient sensor, converted to the right
-  // units.
-  readings.pressure_cm_h2o = cur_pressure.cmH2O();
-
   // Flow rate is inhalation flow minus exhalation flow. Positive value is flow
   // into lungs, and negative is flow out of lungs.
   VolumetricFlow flow = get_volumetric_inflow() - get_volumetric_outflow();
-  readings.flow_ml_per_min = flow.ml_per_min();
-
-  readings.volume_ml = integrate_flow(flow).ml();
-
-  return readings;
+  return {.pressure_cm_h2o = get_patient_pressure().cmH2O(),
+          .volume_ml = integrate_flow(flow).ml(),
+          .flow_ml_per_min = flow.ml_per_min()};
 }

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -23,6 +23,7 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 #define SENSORS_H
 
 #include "hal.h"
+#include "network_protocol.pb.h"
 #include "units.h"
 
 // A namespace class for constants related to pressure sensors.
@@ -60,5 +61,9 @@ VolumetricFlow get_volumetric_outflow();
  * the venturi.
  */
 VolumetricFlow pressure_delta_to_flow(Pressure delta);
+
+// get the sensor readings (patient pressure, volumetric flow and tidal
+// volume) from the sensors
+SensorReadings get_sensor_readings();
 
 #endif // SENSORS_H

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -63,6 +63,8 @@ static GuiStatus gui_status = GuiStatus_init_zero;
 
 // This class is here to allow integration of our controller into Modellica
 // software and run closed-loop tests in a simulated physical environment
+// TODO: move all static states from the controller computations inside that
+// class
 class Controller {
 public:
   ActuatorsState Run(Time now, const VentParams &params,
@@ -75,6 +77,8 @@ public:
                 blower_pid_compute_fan_power(now, desired_state, readings)};
   }
 };
+
+static Controller controller;
 
 // NO_GUI_DEV_MODE is a hacky development mode until we have the GUI working.
 //
@@ -133,7 +137,6 @@ static void controller_loop() {
 
     controller_status.active_params = gui_status.desired_params;
 
-    Controller controller;
     ActuatorsState actuators_state =
         controller.Run(Hal.now(), controller_status.active_params,
                        controller_status.sensor_readings);

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -30,7 +30,7 @@ public:
 
 TEST_F(BlowerFsmTest, InitiallyOff) {
   VentParams p = VentParams_init_zero;
-  BlowerSystemState s = blower_fsm_desired_state(p);
+  BlowerSystemState s = blower_fsm_desired_state(Hal.now(), p);
   EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);
 }
@@ -38,7 +38,7 @@ TEST_F(BlowerFsmTest, InitiallyOff) {
 TEST_F(BlowerFsmTest, StaysOff) {
   VentParams p = VentParams_init_zero;
   Hal.delay(milliseconds(1000));
-  BlowerSystemState s = blower_fsm_desired_state(p);
+  BlowerSystemState s = blower_fsm_desired_state(Hal.now(), p);
   EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);
 }
@@ -58,7 +58,7 @@ void testSequence(
     SCOPED_TRACE("time = " + std::to_string(time_millis));
     EXPECT_EQ(time_millis, Hal.now().millisSinceStartup());
 
-    BlowerSystemState s = blower_fsm_desired_state(params);
+    BlowerSystemState s = blower_fsm_desired_state(Hal.now(), params);
     EXPECT_EQ(s.blower_enabled, blower_enabled);
     EXPECT_EQ(s.setpoint_pressure.cmH2O(), expected_pressure.cmH2O());
     EXPECT_EQ(s.expire_valve_state, expected_valve_state);

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -82,6 +82,19 @@ TEST(Units, VolumetricFlow) {
   checkRelationalOperators(ml_per_min);
 }
 
+TEST(Units, Volume) {
+  EXPECT_FLOAT_EQ(cubic_m(1).cubic_m(), 1);
+  EXPECT_FLOAT_EQ(cubic_m(1).ml(), 1000 * 1000);
+  EXPECT_FLOAT_EQ(ml(1).ml(), 1);
+  EXPECT_FLOAT_EQ(ml(1).cubic_m(), 1 / (1000.0 * 1000));
+  EXPECT_FLOAT_EQ((cubic_m(1) - cubic_m(2)).cubic_m(), -1);
+  EXPECT_FLOAT_EQ((ml(1) + ml(10)).ml(), 11);
+  EXPECT_FLOAT_EQ((cubic_m(1) - ml(1000 * 1000)).cubic_m(), 0);
+
+  checkRelationalOperators(cubic_m);
+  checkRelationalOperators(ml);
+}
+
 TEST(Units, Duration) {
   EXPECT_FLOAT_EQ(seconds(1).seconds(), 1);
   EXPECT_FLOAT_EQ(minutes(1).seconds(), 60);

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -85,8 +85,8 @@ TEST(Units, VolumetricFlow) {
 TEST(Units, Volume) {
   EXPECT_FLOAT_EQ(cubic_m(1).cubic_m(), 1);
   EXPECT_FLOAT_EQ(cubic_m(1).ml(), 1000 * 1000);
-  EXPECT_FLOAT_EQ(ml(1).ml(), 1);
-  EXPECT_FLOAT_EQ(ml(1).cubic_m(), 1 / (1000.0 * 1000));
+  EXPECT_FLOAT_EQ(ml(1).ml(), 1.0);
+  EXPECT_FLOAT_EQ(ml(1).cubic_m(), 1 / (1000.0f * 1000));
   EXPECT_FLOAT_EQ((cubic_m(1) - cubic_m(2)).cubic_m(), -1);
   EXPECT_FLOAT_EQ((ml(1) + ml(10)).ml(), 11);
   EXPECT_FLOAT_EQ((cubic_m(1) - ml(1000 * 1000)).cubic_m(), 0);


### PR DESCRIPTION
This PR should allow integration of the controller to Modelica models for testing.
What it does is:
- refactor code to read sensors inputs prior to any controls computation and execute commands after actual computation
- replace all the calls to Hal.now() in controls computations by a reference to the time of the call. This is considered a good thing for the PID as it makes "now" be closer to the time when measurements were made. Could be considered bad for blower_fsm, as the commands might take one more cycle to be executed, and in blower fsm, this might make 1 breath difference.
- create a class that encapsulates all controls computation (this class is interface with Modellica)

To do but I feel overwhelmed: include ActuatorsState to ControllerStatus in nanopb.

Part of #263 , but doesn't fix it all the way yet.