### PR TITLE
Issue 268 circular buffer

### DIFF
--- a/controller/lib/core/circular_buffer.h
+++ b/controller/lib/core/circular_buffer.h
@@ -1,0 +1,99 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This file implements the HAL (Hardware Abstraction Layer) for the
+STM32L452 processor used on the controller.  Details of the processor's
+peripherals can be found in the reference manual for that processor:
+   https://www.st.com/resource/en/reference_manual/dm00151940-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
+
+Details specific to the ARM processor used in this chip can be found in
+the programmer's manual for the processor available here:
+   https://www.st.com/resource/en/programming_manual/dm00046982-stm32-cortexm4-mcus-and-mpus-programming-manual-stmicroelectronics.pdf
+
+*/
+
+#ifndef CIRCULAR_BUFFER_H_
+#define CIRCULAR_BUFFER_H_
+
+#include <stdint.h>
+#include "hal.h"
+
+// This class is a generic circular buffer for byte sized data.
+//
+// Note that this class is used from both the main line of code
+// and the interrupt handlers, so it needs to be thread safe.
+// I'm disabling interrupts during the critical sections to
+// ensure that's the case.
+template <int N> class CircBuff {
+  volatile uint8_t buff[N];
+  volatile int head, tail;
+
+public:
+  CircBuff() { head = tail = 0; }
+
+  // Return number of bytes available in the buffer to read.
+  int FullCt() {
+    bool p = Hal.IntSuspend();
+    int ct = head - tail;
+    Hal.IntRestore(p);
+    if (ct < 0)
+      ct += N;
+    return ct;
+  }
+
+  // Return number of free spaces in the buffer where more
+  // bytes can be written.
+  int FreeCt() { return N - 1 - FullCt(); }
+
+  // Get the oldest byte from the buffer.
+  // Returns -1 if the buffer is empty
+  int Get() {
+    int ret = -1;
+
+    bool p = Hal.IntSuspend();
+
+    if (head != tail) {
+      ret = buff[tail++];
+      if (tail >= N)
+        tail = 0;
+    }
+
+    Hal.IntRestore(p);
+    return ret;
+  }
+
+  // Add a byte to the buffer
+  // Returnes true on success, false if the buffer is full
+  bool Put(uint8_t dat) {
+    bool ret = false;
+
+    bool p = Hal.IntSuspend();
+
+    int h = head + 1;
+    if (h >= N)
+      h = 0;
+
+    if (h != tail) {
+      buff[head] = dat;
+      head = h;
+      ret = true;
+    }
+
+    Hal.IntRestore(p);
+
+    return ret;
+  }
+};
+
+#endif

--- a/controller/lib/core/circular_buffer.h
+++ b/controller/lib/core/circular_buffer.h
@@ -26,8 +26,8 @@ the programmer's manual for the processor available here:
 #ifndef CIRCULAR_BUFFER_H_
 #define CIRCULAR_BUFFER_H_
 
-#include <stdint.h>
 #include "hal.h"
+#include <stdint.h>
 
 // This class is a generic circular buffer for byte sized data.
 //

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -264,6 +264,30 @@ public:
   // system for configured amount of time
   void watchdog_handler();
 
+  // Interrupt enable/disable functions.
+  //
+  // NOTE:
+  // Interrupts should only be disabled for short periods of time and only for
+  // very good reasons.  Leaving interrupts disabled for long can cause loss of
+  // serial data and other bad effects.
+
+  // Disable interrupts 
+  void IntDisable();
+
+  // Enable interrupts
+  void IntEnable();
+
+  // Disable interrutps and return true if they were enabled when the function
+  // was called.  Return false if interrupts were already disabled.
+  bool IntSuspend();
+
+  // Restore interrupts to the state they were in when IntSuspend was last
+  // called.  The return value from IntSuspend is passed in.
+  // If the input value is false, this function has no effect.
+  void IntRestore( bool yes ){
+     if( yes ) IntEnable();
+  }
+
 private:
   // Initializes watchdog, sets appropriate pins to OUTPUT, etc.  Called by
   // HalApi::init
@@ -439,9 +463,35 @@ inline void HalApi::watchdog_handler() {
 #endif
 }
 
+// Interrupt disable/enable not supported for Arduino HALs yet.
+// I'm assuming these are going away soon so don't require new
+// functionality
+inline void HalApi::IntDisable() {}
+inline void HalApi::IntEnable() {}
+inline bool HalApi::IntSuspend() { return false; }
+
+// Support for bare STM32.  Only a few inline functions are defined here.
+// Most support for this HAL is in a separate cpp file.
 #elif defined(BARE_STM32)
-// The STM32 build implements these functions in a separate cpp file,
-// so nothing needs to be added here.
+  // Disable interrupts.
+  // Returns true if interrupts were enabled when this 
+  // was called or false if they were already disabled.
+
+// Disable interrupts 
+inline void HalApi::IntDisable() { asm volatile("cpsid i" ::: "memory"); }
+
+// Enable interrupts
+inline void HalApi::IntEnable() { asm volatile("cpsie i" ::: "memory"); }
+
+// Disable interrutps and return true if they were enabled when the function
+// was called.  Return false if interrupts were already disabled.
+inline bool HalApi::IntSuspend() {
+  int ret;
+  asm volatile("mrs   %[output], primask\n\t"
+               "cpsid i"
+               : [output] "=r"(ret)::"memory");
+  return (ret == 0);
+}
 
 #else
 
@@ -516,6 +566,10 @@ inline void HalApi::test_serialPutIncomingData(const char *data, uint16_t len) {
   }
   serialIncomingData_.push_back(std::vector<char>(data, data + len));
 }
+
+inline void HalApi::IntDisable() {}
+inline void HalApi::IntEnable() {}
+inline bool HalApi::IntSuspend() { return false; }
 
 #endif
 

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -271,7 +271,7 @@ public:
   // very good reasons.  Leaving interrupts disabled for long can cause loss of
   // serial data and other bad effects.
 
-  // Disable interrupts 
+  // Disable interrupts
   void IntDisable();
 
   // Enable interrupts
@@ -284,8 +284,9 @@ public:
   // Restore interrupts to the state they were in when IntSuspend was last
   // called.  The return value from IntSuspend is passed in.
   // If the input value is false, this function has no effect.
-  void IntRestore( bool yes ){
-     if( yes ) IntEnable();
+  void IntRestore(bool yes) {
+    if (yes)
+      IntEnable();
   }
 
 private:
@@ -473,11 +474,11 @@ inline bool HalApi::IntSuspend() { return false; }
 // Support for bare STM32.  Only a few inline functions are defined here.
 // Most support for this HAL is in a separate cpp file.
 #elif defined(BARE_STM32)
-  // Disable interrupts.
-  // Returns true if interrupts were enabled when this 
-  // was called or false if they were already disabled.
+// Disable interrupts.
+// Returns true if interrupts were enabled when this
+// was called or false if they were already disabled.
 
-// Disable interrupts 
+// Disable interrupts
 inline void HalApi::IntDisable() { asm volatile("cpsid i" ::: "memory"); }
 
 // Enable interrupts

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -495,6 +495,8 @@ inline bool HalApi::IntSuspend() {
 }
 
 #else
+inline void HalApi::init() {}
+inline void HalApi::watchdog_handler() {}
 
 inline Time HalApi::now() { return time_; }
 inline void HalApi::delay(Duration d) { time_ = time_ + d; }

--- a/controller/lib/hal/hal_stm32.cpp
+++ b/controller/lib/hal/hal_stm32.cpp
@@ -577,11 +577,11 @@ public:
 
   // Return the number of bytes currently in the
   // receive buffer and ready to be read.
-  uint16_t RxFull() { return rxDat.FullCt(); }
+  uint16_t RxFull() { return static_cast<uint16_t>(rxDat.FullCt()); }
 
   // Returns the number of free locations in the
   // transmit buffer.
-  uint16_t TxFree() { return txDat.FreeCt(); }
+  uint16_t TxFree() { return static_cast<uint16_t>(txDat.FreeCt()); }
 };
 
 static UART rpUART(UART3_BASE);

--- a/controller/lib/hal/hal_stm32.h
+++ b/controller/lib/hal/hal_stm32.h
@@ -36,24 +36,6 @@ the programmer's manual for the processor available here:
 #define CPU_FREQ_MHZ 80
 #define CPU_FREQ (CPU_FREQ_MHZ * 1000000)
 
-// Some useful inline functions to enable/disable interrupts
-inline void IntDisable() { asm volatile("cpsid i" ::: "memory"); }
-
-inline void IntEnable() { asm volatile("cpsie i" ::: "memory"); }
-
-inline void IntRestore(bool p) {
-  if (p)
-    IntEnable();
-}
-
-inline bool IntSuspend() {
-  int ret;
-  asm volatile("mrs   %[output], primask\n\t"
-               "cpsid i"
-               : [output] "=r"(ret)::"memory");
-  return (ret == 0);
-}
-
 // Interrupt vectors that we currently use.
 // The values here are the offsets into the interrupt table.
 // These can be found in the NVIC chapter (chapter 12) of the

--- a/controller/test/circ_buff/circ_buff_test.cpp
+++ b/controller/test/circ_buff/circ_buff_test.cpp
@@ -15,9 +15,74 @@ limitations under the License.
 
 #include "circular_buffer.h"
 #include "gtest/gtest.h"
+#include <cstdlib>
 
 // Just getting my feet wet with gtest
-TEST(CircBuff, DataIO){
-   ASSERT_EQ( 1, 2 ) << "In these uncertain times, I'm not sure of anything";
+TEST(CircBuff, Counts) {
+  CircBuff<128> buff;
+
+  // Note that a buffer with 128 bytes of storage can only actually
+  // hold 127 bytes.  This is a side effect of how we represent a
+  // full buffer.
+  ASSERT_EQ(buff.FreeCt(), 127);
+  ASSERT_EQ(buff.FullCt(), 0);
+
+  // Add/remove bytes from the buffer and check counts along the way.
+  // The full/free calculations change when the buffer wraps, so I
+  // want to make sure I do this enough times to catch any errors in
+  // that logic
+  for (int i = 0; i < 100; i++) {
+    int full = 0;
+    int free = 127;
+    for (int j = 0; j < 20; j++) {
+      bool ok = buff.Put(0);
+      ASSERT_EQ(ok, true);
+
+      full++;
+      free--;
+      ASSERT_EQ(buff.FreeCt(), free);
+      ASSERT_EQ(buff.FullCt(), full);
+    }
+
+    for (int j = 0; j < 20; j++) {
+      int ch = buff.Get();
+      ASSERT_EQ(ch, 0);
+
+      full--;
+      free++;
+      ASSERT_EQ(buff.FreeCt(), free);
+      ASSERT_EQ(buff.FullCt(), full);
+    }
+  }
 }
 
+// Make sure the data we add to the buffer is the same
+// as the data we get out of it
+TEST(CircBuff, DataIO) {
+  CircBuff<128> buff;
+
+  uint8_t TestSet[200];
+  for (uint32_t i = 0; i < sizeof(TestSet); i++)
+    TestSet[i] = rand();
+
+  // Add data to the buffer until failure
+  for (int i = 0; i < 128; i++) {
+    bool ok = buff.Put(TestSet[i]);
+    if (i < 127) {
+      ASSERT_EQ(ok, true);
+    }
+
+    else {
+      ASSERT_EQ(ok, false);
+      break;
+    }
+  }
+
+  for (int i = 0; i < 127; i++) {
+    int x = buff.Get();
+    ASSERT_EQ(x, TestSet[i]);
+  }
+
+  // The buffer should be empty now
+  ASSERT_EQ(buff.Get(), -1);
+}

--- a/controller/test/circ_buff/circ_buff_test.cpp
+++ b/controller/test/circ_buff/circ_buff_test.cpp
@@ -63,7 +63,7 @@ TEST(CircBuff, DataIO) {
 
   uint8_t TestSet[200];
   for (uint32_t i = 0; i < sizeof(TestSet); i++)
-    TestSet[i] = rand();
+    TestSet[i] = static_cast<uint8_t>(rand());
 
   // Add data to the buffer until failure
   for (int i = 0; i < 128; i++) {

--- a/controller/test/circ_buff/circ_buff_test.cpp
+++ b/controller/test/circ_buff/circ_buff_test.cpp
@@ -86,3 +86,15 @@ TEST(CircBuff, DataIO) {
   // The buffer should be empty now
   ASSERT_EQ(buff.Get(), -1);
 }
+
+// TODO - some other good tests to add when there's time:
+//
+// - Test that when Put() and Get() fail, they have no effect
+//
+// - Test what happens when the buffer is empty or has size 1
+//
+// - Exhaustively test the state space of a small circular buffer (if it
+//   works for a buffer of size 5, it probably also works for 128 - but
+//   with size 5 it's easy to write a completely exhaustive test that
+//   verifies that the buffer implements all operations correctly in states
+//   with all combinations of (head, tail))

--- a/controller/test/circ_buff/circ_buff_test.cpp
+++ b/controller/test/circ_buff/circ_buff_test.cpp
@@ -1,0 +1,23 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "circular_buffer.h"
+#include "gtest/gtest.h"
+
+// Just getting my feet wet with gtest
+TEST(CircBuff, DataIO){
+   ASSERT_EQ( 1, 2 ) << "In these uncertain times, I'm not sure of anything";
+}
+


### PR DESCRIPTION
This is a simple change to close issue #268.  It just moves the circular buffer implementation from the HAL to the core library and adds some unit tests for the buffer.

Fixes #268 