### PR TITLE
Tweak SensorReadings proto.

### DIFF
--- a/common/generated_libs/network_protocol/network_protocol.pb.c
+++ b/common/generated_libs/network_protocol/network_protocol.pb.c
@@ -19,3 +19,8 @@ PB_BIND(SensorReadings, SensorReadings, AUTO)
 
 
 PB_BIND(Alarm, Alarm, AUTO)
+
+
+
+
+

--- a/common/generated_libs/network_protocol/network_protocol.pb.h
+++ b/common/generated_libs/network_protocol/network_protocol.pb.h
@@ -33,9 +33,11 @@ typedef struct _Alarm {
 } Alarm;
 
 typedef struct _SensorReadings {
-    float pressure_cm_h2o;
+    float patient_pressure_cm_h2o;
     float volume_ml;
     float flow_ml_per_min;
+    float inflow_pressure_diff_cm_h2o;
+    float outflow_pressure_diff_cm_h2o;
 } SensorReadings;
 
 typedef struct _VentParams {
@@ -85,18 +87,20 @@ typedef struct _GuiStatus {
 #define GuiStatus_init_default                   {0, VentParams_init_default, 0, {Alarm_init_default, Alarm_init_default, Alarm_init_default, Alarm_init_default}}
 #define ControllerStatus_init_default            {0, VentParams_init_default, SensorReadings_init_default, 0, {Alarm_init_default, Alarm_init_default, Alarm_init_default, Alarm_init_default}, 0, 0}
 #define VentParams_init_default                  {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define SensorReadings_init_default              {0, 0, 0}
+#define SensorReadings_init_default              {0, 0, 0, 0, 0}
 #define Alarm_init_default                       {0, _AlarmKind_MIN}
 #define GuiStatus_init_zero                      {0, VentParams_init_zero, 0, {Alarm_init_zero, Alarm_init_zero, Alarm_init_zero, Alarm_init_zero}}
 #define ControllerStatus_init_zero               {0, VentParams_init_zero, SensorReadings_init_zero, 0, {Alarm_init_zero, Alarm_init_zero, Alarm_init_zero, Alarm_init_zero}, 0, 0}
 #define VentParams_init_zero                     {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-#define SensorReadings_init_zero                 {0, 0, 0}
+#define SensorReadings_init_zero                 {0, 0, 0, 0, 0}
 #define Alarm_init_zero                          {0, _AlarmKind_MIN}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define Alarm_start_time_tag                     1
 #define Alarm_kind_tag                           2
-#define SensorReadings_pressure_cm_h2o_tag       1
+#define SensorReadings_patient_pressure_cm_h2o_tag 1
+#define SensorReadings_inflow_pressure_diff_cm_h2o_tag 4
+#define SensorReadings_outflow_pressure_diff_cm_h2o_tag 5
 #define SensorReadings_volume_ml_tag             2
 #define SensorReadings_flow_ml_per_min_tag       3
 #define VentParams_mode_tag                      1
@@ -161,9 +165,11 @@ X(a, STATIC,   REQUIRED, UINT32,   alarm_hi_breaths_per_min,  13)
 #define VentParams_DEFAULT NULL
 
 #define SensorReadings_FIELDLIST(X, a) \
-X(a, STATIC,   REQUIRED, FLOAT,    pressure_cm_h2o,   1) \
+X(a, STATIC,   REQUIRED, FLOAT,    patient_pressure_cm_h2o,   1) \
 X(a, STATIC,   REQUIRED, FLOAT,    volume_ml,         2) \
-X(a, STATIC,   REQUIRED, FLOAT,    flow_ml_per_min,   3)
+X(a, STATIC,   REQUIRED, FLOAT,    flow_ml_per_min,   3) \
+X(a, STATIC,   REQUIRED, FLOAT,    inflow_pressure_diff_cm_h2o,   4) \
+X(a, STATIC,   REQUIRED, FLOAT,    outflow_pressure_diff_cm_h2o,   5)
 #define SensorReadings_CALLBACK NULL
 #define SensorReadings_DEFAULT NULL
 
@@ -188,9 +194,9 @@ extern const pb_msgdesc_t Alarm_msg;
 
 /* Maximum encoded size of messages (where known) */
 #define GuiStatus_size                           140
-#define ControllerStatus_size                    167
+#define ControllerStatus_size                    177
 #define VentParams_size                          67
-#define SensorReadings_size                      15
+#define SensorReadings_size                      25
 #define Alarm_size                               13
 
 #ifdef __cplusplus

--- a/common/generated_libs/network_protocol/network_protocol.proto
+++ b/common/generated_libs/network_protocol/network_protocol.proto
@@ -203,9 +203,11 @@ enum VentMode {
 }
 
 message SensorReadings {
-  required float pressure_cm_h2o = 1;
+  required float patient_pressure_cm_h2o = 1;
   required float volume_ml = 2;
   required float flow_ml_per_min = 3;
+  required float inflow_pressure_diff_cm_h2o = 4;
+  required float outflow_pressure_diff_cm_h2o = 5;
 }
 
 enum AlarmKind {

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -57,14 +57,14 @@ float Controller::ComputeFanPower(Time now,
   // consistency, we still run the PID iteration above.
   float output;
   if (desired_state.blower_enabled) {
-    output =
-        pid_.Compute(/*time=*/now,
-                     /*input=*/cmH2O(sensor_readings.pressure_cm_h2o).kPa(),
-                     /*setpoint=*/desired_state.setpoint_pressure.kPa());
+    output = pid_.Compute(
+        /*time=*/now,
+        /*input=*/cmH2O(sensor_readings.patient_pressure_cm_h2o).kPa(),
+        /*setpoint=*/desired_state.setpoint_pressure.kPa());
   } else {
     output = 0;
     pid_.Observe(/*time=*/now,
-                 /*input=*/cmH2O(sensor_readings.pressure_cm_h2o).kPa(),
+                 /*input=*/cmH2O(sensor_readings.patient_pressure_cm_h2o).kPa(),
                  /*setpoint=*/desired_state.setpoint_pressure.kPa(),
                  /*output=*/output);
   }

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -163,7 +163,11 @@ SensorReadings Sensors::GetSensorReadings() {
   VolumetricFlow flow =
       PressureDeltaToFlow(inflow_delta) - PressureDeltaToFlow(outflow_delta);
   tv_integrator_.AddFlow(Hal.now(), flow);
-  return {.pressure_cm_h2o = patient_pressure.cmH2O(),
-          .volume_ml = tv_integrator_.GetTV().ml(),
-          .flow_ml_per_min = flow.ml_per_min()};
+  return {
+      .patient_pressure_cm_h2o = patient_pressure.cmH2O(),
+      .volume_ml = tv_integrator_.GetTV().ml(),
+      .flow_ml_per_min = flow.ml_per_min(),
+      .inflow_pressure_diff_cm_h2o = inflow_delta.cmH2O(),
+      .outflow_pressure_diff_cm_h2o = outflow_delta.cmH2O(),
+  };
 }

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -87,11 +87,14 @@ static void DEV_MODE_comms_handler(const ControllerStatus &controller_status,
   }
   last_sent = now;
 
-  debugPrint("%.2f, %.2f, %.2f, %.2f\r\n",
-             controller_status.fan_setpoint_cm_h2o,
-             controller_status.sensor_readings.pressure_cm_h2o,
-             controller_status.sensor_readings.flow_ml_per_min / 1000.0f,
-             controller_status.sensor_readings.volume_ml / 10.f);
+  auto &r = controller_status.sensor_readings;
+  debugPrint("%.2f, ", controller_status.fan_setpoint_cm_h2o);
+  debugPrint("%.2f, ", r.patient_pressure_cm_h2o);
+  debugPrint("%.2f, ", r.inflow_pressure_diff_cm_h2o);
+  debugPrint("%.2f, ", r.outflow_pressure_diff_cm_h2o);
+  debugPrint("%.2f, ", r.flow_ml_per_min / 1000.0f);
+  // debugPrint("%.2f, ", r.volume_ml / 10.f);
+  debugPrint("\n");
 }
 #endif
 

--- a/controller/test/comms/comms_test.cpp
+++ b/controller/test/comms/comms_test.cpp
@@ -30,7 +30,7 @@ TEST(CommTests, SendControllerStatus) {
       std::numeric_limits<uint32_t>::max();
   s.active_params.alarm_hi_breaths_per_min =
       std::numeric_limits<uint32_t>::max();
-  s.sensor_readings.pressure_cm_h2o = 11;
+  s.sensor_readings.patient_pressure_cm_h2o = 11;
   s.sensor_readings.volume_ml = 800;
   s.sensor_readings.flow_ml_per_min = 1000;
 
@@ -51,8 +51,8 @@ TEST(CommTests, SendControllerStatus) {
   EXPECT_EQ(s.uptime_ms, sent.uptime_ms);
   EXPECT_EQ(s.active_params.mode, sent.active_params.mode);
   EXPECT_EQ(s.active_params.peep_cm_h2o, sent.active_params.peep_cm_h2o);
-  EXPECT_EQ(s.sensor_readings.pressure_cm_h2o,
-            sent.sensor_readings.pressure_cm_h2o);
+  EXPECT_EQ(s.sensor_readings.patient_pressure_cm_h2o,
+            sent.sensor_readings.patient_pressure_cm_h2o);
 }
 
 TEST(CommTests, CommandRx) {

--- a/controller/test/sensor_tests/sensors_test.cpp
+++ b/controller/test/sensor_tests/sensors_test.cpp
@@ -88,7 +88,7 @@ TEST(SensorTests, FullScaleReading) {
                              MPXV5004_PressureToVoltage(kPa(1.0)));
 
     auto readings = sensors.GetSensorReadings();
-    float pressurePatient = cmH2O(readings.pressure_cm_h2o).kPa();
+    float pressurePatient = cmH2O(readings.patient_pressure_cm_h2o).kPa();
     EXPECT_NEAR(pressurePatient, p.kPa(), COMPARISON_TOLERANCE);
 
     // Inhalation and exhalation should match because they are fed with the same

--- a/gui/gui_state_container.cpp
+++ b/gui/gui_state_container.cpp
@@ -14,7 +14,7 @@ void GuiStateContainer::update(QAbstractSeries *pressure_series,
     int neg_millis_ago = TimeAMinusB(time, now).count();
     pressure_points.append(
         QPointF(neg_millis_ago * 0.001,
-                controller_status.sensor_readings.pressure_cm_h2o));
+                controller_status.sensor_readings.patient_pressure_cm_h2o));
     flow_points.append(
         QPointF(neg_millis_ago * 0.001,
                 controller_status.sensor_readings.flow_ml_per_min));

--- a/gui/gui_state_container.h
+++ b/gui/gui_state_container.h
@@ -100,7 +100,7 @@ public slots:
 private:
   qreal get_pressure_readout() const {
     std::unique_lock<std::mutex> l(mu_);
-    return history_.GetLastStatus().sensor_readings.pressure_cm_h2o;
+    return history_.GetLastStatus().sensor_readings.patient_pressure_cm_h2o;
   }
   qreal get_flow_readout() const {
     std::unique_lock<std::mutex> l(mu_);

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[]) {
           controller_status->uptime_ms =
               TimeAMinusB(SteadyClock::now(), startup_time).count();
           auto *sensors = &controller_status->sensor_readings;
-          sensors->pressure_cm_h2o =
+          sensors->patient_pressure_cm_h2o =
               15 + 10 * sin(controller_status->uptime_ms * 0.001);
           sensors->flow_ml_per_min =
               120 * sin(controller_status->uptime_ms * 0.003);


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Tweak SensorReadings proto.
    
    - Rename pressure_cm_h2o -> patient_pressure_cm_h2o
    - Add {inflow,outflow}_pressure_cm_h2o.  These values are primarily
      useful for debugging, but it's fine to send them everywhere.
    - Tweak the DEV_MODE serial printf.  Now it's a series of printfs, so
      that it's easy to comment one out.
    
      Volume is commented out in the printf because without something to fix
      the linear component of the volume, it quickly overwhelms the other
      values in the graph, rendering everything else out-of-scale.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #311 Tweak SensorReadings proto. 👈 **YOU ARE HERE**
1. #312 Make Hal::analog{Read,Write} use Voltages.
1. #313 Add BlockInterrupts RAII class.
1. #293 Fix trailing whitespace in a README.md file.

</git-pr-chain>





