### PR TITLE
Bitfield-ify UART timeout field.

### DIFF
--- a/controller/lib/hal/hal_stm32_regs.h
+++ b/controller/lib/hal/hal_stm32_regs.h
@@ -17,7 +17,8 @@ typedef volatile uint8_t BREG;
 // to configure various modules (like timers, serial ports, etc).
 // Detailed information on these modules and the registers
 // used to configure them can be found in the reference
-// manual for this chip.
+// manual for this chip:
+// https://www.st.com/resource/en/reference_manual/dm00151940-stm32l41xxx42xxx43xxx44xxx45xxx46xxx-advanced-armbased-32bit-mcus-stmicroelectronics.pdf
 ///////////////////////////////////////////////////////////////
 
 // Reset & clock controller
@@ -172,7 +173,13 @@ struct UART_Regs {
   } ctrl3;
   REG baud;
   REG guard;
-  REG timeout;
+  union {
+    struct {
+      REG rto : 24; // receiver timeout
+      REG blen : 8; // block length
+    } s;
+    REG r;
+  } timeout;
   REG request;
   REG status;
   REG intClear;

--- a/controller/lib/hal/uart_dma.cpp
+++ b/controller/lib/hal/uart_dma.cpp
@@ -145,7 +145,7 @@ bool UART_DMA::startRX(const char *buf, const uint32_t length,
 
   // setup rx timeout
   // max timeout is 24 bit
-  uart->timeout = timeout & 0x00FFFFFF;
+  uart->timeout.s.rto = timeout & 0x00FFFFFF;
   uart->intClear = (1 << 11); // Clear rx timeout flag
   uart->request = (1 << 3);   // Clear RXNE flag
   uart->ctrl1.s.rtoie = 1;    // Enable receive timeout interrupt


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Bitfield-ify UART timeout field.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #337 Move sprintf.{h,cpp} to new debug library.
1. #338 Fix Flash/RAM size in STM32 board config.
1. 👉 #339 Bitfield-ify UART timeout field. 👈 **YOU ARE HERE**
1. #340 Bitfield-ify UART `request` field.
1. #341 Bitfield-ify UART status register.
1. #342 Bitfield-ify UART intClear register.
1. #343 C++ nits in uart_dma.
1. #344 Templatize CircularBuffer's datatype.

</git-pr-chain>



