### PR TITLE
Fix typo in sensor readings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # VentilatorSoftware
 
-[![Build Status](https://travis-ci.com/RespiraWorks/VentilatorSoftware.svg?branch=master)](https://travis-ci.com/RespiraWorks/VentilatorSoftware)
+[![Travis Build Status](https://travis-ci.com/RespiraWorks/VentilatorSoftware.svg?branch=master)](https://travis-ci.com/RespiraWorks/VentilatorSoftware)
+[![CircleCI Build Status](https://circleci.com/gh/RespiraWorks/VentilatorSoftware.svg?style=shield)](https://circleci.com/gh/RespiraWorks/VentilatorSoftware/tree/master)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: clang-format](https://img.shields.io/badge/code%20style-clang--format-blue)](https://clang.llvm.org/docs/ClangFormat.html)
+[![Built with: platformio](https://img.shields.io/badge/built%20with-platformio-orange)](https://platformio.org/)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/RespiraWorks/VentilatorSoftware)](https://github.com/RespiraWorks/VentilatorSoftware/pulse)
 
 This is a common repository for all software components of the [RespiraWorks](http://respira.works) open source ventilator project.
 

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -159,7 +159,7 @@ SensorReadings Sensors::GetSensorReadings() {
   // into lungs, and negative is flow out of lungs.
   auto patient_pressure = ReadPressureSensor(PATIENT_PRESSURE);
   auto inflow_delta = ReadPressureSensor(INFLOW_PRESSURE_DIFF);
-  auto outflow_delta = ReadPressureSensor(INFLOW_PRESSURE_DIFF);
+  auto outflow_delta = ReadPressureSensor(OUTFLOW_PRESSURE_DIFF);
   VolumetricFlow flow =
       PressureDeltaToFlow(inflow_delta) - PressureDeltaToFlow(outflow_delta);
   tv_integrator_.AddFlow(Hal.now(), flow);


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix typo in sensor readings.
    
    We were reading the wrong sensor for outflow delta.
    
    This was not caught by code review because it was introduced in a "fix
    review comments" change.  It was not caught by a unit test because unit
    tests always feed the same inflow and outflow data.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #294 Update badges in README.md.
1. 👉 #303 Fix typo in sensor readings. 👈 **YOU ARE HERE**
1. #293 Fix trailing whitespace in a README.md file.

</git-pr-chain>
