### PR TITLE
Make Hal::analog{Read,Write} use Voltages.

### DIFF
--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -24,7 +24,5 @@ void actuators_execute(const ActuatorsState &desired_state) {
                        ? VoltageLevel::HAL_LOW
                        : VoltageLevel::HAL_HIGH);
   // set blower PWM
-  // TODO: create PWM limits in HAL (255) and use this instead
-  Hal.analogWrite(PwmPin::BLOWER,
-                  static_cast<int>(desired_state.fan_power * 255.0f));
+  Hal.analogWrite(PwmPin::BLOWER, desired_state.fan_power);
 }

--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -21,8 +21,8 @@ void actuators_execute(const ActuatorsState &desired_state) {
   // voltage means closed.  Hardware spec: https://bit.ly/3aERr69
   Hal.digitalWrite(BinaryPin::SOLENOID,
                    desired_state.expire_valve_state == ValveState::OPEN
-                       ? VoltageLevel::HAL_LOW
-                       : VoltageLevel::HAL_HIGH);
+                       ? VoltageLevel::LOW
+                       : VoltageLevel::HIGH);
   // set blower PWM
   Hal.analogWrite(PwmPin::BLOWER, desired_state.fan_power);
 }

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -80,7 +80,7 @@ private:
   Pressure ReadPressureSensor(Sensor s);
 
   // Calibrated average sensor values in a zero state.
-  float sensors_zero_vals_[NUM_SENSORS];
+  Voltage sensors_zero_vals_[NUM_SENSORS];
 
   // State related to integrating volume from flow.
   TVIntegrator tv_integrator_;

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -20,9 +20,6 @@ limitations under the License.
 // The canonical list of hardware and the pins they connect to is:
 // https://bit.ly/3aERr69
 //
-// You shouldn't include <Arduino.h> outside of this file; everything that
-// interacts with the hardware should go through here.
-//
 // When running in test mode, HalApi is pedantically a fake, not a mock.  All
 // that means is that the methods have "fake" implementations, trying to
 // loosely mimic the hardware in some defined way.  For example, instead of
@@ -37,6 +34,7 @@ limitations under the License.
 
 #include "algorithm.h"
 #include "units.h"
+#include <stdint.h>
 
 #ifdef TEST_MODE
 
@@ -50,34 +48,12 @@ limitations under the License.
 #include <map>
 #include <vector>
 
-#define HAL_CONSTANT(name) HAL_##name
-
 #else // !TEST_MODE
 
 #if !defined(BARE_STM32)
 #error "When running without TEST_MODE, expecting BARE_STM32 to be defined"
 #endif
 
-#if defined(BARE_STM32)
-#include <stdint.h>
-
-// Some constants that would normally be in the Arduino header
-// which we're not using on the bare system
-
-#define INPUT 0
-#define OUTPUT 1
-#define INPUT_PULLUP 2
-
-#define LOW 0
-#define HIGH 1
-
-#else
-#include <Arduino.h>
-#endif // BARE_STM32
-
-// "HAL" has to be there because the respective Arduino symbols are macros,
-// e.g. A0 expands to 14, so we can't have a constant named A0.
-#define HAL_CONSTANT(name) HAL_##name = name
 #endif // TEST_MODE
 
 // ---------------------------------------------------------------
@@ -87,18 +63,18 @@ limitations under the License.
 // ---------------------------------------------------------------
 
 // Mode of a digital pin.
-// Usage: PinMode::HAL_INPUT etc.
+// Usage: PinMode::INPUT etc.
 enum class PinMode {
   // Test code relies on INPUT being the first enumeration (to get the behavior
   // that INPUT pins are the default).
-  HAL_CONSTANT(INPUT),
-  HAL_CONSTANT(OUTPUT),
-  HAL_CONSTANT(INPUT_PULLUP)
+  INPUT,
+  OUTPUT,
+  INPUT_PULLUP
 };
 
 // Voltage level of a digital pin.
-// Usage: VoltageLevel::HAL_HIGH, HAL_LOW
-enum class VoltageLevel { HAL_CONSTANT(HIGH), HAL_CONSTANT(LOW) };
+// Usage: VoltageLevel::HIGH, LOW
+enum class VoltageLevel { HIGH, LOW };
 
 enum class AnalogPin {
   // MPXV5004DP pressure sensors.
@@ -376,13 +352,13 @@ inline void HalApi::setDigitalPinMode(BinaryPin pin, PinMode mode) {
   binary_pin_modes_[pin] = mode;
 }
 inline void HalApi::digitalWrite(BinaryPin pin, VoltageLevel value) {
-  if (binary_pin_modes_[pin] != PinMode::HAL_OUTPUT) {
+  if (binary_pin_modes_[pin] != PinMode::OUTPUT) {
     throw "Can only write to an OUTPUT pin";
   }
   binary_pin_values_[pin] = value;
 }
 inline void HalApi::analogWrite(PwmPin pin, float duty) {
-  if (pwm_pin_modes_[pin] != PinMode::HAL_OUTPUT) {
+  if (pwm_pin_modes_[pin] != PinMode::OUTPUT) {
     throw "Can only write to an OUTPUT pin";
   }
   pwm_pin_values_[pin] = duty;

--- a/controller/lib/hal/hal_stm32.cpp
+++ b/controller/lib/hal/hal_stm32.cpp
@@ -229,11 +229,11 @@ void HalApi::digitalWrite(BinaryPin pin, VoltageLevel value) {
   }();
 
   switch (value) {
-  case VoltageLevel::HAL_HIGH:
+  case VoltageLevel::HIGH:
     GPIO_SetPin(base, bit);
     break;
 
-  case VoltageLevel::HAL_LOW:
+  case VoltageLevel::LOW:
     GPIO_ClrPin(base, bit);
     break;
   }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Make Hal::analog{Read,Write} use Voltages.
    
    Instead of using raw numbers in the range 0-1024 and 0-255.
    
    This lets us take advantage of the additional ADC and PWM resolution in
    STM32, but it's also just a nicer and more strongly-typed API.
1. Nix HAL_CONSTANT.
    
    This was a workaround for #defines in the Arduino headers, which we are
    rid of.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #312 Make Hal::analog{Read,Write} use Voltages. 👈 **YOU ARE HERE**
1. #313 Add BlockInterrupts RAII class.
1. #293 Fix trailing whitespace in a README.md file.

</git-pr-chain>






