### PR TITLE
C++17 tweaks to hal_stm32.{h,cpp}

### DIFF
--- a/controller/lib/hal/hal_stm32.h
+++ b/controller/lib/hal/hal_stm32.h
@@ -116,14 +116,14 @@ inline SysCtrl_Reg *const SYSCTL_BASE =
     reinterpret_cast<SysCtrl_Reg *>(0xE000E000);
 
 // Interrupt controller
-typedef struct {
+struct IntCtrl_Regs {
   REG setEna[32];
   REG clrEna[32];
   REG setPend[32];
   REG clrPend[32];
   REG active[64];
   BREG priority[1024];
-} IntCtrl_Regs;
+};
 inline IntCtrl_Regs *const NVIC_BASE =
     reinterpret_cast<IntCtrl_Regs *>(0xE000E100);
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. C++17 tweaks to hal_stm32.{h,cpp}
    
    The most significant is using the IIFE trick for switch statements that
    "return" a value.  This is safer because e.g. when you're returning two
    variables, you *can't* forget to assign one of them.
    
    No functional change.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #295 C++17 tweaks to hal_stm32.{h,cpp} 👈 **YOU ARE HERE**
1. #296 Tweak clang-tidy and YCM flags.
1. #297 Pass -Wno-sign-conversion to gcc.
1. #293 Fix trailing whitespace in a README.md file.
1. #294 Update badges in README.md.

</git-pr-chain>



























