### PR TITLE
Fix Flash/RAM size in STM32 board config.

### DIFF
--- a/boards/custom_stm32.json
+++ b/boards/custom_stm32.json
@@ -26,8 +26,8 @@
   ],
   "name": "ST Nucleo L452RE",
   "upload": {
-    "maximum_ram_size": 65536,
-    "maximum_size": 262144,
+    "maximum_ram_size": 163840,
+    "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
       "jlink",


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix Flash/RAM size in STM32 board config.
    
    See https://en.wikipedia.org/wiki/STM32, which lists the specs better
    than anything else I have found.
    
    Patch by sglow@ in issue_301_debug_interface.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #338 Fix Flash/RAM size in STM32 board config. 👈 **YOU ARE HERE**
1. #347 Bitfield-ify UART timeout field.
1. #340 Bitfield-ify UART `request` field.
1. #348 Bitfield-ify UART status register.
1. #342 Bitfield-ify UART intClear register.
1. #343 C++ nits in uart_dma.
1. #344 Templatize CircularBuffer's datatype.

</git-pr-chain>






