### PR TITLE
Fix sprintf build on my machine.

### DIFF
--- a/controller/lib/core/sprintf.cpp
+++ b/controller/lib/core/sprintf.cpp
@@ -439,9 +439,9 @@ static int FormatLong(FieldInfo *info, long long val, char *str, int max) {
 static int FormatFloat(FieldInfo *info, float val, char *str, int max) {
   // Check for outliers
   const char *bad = 0;
-  if (isnanf(val))
+  if (isnan(val))
     bad = (val < 0) ? "-nan" : "nan";
-  if (isinff(val))
+  if (isinf(val))
     bad = (val < 0) ? "-inf" : "inf";
   if (bad) {
     for (int i = 0; i < max && bad[i]; i++)
@@ -542,7 +542,7 @@ static int FormatExp(FieldInfo *info, float val, char *str, int max) {
   int exp = 0;
   float av = fabsf(val);
 
-  if (av) {
+  if (av != 0) {
     exp = (int)floorf(log10f(av));
     val *= powf(10.0f, static_cast<float>(-exp));
   }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix sprintf build on my machine.
    
    - isnanf/isinff doesn't exist for me, and afaict they're not standard C
      functions. https://en.cppreference.com/w/c/numeric/math/isnan
      https://en.cppreference.com/w/c/numeric/math/isinf
    
    - I get a warning about `if (av)` when `av` is a float.  Made explicit.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #299 Fix sprintf build on my machine. 👈 **YOU ARE HERE**
1. #284 Remove stl::min/max/clamp.
1. #285 Use C++ STL math functions in sensors.cpp.
1. #286 Reformat decoder.py.
1. #287 Add __pycache__ to gitignore.
1. #288 Update pinout in HAL for STM32.
1. #289 Update comment in sensors.cpp for STM32.
1. #290 gui/build.sh: Build GUI in parallel.
1. #291 Unbreak DEV_MODE build.
1. #292 Add+run precommit for the 'black' Python formatter
1. #293 Fix trailing whitespace in a README.md file.
1. #295 C++17 tweaks to hal_stm32.{h,cpp}
1. #296 Tweak clang-tidy and YCM flags.
1. #297 Pass -Wno-sign-conversion to gcc.
1. #294 Update badges in README.md.

</git-pr-chain>







