### PR TITLE
Remove stl::min/max/clamp.

### DIFF
--- a/controller/lib/core/comms.cpp
+++ b/controller/lib/core/comms.cpp
@@ -103,7 +103,7 @@ static void process_tx(const ControllerStatus &controller_status) {
     // it matches nanopb.
     uint16_t bytes_written =
         Hal.serialWrite(reinterpret_cast<char *>(tx_buffer) + tx_idx,
-                        stl::min(bytes_avail, tx_bytes_remaining));
+                        std::min(bytes_avail, tx_bytes_remaining));
     // TODO: How paranoid should we be about this underflowing?  Perhaps we
     // should reset the device if this or other invariants are violated?
     tx_bytes_remaining =

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -428,14 +428,14 @@ inline void HalApi::analogWrite(PwmPin pin, int value) {
   ::analogWrite(rawPin(pin), value);
 }
 [[nodiscard]] inline uint16_t HalApi::serialRead(char *buf, uint16_t len) {
-  return Serial.readBytes(buf, stl::min(len, serialBytesAvailableForRead()));
+  return Serial.readBytes(buf, std::min(len, serialBytesAvailableForRead()));
 }
 inline uint16_t HalApi::serialBytesAvailableForRead() {
   return Serial.available();
 }
 [[nodiscard]] inline uint16_t HalApi::serialWrite(const char *buf,
                                                   uint16_t len) {
-  return Serial.write(buf, stl::min(len, serialBytesAvailableForWrite()));
+  return Serial.write(buf, std::min(len, serialBytesAvailableForWrite()));
 }
 inline uint16_t HalApi::serialBytesAvailableForWrite() {
   return Serial.availableForWrite();
@@ -545,7 +545,7 @@ inline void HalApi::analogWrite(PwmPin pin, int value) {
     return 0;
   }
   auto &readBuf = serialIncomingData_.front();
-  uint16_t n = stl::min(len, static_cast<uint16_t>(readBuf.size()));
+  uint16_t n = std::min(len, static_cast<uint16_t>(readBuf.size()));
   memcpy(buf, readBuf.data(), n);
   readBuf.erase(readBuf.begin(), readBuf.begin() + n);
   if (readBuf.empty()) {
@@ -560,7 +560,7 @@ inline uint16_t HalApi::serialBytesAvailableForRead() {
 }
 [[nodiscard]] inline uint16_t HalApi::serialWrite(const char *buf,
                                                   uint16_t len) {
-  uint16_t n = stl::min(len, serialBytesAvailableForWrite());
+  uint16_t n = std::min(len, serialBytesAvailableForWrite());
   serialOutgoingData_.insert(serialOutgoingData_.end(), buf, buf + n);
   return n;
 }
@@ -570,7 +570,7 @@ inline uint16_t HalApi::serialBytesAvailableForWrite() {
   return 64;
 }
 inline uint16_t HalApi::test_serialGetOutgoingData(char *data, uint16_t len) {
-  uint16_t n = stl::min(len, static_cast<uint16_t>(serialOutgoingData_.size()));
+  uint16_t n = std::min(len, static_cast<uint16_t>(serialOutgoingData_.size()));
   memcpy(data, serialOutgoingData_.data(), n);
   serialOutgoingData_.erase(serialOutgoingData_.begin(),
                             serialOutgoingData_.begin() + n);

--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -64,7 +64,7 @@ float PID::Compute(Time now, float input, float setpoint) {
     output_sum_ -= kp * dInput;
   }
 
-  output_sum_ = stl::clamp(output_sum_, out_min_, out_max_);
+  output_sum_ = std::clamp(output_sum_, out_min_, out_max_);
 
   float res = output_sum_;
   if (p_term_ == ProportionalTerm::ON_ERROR) {
@@ -83,7 +83,7 @@ float PID::Compute(Time now, float input, float setpoint) {
   // when should we expect to perform our next output calculation
   next_sample_time_ = next_sample_time_ + sample_period_;
 
-  last_output_ = stl::clamp(res, out_min_, out_max_);
+  last_output_ = std::clamp(res, out_min_, out_max_);
   return last_output_;
 }
 
@@ -96,5 +96,5 @@ void PID::Observe(Time now, float input, float setpoint, float actual_output) {
   // Reset output_sum_ to actual_output so that the next Compute()
   // will adjust it only slightly (as if it had been computed by a current
   // Compute() call), avoiding a spike.
-  output_sum_ = stl::clamp(actual_output, out_min_, out_max_);
+  output_sum_ = std::clamp(actual_output, out_min_, out_max_);
 }

--- a/controller/lib/stl/algorithm.h
+++ b/controller/lib/stl/algorithm.h
@@ -15,24 +15,14 @@ limitations under the License.
 #ifndef ALGORITHM_H
 #define ALGORITHM_H
 
-// This file is a "Polyfill" for some functions in <algorithm>, which is
-// unavailable on Arduino.
+// Include this file instead of <algorithm>.
+//
+// It works around the fact that Arduino.h defines min/max macros, which causes
+// it to conflict with std::min/max.
+//
+// TODO: Remove this and use plain <algorithm> once the `nucleo` (i.e. stm32 +
+// Arduino API) platform is gone.
 
-// Undefine evil min/max macros defined by Arduino.h.  These are prone to the
-// following bug:
-//
-//   int a = min(b, fn());
-//   assert(a <= b);
-//
-// You'd expect this assert to always be true, but it might fail!  The min
-// macro expands to
-//
-//   int a = b < fn() ? b : fn();
-//
-// and you can see that this might evaluate fn() twice.  There's no guarantee
-// that the second return is equal to the first.
-//
-// Use stl::min/max instead.
 #if !defined(TEST_MODE) && !defined(BARE_STM32)
 #include <Arduino.h>
 #endif
@@ -40,20 +30,6 @@ limitations under the License.
 #undef min
 #undef max
 
-namespace stl {
+#include <algorithm>
 
-template <typename T> constexpr const T &min(const T &a, const T &b) {
-  return a < b ? a : b;
-}
-
-template <typename T> constexpr const T &max(const T &a, const T &b) {
-  return a > b ? a : b;
-}
-
-template <typename T>
-constexpr const T &clamp(const T &v, const T &lo, const T &hi) {
-  return (v < lo) ? lo : (hi < v) ? hi : v;
-}
-
-} // namespace stl
 #endif // ALGORITHM_H


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Remove stl::min/max/clamp.
    
    Use std::min/max/clamp now that we always have a C++ standard library
    available.
    
    Unfortunately we can't remove our algorithm.h shim quite yet; see
    comment in the header.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #284 Remove stl::min/max/clamp. 👈 **YOU ARE HERE**
1. #285 Use C++ STL math functions in sensors.cpp.
1. #286 Reformat decoder.py.
1. #287 Add __pycache__ to gitignore.
1. #288 Update pinout in HAL for STM32.
1. #289 Update comment in sensors.cpp for STM32.
1. #290 gui/build.sh: Build GUI in parallel.
1. #291 Unbreak DEV_MODE build.
1. #292 Add+run precommit for the 'black' Python formatter
1. #293 Fix trailing whitespace in a README.md file.
1. #295 C++17 tweaks to hal_stm32.{h,cpp}
1. #296 Tweak clang-tidy and YCM flags.
1. #297 Pass -Wno-sign-conversion to gcc.
1. #294 Update badges in README.md.

</git-pr-chain>


























