### PR TITLE
Pass -Wno-sign-conversion to gcc.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -45,7 +45,7 @@ build_unflags = -std=gnu11 -std=gnu++14
 [env:stm32]
 platform = ststm32
 board = custom_stm32
-build_flags = ${env.build_flags} -Wconversion -Wno-error=register -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DBARE_STM32 -Wl,-Map,stm32.map -Wl,-u,vectors -Wl,-u,_init
+build_flags = ${env.build_flags} -Wconversion -Wno-sign-conversion -Wno-error=register -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DBARE_STM32 -Wl,-Map,stm32.map -Wl,-u,vectors -Wl,-u,_init
 board_build.ldscript = boards/stm32_ldscript.ld
 build_unflags = -std=gnu11 -std=gnu++14
 extra_scripts = boards/stm32_scripts.py
@@ -56,7 +56,7 @@ lib_extra_dirs =
   ${env.lib_extra_dirs}
   common/test_libs
 ; googletest requires pthread.
-build_flags = ${env.build_flags} -DTEST_MODE -pthread -Wconversion
+build_flags = ${env.build_flags} -DTEST_MODE -pthread -Wconversion -Wno-sign-conversion
 lib_deps =
   googletest
 ; This is needed for the googletest lib_dep to work.  I don't understand why.


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Pass -Wno-sign-conversion to gcc.
    
    I believe this is no functional change: GCC's docs claim that
    sign-conversion is enabled by -Wconversion only for C code.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #297 Pass -Wno-sign-conversion to gcc. 👈 **YOU ARE HERE**
1. #293 Fix trailing whitespace in a README.md file.
1. #294 Update badges in README.md.

</git-pr-chain>




























