### PR TITLE
Revert "Removes nucleo env but makes test.sh run both stm32 and uno, until uno is gone"

### DIFF
--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -40,9 +40,10 @@ limitations under the License.
 
 #ifdef TEST_MODE
 
-#if defined(ARDUINO_AVR_UNO) || defined(BARE_STM32)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_NUCLEO_L452RE) ||              \
+    defined(BARE_STM32)
 #error                                                                         \
-    "TEST_MODE intended to be run only on native, but ARDUINO_AVR_UNO or BARE_STM32 is defined"
+    "TEST_MODE intended to be run only on native, but ARDUINO_AVR_UNO or ARDUINO_NUCLEO_L452RE or BARE_STM32 is defined"
 #endif
 
 #include <cstring>
@@ -54,9 +55,10 @@ limitations under the License.
 
 #else // !TEST_MODE
 
-#if !defined(ARDUINO_AVR_UNO) && !defined(BARE_STM32)
+#if !defined(ARDUINO_AVR_UNO) && !defined(ARDUINO_NUCLEO_L452RE) &&            \
+    !defined(BARE_STM32)
 #error                                                                         \
-    "When running without TEST_MODE, expecting ARDUINO_AVR_UNO or BARE_STM32 to be defined"
+    "When running without TEST_MODE, expecting ARDUINO_AVR_UNO or ARDUINO_NUCLEO_L452RE or BARE_STM32 to be defined"
 #endif
 
 #if defined(BARE_STM32)
@@ -316,7 +318,7 @@ private:
   std::vector<char> serialOutgoingData_;
 #endif
 
-#if defined(ARDUINO_AVR_UNO)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_NUCLEO_L452RE)
   // Value of ::millis() at last call to watchdog_handler().  Used to detect
   // clock overflows.
   uint32_t last_millis_ = 0;
@@ -329,7 +331,7 @@ private:
 
 extern HalApi Hal;
 
-#if defined(ARDUINO_AVR_UNO)
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_NUCLEO_L452RE)
 
 inline void HalApi::init() {
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,9 @@ platform_packages =
 ; A newer version of the toolchain than the default one, to support C++17.
   toolchain-atmelavr @1.70300.191015
 
+; TODO: Remove me once env:stm32 can do everything that nucleo can.  (stm32 is
+; our custom STM32 HAL, whereas nucleo uses the Arduino API atop the STM32
+; chip.)
 [env:nucleo]
 platform = ststm32
 board = nucleo_l452re

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,13 @@ platform_packages =
 ; A newer version of the toolchain than the default one, to support C++17.
   toolchain-atmelavr @1.70300.191015
 
+[env:nucleo]
+platform = ststm32
+board = nucleo_l452re
+framework = arduino
+build_flags = -Icommon/include/ -std=gnu++17 -Wall -Werror -Wno-error=register -w
+build_unflags = -std=gnu11 -std=gnu++14
+
 [env:stm32]
 platform = ststm32
 board = custom_stm32

--- a/test.sh
+++ b/test.sh
@@ -25,9 +25,8 @@ cd "$(dirname "$0")"
 
 # Controller unit tests on native.
 pio test -e native
-# Make sure controller builds for target platforms.
-pio run -e uno
-pio run -e stm32
+# Make sure controller builds for target platform.
+pio run
 
 # Code style / bug-prone pattern checks (eg. clang-tidy)
 # WARNING: This might sometimes give different results for different people,

--- a/test.sh
+++ b/test.sh
@@ -25,8 +25,11 @@ cd "$(dirname "$0")"
 
 # Controller unit tests on native.
 pio test -e native
+
 # Make sure controller builds for target platform.
-pio run
+pio run -e uno
+pio run -e stm32
+pio run -e nucleo
 
 # Code style / bug-prone pattern checks (eg. clang-tidy)
 # WARNING: This might sometimes give different results for different people,


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Revert "Removes nucleo env but makes test.sh run both stm32 and uno, until uno is gone"
    
    This reverts commit 6392c1cba737030a7ddcc62ca4757682bc9dd614.
    
    It turns out that we're not quite ready to get rid of the "nucleo"
    target yet.  The Arduino APIs are useful for communicating with the
    STM32 dev board until:
    
     - Our HAL knows how to talk over the STM's USB serial output.
     - Our HAL knows works with L452RE-P's pinout -- or otherwise we get rid
       of all the -P boards.
    
    This is a clean revert.  In a separate commit I will restore the
    desirable changes to test.sh.
1. Update test.sh to run on all relevant platforms.
    
    Currently relevant platforms are uno, stm32, and nucleo.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #278 Revert "Removes nucleo env but makes test.sh run both stm32 and uno, until uno is gone" 👈 **YOU ARE HERE**

</git-pr-chain>
