### PR TITLE
Delete support for Arduino Uno.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,6 @@ include_dir = controller/include
 src_dir = controller/src
 test_dir = controller/test
 lib_dir = controller/lib
-; Make `platformio run` build just env:uno.  We skip env:native for now because
-; it doesn't build!
 default_envs = stm32
 
 [env]
@@ -33,14 +31,6 @@ build_unflags =
   -std=gnu++11
   -std=gnu++14
   -fpermissive
-
-[env:uno]
-platform = atmelavr
-board = uno
-framework = arduino
-platform_packages =
-; A newer version of the toolchain than the default one, to support C++17.
-  toolchain-atmelavr @1.70300.191015
 
 ; TODO: Remove me once env:stm32 can do everything that nucleo can.  (stm32 is
 ; our custom STM32 HAL, whereas nucleo uses the Arduino API atop the STM32
@@ -73,8 +63,12 @@ lib_deps =
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
 extra_scripts = platformio_sanitizers.py
-; Run clang-tidy only on native: it seems to get confused by Uno headers that
-; can only be parsed by gcc.
+
+; Run clang-tidy only on native: it seems to get confused by headers that can
+; only be parsed by gcc.
+;
+; TODO(jlebar): Is this still necessary now that we have dropped support for
+; Uno?  If so, will it still be necessary when we drop support for Nucleo?
 check_tool = clangtidy
 check_flags =
   ; The actual checks are defined in .clang-tidy.

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,6 @@ cd "$(dirname "$0")"
 pio test -e native
 
 # Make sure controller builds for target platform.
-pio run -e uno
 pio run -e stm32
 pio run -e nucleo
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Delete support for Arduino Uno.
    
    Goodbye, fair chip.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #282 Delete support for Arduino Uno. 👈 **YOU ARE HERE**
1. #283 Use std::variant in blower_fsm.h.
1. #284 Remove stl::min/max/clamp.
1. #285 Use C++ STL math functions in sensors.cpp.
1. #286 Reformat decoder.py.
1. #287 Add __pycache__ to gitignore.
1. #288 Update pinout in HAL for STM32.
1. #289 Update comment in sensors.cpp for STM32.
1. #290 gui/build.sh: Build GUI in parallel.
1. #291 Unbreak DEV_MODE build.
1. #292 Add+run precommit for the 'black' Python formatter
1. #293 Fix trailing whitespace in a README.md file.
1. #294 Update badges in README.md.
1. #295 C++17 tweaks to hal_stm32.{h,cpp}
1. #296 Tweak clang-tidy and YCM flags.
1. #297 Pass -Wno-sign-conversion to gcc.

</git-pr-chain>














