### PR TITLE
issue #175: push docker image to docker hub when tests pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,13 +93,10 @@ jobs:
           command: |
             docker run -i respiraworks/gui:$CIRCLE_SHA1 gui/test.sh
 
-    gui-push-image:
-      executor: gui-executor
-      filters:
-        branch:
-          only: $CIRCLE_BRANCH #change to `master` only we confirm this works
-      steps:
-        - run:
+  gui-push-image:
+    executor: gui-executor
+    steps:
+      - run:
           name: Push docker image
           command: |
             echo "$DOCKER_HUB_TOKEN" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
@@ -116,6 +113,9 @@ workflows:
             - common-precommit-checks
             - gui-static-analysis
       - gui-push-image:
+          filters:
+            branches:
+              only: $CIRCLE_BRANCH #change to `master` only we confirm this works
           requires:
             - gui-build-image
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,4 +118,3 @@ workflows:
               only: $CIRCLE_BRANCH #change to `master` only we confirm this works
           requires:
             - gui-build-image
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,10 +92,16 @@ jobs:
           name: Run tests
           command: |
             docker run -i respiraworks/gui:$CIRCLE_SHA1 gui/test.sh
+      - persist_to_workspace:
+          root: /var/lib/docker/
+          paths:
+            - image
 
   gui-push-image:
     executor: gui-executor
     steps:
+      - attach_workspace:
+          at: /var/lib/docker/image
       - run:
           name: Push docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+executors:
+  gui-executor:
+    machine:
+      image: ubuntu-1604:201903-01
+
 jobs:
   common-precommit-checks:
     docker:
@@ -38,9 +43,9 @@ jobs:
           name: Run tests
           command: |
             docker run --privileged -t controller-test-image
+
   gui-static-analysis:
-    machine:
-      image: ubuntu-1604:201903-01
+    executor: gui-executor
     steps:
       - checkout
       - run:
@@ -54,8 +59,7 @@ jobs:
             cd ~/project/gui && cppcheck . --error-exitcode=1 && cd -
 
   gui-build-image:
-    machine:
-      image: ubuntu-1604:201903-01
+    executor: gui-executor
     steps:
       - checkout
       - run:
@@ -88,7 +92,14 @@ jobs:
           name: Run tests
           command: |
             docker run -i respiraworks/gui:$CIRCLE_SHA1 gui/test.sh
-      - run:
+
+    gui-push-image:
+      executor: gui-executor
+      filters:
+        branch:
+          only: $CIRCLE_BRANCH #change to `master` only we confirm this works
+      steps:
+        - run:
           name: Push docker image
           command: |
             echo "$DOCKER_HUB_TOKEN" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
@@ -104,3 +115,7 @@ workflows:
           requires:
             - common-precommit-checks
             - gui-static-analysis
+      - gui-push-image:
+          requires:
+            - gui-build-image
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,6 @@ workflows:
       - gui-push-image:
           filters:
             branches:
-              only: $CIRCLE_BRANCH #change to `master` only we confirm this works
+              only: slankard/issue_175-docker-hub-push #change to `master` only we confirm this works
           requires:
             - gui-build-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,11 @@ jobs:
           name: Run tests
           command: |
             docker run -i respiraworks/gui:$CIRCLE_SHA1 gui/test.sh
+      - run:
+          name: Push docker image
+          command: |
+            echo "$DOCKER_HUB_TOKEN" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
+            docker push respiraworks/gui:$CIRCLE_SHA1
 
 workflows:
   commit:


### PR DESCRIPTION
With this change, a successful GUI build & test will result in pushing the Docker image to Docker Hub:
https://hub.docker.com/repository/docker/respiraworks/gui

Since this build works off of the master branch, we can consider these builds "unstable" perhaps and later develop a release process for "stable" builds.