### PR TITLE
C++ nits in uart_dma.

### DIFF
--- a/controller/lib/hal/uart_dma.cpp
+++ b/controller/lib/hal/uart_dma.cpp
@@ -19,8 +19,6 @@
 
 extern UART_DMA dmaUART;
 
-// TODO(jlebar): "inline" functions here should be static.
-
 // Performs UART3 initialization
 void UART_DMA::init(int baud) {
   // Set baud rate register
@@ -175,16 +173,16 @@ void UART_DMA::stopRX() {
   }
 }
 
-inline bool isCharacterMatchInterrupt() {
+static bool isCharacterMatchInterrupt() {
   return UART3_BASE->status.s.cmf != 0;
 }
 
-inline bool isRxTimeout() {
+static bool isRxTimeout() {
   // Timeout interrupt enable and RTOF - Receiver timeout
   return UART3_BASE->ctrl1.s.rtoie && UART3_BASE->status.s.rtof;
 }
 
-inline bool isRxError() {
+static bool isRxError() {
   return isRxTimeout() || UART3_BASE->status.s.ore || // overrun error
          UART3_BASE->status.s.fe;                     // frame error
 
@@ -193,7 +191,7 @@ inline bool isRxError() {
   // UART3_BASE->status.s.nf || // START bit noise detection flag
 }
 
-inline void UART_DMA::UART_ISR() {
+void UART_DMA::UART_ISR() {
   if (isRxError()) {
     RxError_t e = RxError_t::RX_ERROR_UNKNOWN;
     if (isRxTimeout()) {
@@ -225,7 +223,7 @@ inline void UART_DMA::UART_ISR() {
   }
 }
 
-inline void UART_DMA::DMA_TX_ISR() {
+void UART_DMA::DMA_TX_ISR() {
   if (dma->intStat.teif2) {
     stopTX();
     txListener.onTxError();
@@ -235,7 +233,7 @@ inline void UART_DMA::DMA_TX_ISR() {
   }
 }
 
-inline void UART_DMA::DMA_RX_ISR() {
+void UART_DMA::DMA_RX_ISR() {
   if (dma->intStat.teif3) {
     stopRX();
     rxListener.onRxError(RxError_t::RX_ERROR_DMA);

--- a/controller/lib/hal/uart_dma.h
+++ b/controller/lib/hal/uart_dma.h
@@ -2,13 +2,13 @@
 #define __UART_DMA
 #include "hal_stm32_regs.h"
 
-typedef enum {
+enum RxError_t {
   RX_ERROR_UNKNOWN,
   RX_ERROR_OVR,
   RX_ERROR_FRAMING,
   RX_ERROR_TIMEOUT,
   RX_ERROR_DMA
-} RxError_t;
+};
 
 // An interface that gets called back by the driver on rx, tx complete
 // and rx character match events.
@@ -35,7 +35,7 @@ class DMACtrl {
   DMA_Regs *const dma;
 
 public:
-  DMACtrl(DMA_Regs *const dma) : dma(dma) {}
+  explicit DMACtrl(DMA_Regs *const dma) : dma(dma) {}
   void init() {
     // UART3 reception happens on DMA1 channel 3
     dma->chanSel.c3s = 0b0010;
@@ -83,7 +83,7 @@ public:
   // setup. Returns true if no reception is in progress and new reception
   // was setup.
 
-  bool startRX(const char *buf, const uint32_t length, const uint32_t timeout);
+  bool startRX(const char *buf, uint32_t length, uint32_t timeout);
   void stopRX();
   void charMatchEnable();
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. C++ nits in uart_dma.
    
    - "inline" should only be used on functions in header files.  In modern
      C and C++, it is a directive to the linker that a function should be
      deduplicated.  See https://en.cppreference.com/w/cpp/language/inline,
      "The original intent of the inline keyword..."
    
      Functions which are "private" to .cpp files should be marked static.
      This prevents an ODR violation (undefined behavior) which would occur
      if a different cpp file defined a function of the same name.
    
    - Marked a one-arg constructor as "explicit".  Most one-arg constructors
      should be explicit; see https://en.cppreference.com/w/cpp/language/explicit.
    
    - Got rid of `const uint32_t` in function declaration.  This is a nit,
      and a weird corner-case in C++.  Behold.
    
      The intent of this `const` is to prevent the definition of the
      function from modifying the const variable.  But
    
       (a) The definition may or may not specify const; it doesn't actually
           matter what the declaration says!
    
       (b) We could say, the declaration should match the definition.  But
           the caller cannot observe whether or not the callee modifies an
           argument that's passed by value.  Because it's not observable, it
           shouldn't be part of the API, i.e. it shouldn't be in the header.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #343 C++ nits in uart_dma. 👈 **YOU ARE HERE**
1. #344 Templatize CircularBuffer's datatype.

</git-pr-chain>













