### PR TITLE
Removes nucleo env but makes test.sh run both stm32 and uno, until uno is gone

### DIFF
--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -40,10 +40,9 @@ limitations under the License.
 
 #ifdef TEST_MODE
 
-#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_NUCLEO_L452RE) ||              \
-    defined(BARE_STM32)
+#if defined(ARDUINO_AVR_UNO) || defined(BARE_STM32)
 #error                                                                         \
-    "TEST_MODE intended to be run only on native, but ARDUINO_AVR_UNO or ARDUINO_NUCLEO_L452RE or BARE_STM32 is defined"
+    "TEST_MODE intended to be run only on native, but ARDUINO_AVR_UNO or BARE_STM32 is defined"
 #endif
 
 #include <cstring>
@@ -55,10 +54,9 @@ limitations under the License.
 
 #else // !TEST_MODE
 
-#if !defined(ARDUINO_AVR_UNO) && !defined(ARDUINO_NUCLEO_L452RE) &&            \
-    !defined(BARE_STM32)
+#if !defined(ARDUINO_AVR_UNO) && !defined(BARE_STM32)
 #error                                                                         \
-    "When running without TEST_MODE, expecting ARDUINO_AVR_UNO or ARDUINO_NUCLEO_L452RE or BARE_STM32 to be defined"
+    "When running without TEST_MODE, expecting ARDUINO_AVR_UNO or BARE_STM32 to be defined"
 #endif
 
 #if defined(BARE_STM32)
@@ -293,7 +291,7 @@ private:
   std::vector<char> serialOutgoingData_;
 #endif
 
-#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_NUCLEO_L452RE)
+#if defined(ARDUINO_AVR_UNO)
   // Value of ::millis() at last call to watchdog_handler().  Used to detect
   // clock overflows.
   uint32_t last_millis_ = 0;
@@ -306,7 +304,7 @@ private:
 
 extern HalApi Hal;
 
-#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_NUCLEO_L452RE)
+#if defined(ARDUINO_AVR_UNO)
 
 inline void HalApi::init() {
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,13 +38,6 @@ platform_packages =
 ; A newer version of the toolchain than the default one, to support C++17.
   toolchain-atmelavr @1.70300.191015
 
-[env:nucleo]
-platform = ststm32
-board = nucleo_l452re
-framework = arduino
-build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror -Wno-error=register -w
-build_unflags = -std=gnu11 -std=gnu++14
-
 [env:stm32]
 platform = ststm32
 board = custom_stm32

--- a/test.sh
+++ b/test.sh
@@ -25,8 +25,9 @@ cd "$(dirname "$0")"
 
 # Controller unit tests on native.
 pio test -e native
-# Make sure controller builds for target platform.
-pio run
+# Make sure controller builds for target platforms.
+pio run -e uno
+pio run -e stm32
 
 # Code style / bug-prone pattern checks (eg. clang-tidy)
 # WARNING: This might sometimes give different results for different people,


### PR DESCRIPTION
Nucleo (STM32 with Arduino SDK) is not going to be used because instead we're going to use bare STM32 that @sglow added in #225 .