### PR TITLE
Enables -Wconversion and fixes violations, including several serious bugs

### DIFF
--- a/common/libs/checksum/checksum.cpp
+++ b/common/libs/checksum/checksum.cpp
@@ -18,11 +18,12 @@ limitations under the License.
 
 uint16_t checksum_fletcher16(const char *data, uint8_t count,
                              uint16_t state /*=0*/) {
-  uint8_t s1 = state & 0xff;
-  uint8_t s2 = (state >> 8) & 0xff;
+  uint8_t s1 = static_cast<uint8_t>(state & 0xff);
+  uint8_t s2 = static_cast<uint8_t>((state >> 8) & 0xff);
   for (uint8_t index = 0; index < count; ++index) {
-    s1 = (uint16_t{s1} + static_cast<uint16_t>(data[index])) % 255;
-    s2 = (uint16_t{s2} + uint16_t{s1}) % 255;
+    s1 = static_cast<uint8_t>(
+        (uint16_t{s1} + static_cast<uint16_t>(data[index])) % 255);
+    s2 = static_cast<uint8_t>((uint16_t{s2} + uint16_t{s1}) % 255);
   }
-  return static_cast<uint16_t>(uint16_t{s2} << 8) | s1;
+  return static_cast<uint16_t>((uint16_t{s2} << 8) | s1);
 }

--- a/common/libs/checksum/checksum.cpp
+++ b/common/libs/checksum/checksum.cpp
@@ -24,5 +24,5 @@ uint16_t checksum_fletcher16(const char *data, uint8_t count,
     s1 = (uint16_t{s1} + static_cast<uint16_t>(data[index])) % 255;
     s2 = (uint16_t{s2} + uint16_t{s1}) % 255;
   }
-  return (uint16_t{s2} << 8) | s1;
+  return static_cast<uint16_t>(uint16_t{s2} << 8) | s1;
 }

--- a/common/libs/checksum/checksum.h
+++ b/common/libs/checksum/checksum.h
@@ -41,7 +41,7 @@ inline uint16_t check_bytes_fletcher16(uint16_t checksum) {
   uint8_t f1 = (checksum >> 8) & 0xff;
   uint8_t c0 = 0xff - ((f0 + f1) % 0xff);
   uint8_t c1 = 0xff - ((f0 + c0) % 0xff);
-  return (uint16_t{c0} << 8) | c1;
+  return static_cast<uint16_t>(uint16_t{c0} << 8) | c1;
 }
 
 // Verifies the checksum of a packet.

--- a/common/libs/checksum/checksum.h
+++ b/common/libs/checksum/checksum.h
@@ -37,10 +37,10 @@ uint16_t checksum_fletcher16(const char *data, uint8_t count,
 // bytes [b1 b2] such that checksum(p | b1 | b2) == 0, where `|` represents
 // concatenation.
 inline uint16_t check_bytes_fletcher16(uint16_t checksum) {
-  uint8_t f0 = checksum & 0xff;
-  uint8_t f1 = (checksum >> 8) & 0xff;
-  uint8_t c0 = 0xff - ((f0 + f1) % 0xff);
-  uint8_t c1 = 0xff - ((f0 + c0) % 0xff);
+  uint8_t f0 = static_cast<uint8_t>(checksum & 0xff);
+  uint8_t f1 = static_cast<uint8_t>((checksum >> 8) & 0xff);
+  uint8_t c0 = static_cast<uint8_t>(0xff - ((f0 + f1) % 0xff));
+  uint8_t c1 = static_cast<uint8_t>(0xff - ((f0 + c0) % 0xff));
   return static_cast<uint16_t>(uint16_t{c0} << 8) | c1;
 }
 

--- a/common/libs/checksum/checksum.h
+++ b/common/libs/checksum/checksum.h
@@ -41,7 +41,7 @@ inline uint16_t check_bytes_fletcher16(uint16_t checksum) {
   uint8_t f1 = static_cast<uint8_t>((checksum >> 8) & 0xff);
   uint8_t c0 = static_cast<uint8_t>(0xff - ((f0 + f1) % 0xff));
   uint8_t c1 = static_cast<uint8_t>(0xff - ((f0 + c0) % 0xff));
-  return static_cast<uint16_t>(uint16_t{c0} << 8) | c1;
+  return static_cast<uint16_t>((uint16_t{c0} << 8) | c1);
 }
 
 // Verifies the checksum of a packet.

--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -91,6 +91,8 @@ namespace units_detail {
 // [1] https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 template <class Q, class ValTy> class Scalar {
 public:
+  Scalar() : val_(0) {}
+
   constexpr bool operator<(const Scalar &s) const { return val_ < s.val_; }
   constexpr bool operator<=(const Scalar &s) const { return val_ <= s.val_; }
   constexpr bool operator==(const Scalar &s) const { return val_ == s.val_; }
@@ -132,7 +134,7 @@ public:
 
 private:
   // https://www.google.com/search?q=kpa+to+cmh2o
-  static inline constexpr float CM_H2O_PER_KPA = 10.1972;
+  static inline constexpr float CM_H2O_PER_KPA = 10.1972f;
 
   constexpr friend Pressure kPa(float kpa);
   constexpr friend Pressure cmH2O(float cm_h2o);
@@ -218,7 +220,7 @@ constexpr VolumetricFlow ml_per_min(float ml_per_min) {
 //
 class Time;
 
-// Represents a length of time.
+// Represents a non-negative length of time.
 //
 // Precision: 1ms
 //
@@ -226,10 +228,10 @@ class Time;
 //  - seconds
 //  - milliseconds
 //
-// Native unit (implementation detail): int64_t miliseconds
-class Duration : public units_detail::Scalar<Duration, int64_t> {
+// Native unit (implementation detail): uint64_t miliseconds
+class Duration : public units_detail::Scalar<Duration, uint64_t> {
 public:
-  [[nodiscard]] constexpr int64_t milliseconds() const { return val_; }
+  [[nodiscard]] constexpr uint64_t milliseconds() const { return val_; }
   [[nodiscard]] constexpr float seconds() const {
     return static_cast<float>(val_) / 1000;
   }
@@ -243,20 +245,22 @@ public:
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
 private:
-  constexpr friend Duration milliseconds(int64_t millis);
+  constexpr friend Duration milliseconds(uint64_t millis);
   constexpr friend Duration seconds(float secs);
 
-  using units_detail::Scalar<Duration, int64_t>::Scalar;
+  using units_detail::Scalar<Duration, uint64_t>::Scalar;
 };
 
-constexpr Duration milliseconds(int64_t millis) { return Duration(millis); }
-constexpr Duration seconds(float secs) { return Duration(1000 * secs); }
+constexpr Duration milliseconds(uint64_t millis) { return Duration(millis); }
+constexpr Duration seconds(float secs) {
+  return Duration(static_cast<uint64_t>(1000 * secs));
+}
 constexpr Duration minutes(float mins) { return seconds(mins * 60); }
 constexpr Duration operator*(int n, Duration d) {
-  return milliseconds(n * d.milliseconds());
+  return milliseconds(static_cast<uint64_t>(n) * d.milliseconds());
 }
 constexpr Duration operator*(Duration d, int n) {
-  return milliseconds(n * d.milliseconds());
+  return milliseconds(static_cast<uint64_t>(n) * d.milliseconds());
 }
 
 // Represents a point in time, relative to when the device started up.  See
@@ -267,10 +271,10 @@ constexpr Duration operator*(Duration d, int n) {
 // Units:
 //  - milliseconds
 //
-// Native unit (implementation detail): int64_t miliseconds
-class Time : public units_detail::Scalar<Time, int64_t> {
+// Native unit (implementation detail): uint64_t miliseconds
+class Time : public units_detail::Scalar<Time, uint64_t> {
 public:
-  [[nodiscard]] int64_t millisSinceStartup() const { return val_; }
+  [[nodiscard]] uint64_t millisSinceStartup() const { return val_; }
 
   constexpr friend Time operator+(const Time &a, const Duration &b);
   constexpr friend Time operator+(const Duration &a, const Time &b);
@@ -280,12 +284,12 @@ public:
   inline Time &operator-=(const Duration &dt) { return *this = *this - dt; }
 
 private:
-  constexpr friend Time millisSinceStartup(int64_t millis);
+  constexpr friend Time millisSinceStartup(uint64_t millis);
 
-  using units_detail::Scalar<Time, int64_t>::Scalar;
+  using units_detail::Scalar<Time, uint64_t>::Scalar;
 };
 
-constexpr Time millisSinceStartup(int64_t millis) { return Time(millis); }
+constexpr Time millisSinceStartup(uint64_t millis) { return Time(millis); }
 
 constexpr inline Duration operator+(const Duration &a, const Duration &b) {
   return Duration(a.val_ + b.val_);

--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -257,10 +257,10 @@ constexpr Duration seconds(float secs) {
 }
 constexpr Duration minutes(float mins) { return seconds(mins * 60); }
 constexpr Duration operator*(int n, Duration d) {
-  return milliseconds(static_cast<uint64_t>(n) * d.milliseconds());
+  return milliseconds(static_cast<int64_t>(n) * d.milliseconds());
 }
 constexpr Duration operator*(Duration d, int n) {
-  return milliseconds(static_cast<uint64_t>(n) * d.milliseconds());
+  return milliseconds(static_cast<int64_t>(n) * d.milliseconds());
 }
 
 // Represents a point in time, relative to when the device started up.  See

--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -220,7 +220,7 @@ constexpr VolumetricFlow ml_per_min(float ml_per_min) {
 //
 class Time;
 
-// Represents a non-negative length of time.
+// Represents a length of time.
 //
 // Precision: 1ms
 //
@@ -228,10 +228,10 @@ class Time;
 //  - seconds
 //  - milliseconds
 //
-// Native unit (implementation detail): uint64_t miliseconds
-class Duration : public units_detail::Scalar<Duration, uint64_t> {
+// Native unit (implementation detail): int64_t miliseconds
+class Duration : public units_detail::Scalar<Duration, int64_t> {
 public:
-  [[nodiscard]] constexpr uint64_t milliseconds() const { return val_; }
+  [[nodiscard]] constexpr int64_t milliseconds() const { return val_; }
   [[nodiscard]] constexpr float seconds() const {
     return static_cast<float>(val_) / 1000;
   }
@@ -245,15 +245,15 @@ public:
   constexpr friend Duration operator-(const Time &a, const Time &b);
 
 private:
-  constexpr friend Duration milliseconds(uint64_t millis);
+  constexpr friend Duration milliseconds(int64_t millis);
   constexpr friend Duration seconds(float secs);
 
-  using units_detail::Scalar<Duration, uint64_t>::Scalar;
+  using units_detail::Scalar<Duration, int64_t>::Scalar;
 };
 
-constexpr Duration milliseconds(uint64_t millis) { return Duration(millis); }
+constexpr Duration milliseconds(int64_t millis) { return Duration(millis); }
 constexpr Duration seconds(float secs) {
-  return Duration(static_cast<uint64_t>(1000 * secs));
+  return Duration(static_cast<int64_t>(1000 * secs));
 }
 constexpr Duration minutes(float mins) { return seconds(mins * 60); }
 constexpr Duration operator*(int n, Duration d) {
@@ -297,17 +297,17 @@ constexpr inline Duration operator+(const Duration &a, const Duration &b) {
 constexpr inline Duration operator-(const Duration &a, const Duration &b) {
   return Duration(a.val_ - b.val_);
 }
-constexpr inline Time operator+(const Time &a, const Duration &b) {
-  return Time(a.val_ + b.val_);
+constexpr inline Time operator+(const Time &t, const Duration &dt) {
+  return Time(t.val_ + static_cast<uint64_t>(dt.val_));
 }
-constexpr inline Time operator+(const Duration &a, const Time &b) {
-  return Time(a.val_ + b.val_);
+constexpr inline Time operator+(const Duration &dt, const Time &t) {
+  return Time(t.val_ + static_cast<uint64_t>(dt.val_));
 }
-constexpr inline Time operator-(const Time &a, const Duration &b) {
-  return Time(a.val_ - b.val_);
+constexpr inline Time operator-(const Time &t, const Duration &dt) {
+  return Time(t.val_ - static_cast<uint64_t>(dt.val_));
 }
 constexpr inline Duration operator-(const Time &a, const Time &b) {
-  return Duration(a.val_ - b.val_);
+  return Duration(static_cast<int64_t>(a.val_ - b.val_));
 }
 
 #endif // UNITS_H

--- a/controller/lib/core/alarm.cpp
+++ b/controller/lib/core/alarm.cpp
@@ -17,7 +17,7 @@ limitations under the License.
 #include "alarm.h"
 
 struct alarm_t {
-  uint32_t timestamp;
+  Time timestamp;
   char data[ALARM_DATALEN];
 };
 
@@ -64,7 +64,7 @@ void alarm_add(const char *data) {
     // No point spending time doing these operations if the stack is full
 
     //TODO work in progress, move alarm code to nanopb transport
-    alarm.timestamp = Hal.now().millisSinceStartup();
+    alarm.timestamp = Hal.now();
 
     // Copy alarm data
     for (uint8_t idx = 0; idx < ALARM_DATALEN; idx++) {
@@ -85,7 +85,7 @@ void alarm_remove() {
   stack_pop(&alarm); // Don't need this alarm anymore, remove it
 }
 
-int32_t alarm_read(uint32_t *timestamp, char *data) {
+int32_t alarm_read(Time *timestamp, char *data) {
   int32_t return_status = VC_STATUS_FAILURE;
   alarm_t *alarm;
   return_status = stack_peek(&alarm);

--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -68,8 +68,9 @@ public:
 class PressureControlFsm {
 public:
   explicit PressureControlFsm(const VentParams &params)
-      : inspire_pressure_(cmH2O(params.pip_cm_h2o)),
-        expire_pressure_(cmH2O(params.peep_cm_h2o)), start_time_(Hal.now()),
+      : inspire_pressure_(cmH2O(static_cast<float>(params.pip_cm_h2o))),
+        expire_pressure_(cmH2O(static_cast<float>(params.peep_cm_h2o))),
+        start_time_(Hal.now()),
         inspire_end_(start_time_ + inspire_duration(params)),
         expire_end_(inspire_end_ + expire_duration(params)) {}
 
@@ -96,12 +97,14 @@ private:
   //
   // https://www.wolframalpha.com/input/?i=solve+t+%3D+x+%2B+y+and+r+%3D+x%2Fy+for+x%2Cy
   static Duration inspire_duration(const VentParams &params) {
-    float t = 60.f / params.breaths_per_min;       // secs per breath
+    float t =
+        60.f / static_cast<float>(params.breaths_per_min); // secs per breath
     float r = params.inspiratory_expiratory_ratio; // I:E
     return seconds(t * r / (1 + r));
   }
   static Duration expire_duration(const VentParams &params) {
-    float t = 60.f / params.breaths_per_min;       // secs per breath
+    float t =
+        60.f / static_cast<float>(params.breaths_per_min); // secs per breath
     float r = params.inspiratory_expiratory_ratio; // I:E
     return seconds(t / (1 + r));
   }

--- a/controller/lib/core/blower_pid.cpp
+++ b/controller/lib/core/blower_pid.cpp
@@ -28,12 +28,12 @@ limitations under the License.
 // Note that Ku and Tu only seem to work with this particular sample time.
 static constexpr Duration PID_SAMPLE_PERIOD = milliseconds(10);
 static constexpr float Ku = 200;
-static constexpr Duration Tu = seconds(1.5);
+static constexpr Duration Tu = seconds(1.5f);
 
 // "No overshoot" settings from the Ziegler-Nichols Wikipedia page.  This
 // avoids overpressurizing the patient's lungs.
-static constexpr float Kp = 0.2 * Ku;
-static constexpr float Ki = 0.4 * Ku / Tu.seconds();
+static constexpr float Kp = 0.2f * Ku;
+static constexpr float Ki = 0.4f * Ku / Tu.seconds();
 static constexpr float Kd = Ku * Tu.seconds() / 15;
 
 // DIRECT means that increases in the output should result in increases in the

--- a/controller/lib/core/comms.cpp
+++ b/controller/lib/core/comms.cpp
@@ -23,7 +23,7 @@ static uint16_t tx_bytes_remaining = 0;
 // Time when we started sending the last ControllerStatus.
 // TODO: Change this to std::optional<Time> once that's available; then we
 // don't need this "clever" initialization.
-constexpr Time kInvalidTime = millisSinceStartup(0xFFFFFFFFFFFFFFFFUL);
+constexpr Time kInvalidTime = millisSinceStartup(0xFFFF'FFFF'FFFF'FFFFUL);
 static Time last_tx = kInvalidTime;
 
 // Our incoming (serialized) GuiStatus proto is incrementally buffered in

--- a/controller/lib/core/comms.cpp
+++ b/controller/lib/core/comms.cpp
@@ -101,13 +101,14 @@ static void process_tx(const ControllerStatus &controller_status) {
   if (tx_bytes_remaining > 0) {
     // TODO(jlebar): Change serialWrite to take a uint8* instead of a char*, so
     // it matches nanopb.
-    auto bytes_written =
+    uint16_t bytes_written =
         Hal.serialWrite(reinterpret_cast<char *>(tx_buffer) + tx_idx,
                         stl::min(bytes_avail, tx_bytes_remaining));
     // TODO: How paranoid should we be about this underflowing?  Perhaps we
     // should reset the device if this or other invariants are violated?
-    tx_bytes_remaining -= bytes_written;
-    tx_idx += bytes_written;
+    tx_bytes_remaining =
+        static_cast<uint16_t>(tx_bytes_remaining - bytes_written);
+    tx_idx = static_cast<uint16_t>(tx_idx + bytes_written);
   }
 }
 

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -64,7 +64,7 @@ constexpr int NUM_SENSORS = 3;
 
 } // anonymous namespace
 
-static int sensorZeroVals[NUM_SENSORS];
+static float sensorZeroVals[NUM_SENSORS];
 
 AnalogPin pin_for(Sensor s) {
   switch (s) {
@@ -105,9 +105,12 @@ void sensors_init() {
   Hal.delay(milliseconds(20));
 
   auto set_zero_level = [](Sensor s) {
-    int sum = 0;
+    float sum = 0;
     for (int i = 0; i < SENSOR_SAMPLES_FOR_INIT; i++) {
-      sum += Hal.analogRead(pin_for(s));
+      // This cast is safe as analogRead returns values in 0..1023,
+      // which is way below the maximum value exactly representable
+      // as a float.
+      sum += static_cast<float>(Hal.analogRead(pin_for(s)));
     }
     sensorZeroVals[s] = sum / SENSOR_SAMPLES_FOR_INIT;
   };
@@ -120,12 +123,12 @@ void sensors_init() {
 //
 // @TODO: Add alarms if sensor value is out of expected range?
 static Pressure read_pressure_sensor(Sensor s) {
-  int sum = 0;
+  float sum = 0;
   for (int i = 0; i < SENSOR_SAMPLES_FOR_READ; i++) {
-    sum += Hal.analogRead(pin_for(s)) - sensorZeroVals[s];
+    sum += static_cast<float>(Hal.analogRead(pin_for(s))) - sensorZeroVals[s];
   }
   // Sensitivity of all pressure sensors is 1 V/kPa; no division needed.
-  return kPa(static_cast<float>(sum) / SENSOR_SAMPLES_FOR_READ * ADC_LSB);
+  return kPa(sum / SENSOR_SAMPLES_FOR_READ * ADC_LSB);
 }
 
 Pressure get_patient_pressure() {

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -64,7 +64,7 @@ constexpr int NUM_SENSORS = 3;
 
 } // anonymous namespace
 
-static float sensorZeroVals[NUM_SENSORS];
+static int sensorZeroVals[NUM_SENSORS];
 
 AnalogPin pin_for(Sensor s) {
   switch (s) {
@@ -105,7 +105,7 @@ void sensors_init() {
   Hal.delay(milliseconds(20));
 
   auto set_zero_level = [](Sensor s) {
-    float sum = 0;
+    int sum = 0;
     for (int i = 0; i < SENSOR_SAMPLES_FOR_INIT; i++) {
       sum += Hal.analogRead(pin_for(s));
     }
@@ -120,7 +120,7 @@ void sensors_init() {
 //
 // @TODO: Add alarms if sensor value is out of expected range?
 static Pressure read_pressure_sensor(Sensor s) {
-  float sum = 0;
+  int sum = 0;
   for (int i = 0; i < SENSOR_SAMPLES_FOR_READ; i++) {
     sum += Hal.analogRead(pin_for(s)) - sensorZeroVals[s];
   }

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -27,13 +27,13 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 // altitude - need mechanism to adjust based on delivery? Constant involving
 // density of air. Density assumed at 15 deg. Celsius and 1 atm of pressure.
 // Sourced from https://en.wikipedia.org/wiki/Density_of_air
-static const float DENSITY_OF_AIR_KG_PER_CUBIC_METER = 1.225; // kg/m^3
+static const float DENSITY_OF_AIR_KG_PER_CUBIC_METER = 1.225f; // kg/m^3
 
 // Diameters relating to Ethan's Alpha Venturi - II
 // (https://docs.google.com/spreadsheets/d/1G9Kb-ImlluK8MOx-ce2rlHUBnTOtAFQvKjjs1bEhlpM/edit#gid=963553579)
 // Port diameter must be larger than choke diameter
 constexpr static Length DEFAULT_VENTURI_PORT_DIAM = millimeters(14);
-constexpr static Length DEFAULT_VENTURI_CHOKE_DIAM = millimeters(5.5);
+constexpr static Length DEFAULT_VENTURI_CHOKE_DIAM = millimeters(5.5f);
 
 static_assert(DEFAULT_VENTURI_PORT_DIAM > DEFAULT_VENTURI_CHOKE_DIAM);
 static_assert(DEFAULT_VENTURI_CHOKE_DIAM > meters(0));
@@ -105,11 +105,11 @@ void sensors_init() {
   Hal.delay(milliseconds(20));
 
   auto set_zero_level = [](Sensor s) {
-    int sum = 0;
+    float sum = 0;
     for (int i = 0; i < SENSOR_SAMPLES_FOR_INIT; i++) {
       sum += Hal.analogRead(pin_for(s));
     }
-    sensorZeroVals[s] = static_cast<float>(sum) / SENSOR_SAMPLES_FOR_INIT;
+    sensorZeroVals[s] = sum / SENSOR_SAMPLES_FOR_INIT;
   };
   set_zero_level(PATIENT_PRESSURE);
   set_zero_level(INFLOW_PRESSURE_DIFF);
@@ -120,7 +120,7 @@ void sensors_init() {
 //
 // @TODO: Add alarms if sensor value is out of expected range?
 static Pressure read_pressure_sensor(Sensor s) {
-  int sum = 0;
+  float sum = 0;
   for (int i = 0; i < SENSOR_SAMPLES_FOR_READ; i++) {
     sum += Hal.analogRead(pin_for(s)) - sensorZeroVals[s];
   }

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -32,8 +32,8 @@ public:
 
   // min/max possible reading from MPXV5004GP pressure sensors
   // The canonical list of hardware in the device is: https://bit.ly/3aERr69
-  inline constexpr static Pressure P_VAL_MIN = kPa(0.0);
-  inline constexpr static Pressure P_VAL_MAX = kPa(3.92);
+  inline constexpr static Pressure P_VAL_MIN = kPa(0.0f);
+  inline constexpr static Pressure P_VAL_MAX = kPa(3.92f);
 };
 
 void sensors_init();

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -218,9 +218,9 @@ public:
 
 #ifndef TEST_MODE
   // Translates to a numeric pin that can be passed to the Arduino API.
-  int rawPin(PwmPin pin);
-  int rawPin(AnalogPin pin);
-  int rawPin(BinaryPin pin);
+  uint8_t rawPin(PwmPin pin);
+  uint8_t rawPin(AnalogPin pin);
+  uint8_t rawPin(BinaryPin pin);
 
 #else
   // Reads up to `len` bytes of data "sent" via serialWrite.  Returns the total
@@ -331,9 +331,11 @@ inline Time HalApi::now() {
   return millisSinceStartup((uint64_t{1} << 32) * num_clock_overflows_ +
                             ::millis());
 }
-inline void HalApi::delay(Duration d) { ::delay(d.milliseconds()); }
+inline void HalApi::delay(Duration d) {
+  ::delay(static_cast<unsigned long>(d.milliseconds()));
+}
 
-inline int HalApi::rawPin(AnalogPin pin) {
+inline uint8_t HalApi::rawPin(AnalogPin pin) {
   // See pinout at https://bit.ly/3aERr69.
   // TODO: Update with STM32 pinout.
   switch (pin) {
@@ -348,7 +350,7 @@ inline int HalApi::rawPin(AnalogPin pin) {
   __builtin_unreachable();
 }
 
-inline int HalApi::rawPin(PwmPin pin) {
+inline uint8_t HalApi::rawPin(PwmPin pin) {
   // See pinout at https://bit.ly/3aERr69.
   // TODO: Update with STM32 pinout.
   switch (pin) {
@@ -359,7 +361,7 @@ inline int HalApi::rawPin(PwmPin pin) {
   __builtin_unreachable();
 }
 
-inline int HalApi::rawPin(BinaryPin pin) {
+inline uint8_t HalApi::rawPin(BinaryPin pin) {
   // See pinout at https://bit.ly/3aERr69.
   // TODO: Update with STM32 pinout.
   switch (pin) {
@@ -474,7 +476,7 @@ inline void HalApi::analogWrite(PwmPin pin, int value) {
     return 0;
   }
   auto &readBuf = serialIncomingData_.front();
-  uint16_t n = stl::min<uint16_t>(len, readBuf.size());
+  uint16_t n = stl::min<uint16_t>(len, static_cast<uint16_t>(readBuf.size()));
   memcpy(buf, readBuf.data(), n);
   readBuf.erase(readBuf.begin(), readBuf.begin() + n);
   if (readBuf.empty()) {
@@ -483,7 +485,9 @@ inline void HalApi::analogWrite(PwmPin pin, int value) {
   return n;
 }
 inline uint16_t HalApi::serialBytesAvailableForRead() {
-  return serialIncomingData_.empty() ? 0 : serialIncomingData_.front().size();
+  return serialIncomingData_.empty()
+             ? 0
+             : static_cast<uint16_t>(serialIncomingData_.front().size());
 }
 [[nodiscard]] inline uint16_t HalApi::serialWrite(const char *buf,
                                                   uint16_t len) {
@@ -497,7 +501,8 @@ inline uint16_t HalApi::serialBytesAvailableForWrite() {
   return 64;
 }
 inline uint16_t HalApi::test_serialGetOutgoingData(char *data, uint16_t len) {
-  uint16_t n = stl::min<uint16_t>(len, serialOutgoingData_.size());
+  uint16_t n = stl::min<uint16_t>(
+      len, static_cast<uint16_t>(serialOutgoingData_.size()));
   memcpy(data, serialOutgoingData_.data(), n);
   serialOutgoingData_.erase(serialOutgoingData_.begin(),
                             serialOutgoingData_.begin() + n);

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -508,7 +508,7 @@ inline uint16_t HalApi::test_serialGetOutgoingData(char *data, uint16_t len) {
   return n;
 }
 inline void HalApi::test_serialPutIncomingData(const char *data, uint16_t len) {
-  constexpr int MAX_MSG_SIZE = 64;
+  constexpr uint16_t MAX_MSG_SIZE = 64;
   while (len > MAX_MSG_SIZE) {
     serialIncomingData_.push_back(std::vector<char>(data, data + MAX_MSG_SIZE));
     data += MAX_MSG_SIZE;

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -512,7 +512,7 @@ inline void HalApi::test_serialPutIncomingData(const char *data, uint16_t len) {
   while (len > MAX_MSG_SIZE) {
     serialIncomingData_.push_back(std::vector<char>(data, data + MAX_MSG_SIZE));
     data += MAX_MSG_SIZE;
-    len -= MAX_MSG_SIZE;
+    len = static_cast<uint16_t>(len - MAX_MSG_SIZE);
   }
   serialIncomingData_.push_back(std::vector<char>(data, data + len));
 }

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -476,7 +476,7 @@ inline void HalApi::analogWrite(PwmPin pin, int value) {
     return 0;
   }
   auto &readBuf = serialIncomingData_.front();
-  uint16_t n = stl::min<uint16_t>(len, static_cast<uint16_t>(readBuf.size()));
+  uint16_t n = stl::min(len, static_cast<uint16_t>(readBuf.size()));
   memcpy(buf, readBuf.data(), n);
   readBuf.erase(readBuf.begin(), readBuf.begin() + n);
   if (readBuf.empty()) {
@@ -501,8 +501,7 @@ inline uint16_t HalApi::serialBytesAvailableForWrite() {
   return 64;
 }
 inline uint16_t HalApi::test_serialGetOutgoingData(char *data, uint16_t len) {
-  uint16_t n = stl::min<uint16_t>(
-      len, static_cast<uint16_t>(serialOutgoingData_.size()));
+  uint16_t n = stl::min(len, static_cast<uint16_t>(serialOutgoingData_.size()));
   memcpy(data, serialOutgoingData_.data(), n);
   serialOutgoingData_.erase(serialOutgoingData_.begin(),
                             serialOutgoingData_.begin() + n);

--- a/controller/lib/hal/hal_stm32.cpp
+++ b/controller/lib/hal/hal_stm32.cpp
@@ -288,7 +288,7 @@ static void Timer6ISR() {
 
 void HalApi::delay(Duration d) {
   int64_t start = msCount;
-  while (static_cast<uint64_t>(msCount - start) < d.milliseconds()) {
+  while (msCount - start < d.milliseconds()) {
   }
 }
 

--- a/controller/lib/hal/hal_stm32.cpp
+++ b/controller/lib/hal/hal_stm32.cpp
@@ -287,7 +287,7 @@ static void Timer6ISR() {
 
 void HalApi::delay(Duration d) {
   int64_t start = msCount;
-  while ((msCount - start) < d.milliseconds()) {
+  while (static_cast<uint64_t>(msCount - start) < d.milliseconds()) {
   }
 }
 

--- a/controller/lib/hal/hal_stm32.h
+++ b/controller/lib/hal/hal_stm32.h
@@ -360,11 +360,11 @@ inline void GPIO_PinAltFunc(GPIO_Regs *const gpio, int pin, int func) {
 }
 
 inline void GPIO_SetPin(GPIO_Regs *const gpio, int pin) {
-  gpio->set = (1 << pin);
+  gpio->set = static_cast<SREG>(1 << pin);
 }
 
 inline void GPIO_ClrPin(GPIO_Regs *const gpio, int pin) {
-  gpio->clr = (1 << pin);
+  gpio->clr = static_cast<SREG>(1 << pin);
 }
 
 inline int GPIO_GetPin(GPIO_Regs *const gpio, int pin) {

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -49,7 +49,7 @@ void testSequence(
     const std::vector<
         std::tuple<VentParams,
                    /*blower_enabled*/ bool,
-                   /*time_millis*/ int,
+                   /*time_millis*/ uint64_t,
                    /*expected_setpoint_pressure*/ Pressure,
                    /*expected_expiratory_valve_state*/ ValveState>> &seq) {
   for (const auto &[params, blower_enabled, time_millis, expected_pressure,

--- a/controller/test/checksum/checksum_test.cpp
+++ b/controller/test/checksum/checksum_test.cpp
@@ -23,8 +23,8 @@ TEST(Checksum, CheckBytes) {
   uint16_t csum = checksum_fletcher16("abcde", 5);
 
   uint16_t checkBytes = check_bytes_fletcher16(csum);
-  char c0 = checkBytes >> 8;
-  char c1 = checkBytes & 0xff;
+  char c0 = static_cast<char>(checkBytes >> 8);
+  char c1 = static_cast<char>(checkBytes & 0xff);
   csum = checksum_fletcher16(&c0, 1, csum);
   csum = checksum_fletcher16(&c1, 1, csum);
   EXPECT_EQ(csum, 0);
@@ -39,13 +39,13 @@ TEST(Checksum, BitFlips) {
   char data[32];
   memset(&data, '\0', sizeof(data));
 
-  // Start lastChecksum at -1 because our first test will be checksum'ing the
-  // all-zeroes buffer, which should yield 0.
-  uint16_t lastChecksum = -1;
+  // Start lastChecksum at an arbitrary non-zero value because our first test
+  // will be checksum'ing the all-zeroes buffer, which should yield 0.
+  uint16_t lastChecksum = 12345;
 
   const int32_t numTests = int32_t{1} << 16;
   int32_t singleBitFlipCollisions = 0;
-  std::map<int16_t, int32_t> collisions;
+  std::map<uint16_t, uint32_t> collisions;
   for (int32_t i = 0; i < numTests; ++i) {
     uint16_t checksum = checksum_fletcher16(data, sizeof(data));
     collisions[checksum]++;
@@ -54,8 +54,8 @@ TEST(Checksum, BitFlips) {
     }
 
     lastChecksum = checksum;
-    int bitToFlip = rand() % (8 * sizeof(data));
-    uint8_t byteMask = 1 << (bitToFlip % 8);
+    int bitToFlip = rand() % static_cast<int>(8 * sizeof(data));
+    uint8_t byteMask = static_cast<uint8_t>(1 << (bitToFlip % 8));
     data[bitToFlip / 8] ^= byteMask;
   }
 
@@ -71,8 +71,8 @@ TEST(Checksum, BitFlips) {
   auto it = std::max_element(
       collisions.begin(), collisions.end(),
       [](MapElem a, MapElem b) { return a.second < b.second; });
-  int16_t maxCollisionHash = it->first;
-  int32_t maxCollisions = it->second;
+  uint16_t maxCollisionHash = it->first;
+  uint32_t maxCollisions = it->second;
   double maxCollisionsFrac = 1.0 * maxCollisions / numTests;
   printf("%d/%d collisions on worst checksum, 0x%4x\n", maxCollisions, numTests,
          maxCollisionHash);

--- a/controller/test/checksum/checksum_test.cpp
+++ b/controller/test/checksum/checksum_test.cpp
@@ -56,7 +56,7 @@ TEST(Checksum, BitFlips) {
     lastChecksum = checksum;
     int bitToFlip = rand() % static_cast<int>(8 * sizeof(data));
     uint8_t byteMask = static_cast<uint8_t>(1 << (bitToFlip % 8));
-    data[bitToFlip / 8] ^= byteMask;
+    data[bitToFlip / 8] = static_cast<char>(data[bitToFlip / 8] ^ byteMask);
   }
 
   printf("%d/%d collisions after flipping a single bit.\n",

--- a/controller/test/comms/comms_test.cpp
+++ b/controller/test/comms/comms_test.cpp
@@ -22,10 +22,12 @@ TEST(CommTests, SendControllerStatus) {
   s.active_params.expiratory_trigger_ml_per_min = 9;
   // Set very large values here because they take up more space in the encoded
   // proto, and our goal is to make it big.
-  s.active_params.alarm_lo_tidal_volume_ml = -1;
+  s.active_params.alarm_lo_tidal_volume_ml =
+      std::numeric_limits<uint32_t>::max();
   s.active_params.alarm_hi_tidal_volume_ml =
       std::numeric_limits<uint32_t>::max();
-  s.active_params.alarm_lo_breaths_per_min = -1;
+  s.active_params.alarm_lo_breaths_per_min =
+      std::numeric_limits<uint32_t>::max();
   s.active_params.alarm_hi_breaths_per_min =
       std::numeric_limits<uint32_t>::max();
   s.sensor_readings.pressure_cm_h2o = 11;
@@ -66,10 +68,12 @@ TEST(CommTests, CommandRx) {
   s.desired_params.expiratory_trigger_ml_per_min = 9;
   // Set very large values here because they take up more space in the encoded
   // proto, and our goal is to make it big.
-  s.desired_params.alarm_lo_tidal_volume_ml = -1;
+  s.desired_params.alarm_lo_tidal_volume_ml =
+      std::numeric_limits<uint32_t>::max();
   s.desired_params.alarm_hi_tidal_volume_ml =
       std::numeric_limits<uint32_t>::max();
-  s.desired_params.alarm_lo_breaths_per_min = -1;
+  s.desired_params.alarm_lo_breaths_per_min =
+      std::numeric_limits<uint32_t>::max();
   s.desired_params.alarm_hi_breaths_per_min =
       std::numeric_limits<uint32_t>::max();
 
@@ -78,7 +82,8 @@ TEST(CommTests, CommandRx) {
       reinterpret_cast<unsigned char *>(rx_buffer), sizeof(rx_buffer));
   pb_encode(&stream, GuiStatus_fields, &s);
   EXPECT_GT(stream.bytes_written, 0u);
-  Hal.test_serialPutIncomingData(rx_buffer, stream.bytes_written);
+  Hal.test_serialPutIncomingData(rx_buffer,
+                                 static_cast<uint16_t>(stream.bytes_written));
   EXPECT_GT(Hal.serialBytesAvailableForRead(), 0);
 
   ControllerStatus controller_status_ignored = ControllerStatus_init_zero;

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -43,7 +43,7 @@ Time ticks(int num_ticks) { return base + num_ticks * sample_period; }
   EXPECT_NEAR(expected, actual, OUTPUT_TOLERANCE)
 
 TEST(PidTest, Proportional) {
-  const float Kp = 0.9;
+  const float Kp = 0.9f;
   const float setpoint = 25;
   const float input = setpoint - 10;
 
@@ -61,7 +61,7 @@ TEST(PidTest, Proportional) {
 }
 
 TEST(PidTest, IntegralBasic) {
-  const float Ki = 1.75;
+  const float Ki = 1.75f;
   const float setpoint = 25;
   const float input = setpoint - 10;
 
@@ -80,7 +80,7 @@ TEST(PidTest, IntegralBasic) {
 }
 
 TEST(PidTest, IntegralSaturationMax) {
-  const float Ki = 1.75;
+  const float Ki = 1.75f;
   const float setpoint = 25;
   const float input = setpoint - 10;
 
@@ -109,7 +109,7 @@ TEST(PidTest, IntegralSaturationMax) {
 }
 
 TEST(PidTest, IntegralSaturationMin) {
-  const float Ki = 1.75;
+  const float Ki = 1.75f;
   const float setpoint = 25;
   const float input = setpoint + 10;
 
@@ -144,7 +144,7 @@ TEST(PidTest, IntegralSaturationMin) {
 // setpoint2). Derivative on measure and on error should handle this transition
 // differently.
 TEST(PidTest, DerivativeOnMeasure) {
-  const float Kd = 1.5;
+  const float Kd = 1.5f;
   const float setpoint1 = 25;
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
@@ -164,7 +164,7 @@ TEST(PidTest, DerivativeOnMeasure) {
 }
 
 TEST(PidTest, DerivativeOnError) {
-  const float Kd = 1.5;
+  const float Kd = 1.5f;
   const float setpoint1 = 25;
   const float input1 = setpoint1 - 10;
   const float setpoint2 = 17;
@@ -186,7 +186,7 @@ TEST(PidTest, CallFasterThanSample) {
   // effect on output
   const float setpoint = 25;
   const float input = setpoint - 10;
-  PID pid(/*kp=*/5.5, /*ki=*/1.1, /*kd=*/1.5, ProportionalTerm::ON_ERROR,
+  PID pid(/*kp=*/5.5f, /*ki=*/1.1f, /*kd=*/1.5f, ProportionalTerm::ON_ERROR,
           DifferentialTerm::ON_MEASUREMENT, ControlDirection::DIRECT,
           MIN_OUTPUT, MAX_OUTPUT, sample_period);
   int t = 0;
@@ -216,7 +216,7 @@ TEST(PidTest, TaskJitter) {
   // This test uses integral to check the effect of time between calls on the
   // PID output. Introducing jitter in call frequency and checking that the
   // integral takes this jitter into account.
-  const float Ki = 0.5;
+  const float Ki = 0.5f;
   const float setpoint = 25;
   const float input = setpoint - 10;
   PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,
@@ -245,7 +245,7 @@ TEST(PidTest, TaskJitter) {
 TEST(PidTest, MissedSample) {
   // This test uses integral to check the effect of missing a sample in the
   // execution of PID
-  const float Ki = 0.2;
+  const float Ki = 0.2f;
   const float setpoint = 25;
   const float input = setpoint - 10;
   PID pid(/*kp=*/0, Ki, /*kd=*/0, ProportionalTerm::ON_ERROR,

--- a/controller/test/pid_lib/pid_test.cpp
+++ b/controller/test/pid_lib/pid_test.cpp
@@ -297,7 +297,7 @@ TEST(PidTest, Observe) {
   // Do a few cycles where the PID is not actually in control
   float last_output;
   for (int i = 0; i < 10; i++) {
-    last_output = 128 + i;
+    last_output = static_cast<float>(128 + i);
     pid.Observe(ticks(t++), input, setpoint, /*actual_output=*/last_output);
   }
 

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -43,11 +43,11 @@ void checkRelationalOperators(T (*unit)(NumTy)) {
 
 TEST(Units, Pressure) {
   EXPECT_FLOAT_EQ(kPa(1).kPa(), 1);
-  EXPECT_FLOAT_EQ(kPa(1).cmH2O(), 10.1972);
+  EXPECT_FLOAT_EQ(kPa(1).cmH2O(), 10.1972f);
   EXPECT_FLOAT_EQ(cmH2O(1).cmH2O(), 1);
   EXPECT_FLOAT_EQ((kPa(1) - kPa(2)).kPa(), -1);
   EXPECT_FLOAT_EQ((cmH2O(1) + cmH2O(10)).cmH2O(), 11);
-  EXPECT_FLOAT_EQ((kPa(1) - cmH2O(10.1972)).kPa(), 0);
+  EXPECT_FLOAT_EQ((kPa(1) - cmH2O(10.1972f)).kPa(), 0);
 
   checkRelationalOperators(kPa);
   checkRelationalOperators(cmH2O);
@@ -57,7 +57,7 @@ TEST(Units, Length) {
   EXPECT_FLOAT_EQ(meters(1).meters(), 1);
   EXPECT_FLOAT_EQ(meters(1).millimeters(), 1000);
   EXPECT_FLOAT_EQ(millimeters(1).millimeters(), 1);
-  EXPECT_FLOAT_EQ(millimeters(1).meters(), 0.001);
+  EXPECT_FLOAT_EQ(millimeters(1).meters(), 0.001f);
   EXPECT_FLOAT_EQ((meters(1) - meters(2)).meters(), -1);
   EXPECT_FLOAT_EQ((millimeters(1) + millimeters(10)).millimeters(), 11);
   EXPECT_FLOAT_EQ((meters(1) - millimeters(1000)).meters(), 0);
@@ -68,14 +68,14 @@ TEST(Units, Length) {
 
 TEST(Units, VolumetricFlow) {
   EXPECT_FLOAT_EQ(cubic_m_per_sec(1).cubic_m_per_sec(), 1);
-  EXPECT_FLOAT_EQ(cubic_m_per_sec(1).ml_per_min(), 60.0 * 1000 * 1000);
+  EXPECT_FLOAT_EQ(cubic_m_per_sec(1).ml_per_min(), 60.0f * 1000 * 1000);
   EXPECT_FLOAT_EQ(ml_per_min(1).ml_per_min(), 1);
-  EXPECT_FLOAT_EQ(ml_per_min(1).cubic_m_per_sec(), 1 / (60.0 * 1000 * 1000));
+  EXPECT_FLOAT_EQ(ml_per_min(1).cubic_m_per_sec(), 1 / (60.0f * 1000 * 1000));
   EXPECT_FLOAT_EQ((cubic_m_per_sec(1) - cubic_m_per_sec(2)).cubic_m_per_sec(),
                   -1);
   EXPECT_FLOAT_EQ((ml_per_min(1) + ml_per_min(10)).ml_per_min(), 11);
   EXPECT_FLOAT_EQ(
-      (cubic_m_per_sec(1) - ml_per_min(60.0 * 1000 * 1000)).cubic_m_per_sec(),
+      (cubic_m_per_sec(1) - ml_per_min(60.0f * 1000 * 1000)).cubic_m_per_sec(),
       0);
 
   checkRelationalOperators(cubic_m_per_sec);
@@ -89,8 +89,10 @@ TEST(Units, Duration) {
   EXPECT_FLOAT_EQ(seconds(300).minutes(), 5);
   EXPECT_FLOAT_EQ(seconds(1).milliseconds(), 1000);
   EXPECT_FLOAT_EQ(milliseconds(1).milliseconds(), 1);
-  EXPECT_FLOAT_EQ(milliseconds(1).seconds(), 0.001);
-  EXPECT_FLOAT_EQ((seconds(1) - seconds(2)).seconds(), -1);
+  EXPECT_FLOAT_EQ(milliseconds(1).seconds(), 0.001f);
+  EXPECT_FLOAT_EQ((seconds(2) - seconds(1)).seconds(), 1);
+  // Negative durations are not supported.
+  // EXPECT_FLOAT_EQ((seconds(1) - seconds(2)).seconds(), ???);
   EXPECT_FLOAT_EQ((milliseconds(1) + milliseconds(10)).milliseconds(), 11);
   EXPECT_FLOAT_EQ((seconds(1) - milliseconds(1000)).seconds(), 0);
 
@@ -108,7 +110,8 @@ TEST(Units, Time) {
   EXPECT_FLOAT_EQ((ms(2000) - milliseconds(1000)).millisSinceStartup(), 1000);
   EXPECT_FLOAT_EQ((ms(5432) - seconds(3)).millisSinceStartup(), 2432);
   EXPECT_FLOAT_EQ((ms(1000) - millisSinceStartup(500)).seconds(), 0.5);
-  EXPECT_FLOAT_EQ((ms(500) - ms(1000)).seconds(), -0.5);
+  // Negative times are not supported:
+  // EXPECT_FLOAT_EQ((ms(500) - ms(1000)).seconds(), ???);
 
   checkRelationalOperators(millisSinceStartup);
 }

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -91,8 +91,7 @@ TEST(Units, Duration) {
   EXPECT_FLOAT_EQ(milliseconds(1).milliseconds(), 1);
   EXPECT_FLOAT_EQ(milliseconds(1).seconds(), 0.001f);
   EXPECT_FLOAT_EQ((seconds(2) - seconds(1)).seconds(), 1);
-  // Negative durations are not supported.
-  // EXPECT_FLOAT_EQ((seconds(1) - seconds(2)).seconds(), ???);
+  EXPECT_FLOAT_EQ((seconds(1) - seconds(2)).seconds(), -1);
   EXPECT_FLOAT_EQ((milliseconds(1) + milliseconds(10)).milliseconds(), 11);
   EXPECT_FLOAT_EQ((seconds(1) - milliseconds(1000)).seconds(), 0);
 
@@ -104,14 +103,14 @@ TEST(Units, Time) {
   // "millisSinceStartup" is long and makes this test hard to read; shorten it.
   auto ms = &millisSinceStartup;
 
-  EXPECT_FLOAT_EQ(ms(42).millisSinceStartup(), 42);
-  EXPECT_FLOAT_EQ((ms(10) + milliseconds(1)).millisSinceStartup(), 11);
-  EXPECT_FLOAT_EQ((milliseconds(42) + ms(100)).millisSinceStartup(), 142);
-  EXPECT_FLOAT_EQ((ms(2000) - milliseconds(1000)).millisSinceStartup(), 1000);
-  EXPECT_FLOAT_EQ((ms(5432) - seconds(3)).millisSinceStartup(), 2432);
-  EXPECT_FLOAT_EQ((ms(1000) - millisSinceStartup(500)).seconds(), 0.5);
+  EXPECT_EQ(ms(42).millisSinceStartup(), 42u);
+  EXPECT_EQ((ms(10) + milliseconds(1)).millisSinceStartup(), 11u);
+  EXPECT_EQ((milliseconds(42) + ms(100)).millisSinceStartup(), 142u);
+  EXPECT_EQ((ms(2000) - milliseconds(1000)).millisSinceStartup(), 1000u);
+  EXPECT_EQ((ms(5432) - seconds(3)).millisSinceStartup(), 2432u);
+  EXPECT_FLOAT_EQ((ms(1000) - millisSinceStartup(500)).seconds(), 0.5f);
   // Negative times are not supported:
-  // EXPECT_FLOAT_EQ((ms(500) - ms(1000)).seconds(), ???);
+  // EXPECT_EQ((ms(500) - ms(1000)).seconds(), ???);
 
   checkRelationalOperators(millisSinceStartup);
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,9 @@ lib_extra_dirs =
 ; TODO(jkff) It might be possible to use C++17 instead of gnu++17, but
 ; I hit some build errors, they didn't look too bad but with gnu++17
 ; they aren't there at all.
+; TODO: It would be swell if we could have -Wconversion here, unfortunately
+; Arduino libraries have a bunch of errors inside of them and there's no way
+; to suppress it just for Arduino libraries.
 build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror
 build_unflags =
   -std=gnu++11
@@ -53,7 +56,7 @@ lib_extra_dirs =
   ${env.lib_extra_dirs}
   common/test_libs
 ; googletest requires pthread.
-build_flags = ${env.build_flags} -DTEST_MODE -pthread
+build_flags = ${env.build_flags} -DTEST_MODE -pthread -Wconversion
 lib_deps =
   googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.

--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ platform_packages =
 [env:stm32]
 platform = ststm32
 board = custom_stm32
-build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror -Wno-error=register -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DBARE_STM32 -Wl,-Map,stm32.map -Wl,-u,vectors -Wl,-u,_init
+build_flags = ${env.build_flags} -Wconversion -Wno-error=register -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DBARE_STM32 -Wl,-Map,stm32.map -Wl,-u,vectors -Wl,-u,_init
 board_build.ldscript = boards/stm32_ldscript.ld
 build_unflags = -std=gnu11 -std=gnu++14
 extra_scripts = boards/stm32_scripts.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,7 @@ lib_extra_dirs =
 build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror
 build_unflags =
   -std=gnu++11
+  -std=gnu++14
   -fpermissive
 
 [env:uno]
@@ -49,13 +50,10 @@ extra_scripts = boards/stm32_scripts.py
 [env:native]
 platform = native
 lib_extra_dirs =
-  common/libs
-  common/generated_libs
+  ${env.lib_extra_dirs}
   common/test_libs
-  common/third_party
 ; googletest requires pthread.
-build_flags = -Icommon/include/ -std=gnu++17 -DTEST_MODE -pthread -Wall -Werror
-build_unflags = -std=gnu++11
+build_flags = ${env.build_flags} -DTEST_MODE -pthread
 lib_deps =
   googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.


### PR DESCRIPTION
A couple really scary bugs:
- alarm.cpp used an uint32 timestamp instead of uint64 (or time)
- comms.cpp would probably have data corruption if transmitting or receiving more than 128 bytes
- sensors.cpp had float->int precision loss during calibration