### PR TITLE
Update .ycm_extra_conf to use STM32 flags.

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -69,34 +69,32 @@ def pio_pkg_dir(pkg):
 #    means that when you add a new header to a file, ycm won't know how to use
 #    that header until you manually regenerate compile_commands.json!
 #
-#  - platformio uses gcc-avr to compile for Arduino, and that compiler
-#    implicitly adds a bunch of necessary flags that ycm/clangd are not aware
-#    of.  So we'd have to add them here *anyway*.
+#  - platformio uses arm-none-eabi-g++ to compile for our chip, and that
+#    compiler implicitly adds a bunch of necessary flags that ycm/clangd are
+#    not aware of.  So we'd have to add them here *anyway*.
 #
-#  - Most files get compiled with Arduino flags, but some (tests) must be
+#  - Most files get compiled with ARM flags, but some (tests) must be
 #    compiled with native flags.  So even if we used a compilation_database,
 #    we'd have to intelligently choose which set of flags to use here.
 #
 # Flags are defined below.  Feel free to modify them if necessary!
 
-common_flags = ["-x", "c++", "-std=gnu++17", "-fno-exceptions", "-Wall",] + [
+common_flags = [
+    "-x",
+    "c++",
+    "-std=gnu++17",
+    "-fno-exceptions",
+    "-Wall",
+    "-Werror=conversion",
+] + [
     "-I" + d for d in {os.path.dirname(h) for h in glob.glob("**/*.h", recursive=True)}
 ]
 
-arduino_flags = [
-    "-I.pio/libdeps/uno/Nanopb_ID431",
-    "-I.pio/libdeps/uno/PID_ID2",
-    "-isystem" + pio_pkg_dir("framework-arduino-avr/cores/arduino"),
-    "-isystem" + pio_pkg_dir("framework-arduino-avr/variants/standard"),
-    "-isystem" + pio_pkg_dir("toolchain-atmelavr/avr/include"),
-    "-DAVR",
-    "-DARDUINO_AVR_UNO",
-    "-DF_CPU=16000000L",
-    "-DARDUINO_ARCH_AVR",
-    "-DARDUINO=10808",
-    "-D__AVR_ATmega328P__",
-    "-Os",  # AVR headers complain if we compile without optimizations!
-] + ["-I" + d for d in glob.glob(".pio/libdeps/uno/*")]
+stm32_flags = [
+    "-nostdlib",
+    "-DBARE_STM32",
+    "-DF_CPU=80000000L",
+] + ["-I" + d for d in glob.glob(".pio/libdeps/stm32/*")]
 
 native_flags = [
     "-DTEST_MODE",
@@ -161,7 +159,7 @@ def Settings(**kwargs):
             # TODO(jlebar): This is not a perfect heuristic.  In particular, hal.h
             # mixes modes.
             if "/test/" not in filename:
-                flags = common_flags + arduino_flags
+                flags = common_flags + stm32_flags
             else:
                 flags = common_flags + native_flags
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Update .ycm_extra_conf to use STM32 flags.
    
    Now that Uno is gone, we shouldn't build with Uno flags.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #281 Update .ycm_extra_conf to use STM32 flags. 👈 **YOU ARE HERE**
1. #282 Delete support for Arduino Uno.
1. #283 Use std::variant in blower_fsm.h.
1. #284 Remove stl::min/max/clamp.
1. #285 Use C++ STL math functions in sensors.cpp.
1. #286 Reformat decoder.py.
1. #287 Add __pycache__ to gitignore.
1. #288 Update pinout in HAL for STM32.
1. #289 Update comment in sensors.cpp for STM32.
1. #290 gui/build.sh: Build GUI in parallel.
1. #291 Unbreak DEV_MODE build.
1. #292 Add+run precommit for the 'black' Python formatter
1. #293 Fix trailing whitespace in a README.md file.
1. #294 Update badges in README.md.
1. #295 C++17 tweaks to hal_stm32.{h,cpp}
1. #296 Tweak clang-tidy and YCM flags.
1. #297 Pass -Wno-sign-conversion to gcc.

</git-pr-chain>













