### PR TITLE
Add BlockInterrupts RAII class.

### DIFF
--- a/controller/lib/core/circular_buffer.h
+++ b/controller/lib/core/circular_buffer.h
@@ -44,9 +44,8 @@ public:
 
   // Return number of bytes available in the buffer to read.
   int FullCt() {
-    bool p = Hal.IntSuspend();
+    BlockInterrupts block;
     int ct = head - tail;
-    Hal.IntRestore(p);
     if (ct < 0)
       ct += N;
     return ct;
@@ -59,27 +58,21 @@ public:
   // Get the oldest byte from the buffer.
   // Returns -1 if the buffer is empty
   int Get() {
+    BlockInterrupts block;
     int ret = -1;
-
-    bool p = Hal.IntSuspend();
-
     if (head != tail) {
       ret = buff[tail++];
       if (tail >= N)
         tail = 0;
     }
-
-    Hal.IntRestore(p);
     return ret;
   }
 
   // Add a byte to the buffer
   // Returnes true on success, false if the buffer is full
   bool Put(uint8_t dat) {
+    BlockInterrupts block;
     bool ret = false;
-
-    bool p = Hal.IntSuspend();
-
     int h = head + 1;
     if (h >= N)
       h = 0;
@@ -89,9 +82,6 @@ public:
       head = h;
       ret = true;
     }
-
-    Hal.IntRestore(p);
-
     return ret;
   }
 };

--- a/controller/lib/hal/hal_stm32.cpp
+++ b/controller/lib/hal/hal_stm32.cpp
@@ -142,9 +142,7 @@ void HalApi::init() {
   InitUARTs();
   watchdog_init();
   crc32_init();
-
-  // Enable interrupts
-  Hal.IntEnable();
+  Hal.enableInterrupts();
 }
 
 // Reset the processor
@@ -788,7 +786,7 @@ static void EnableClock(void *ptr) {
   // to crash.  That should make it easier to find the
   // bug during development.
   if (ndx < 0) {
-    Hal.IntDisable();
+    Hal.disableInterrupts();
     while (true) {
     }
   }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Add BlockInterrupts RAII class.
    
    This is a safer C++/RAII way to block and restore interrupts.
    
    This slightly expands the critical section in FullCt().  I could reduce
    it if that's a problem.
    
    Also renames IntEnable/IntDisable to enableInterrupts() and
    disableInterrupts().  These names make it so that it's unnecessary to
    have comments explaining what the functions do.  Also our method names
    start with lower case letters (apparently).

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #313 Add BlockInterrupts RAII class. 👈 **YOU ARE HERE**
1. #293 Fix trailing whitespace in a README.md file.

</git-pr-chain>





