### PR TITLE
Adds bare-bones lambda-based DebugVar

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,7 +29,8 @@ Checks: >
   -modernize-use-default-member-init,
   -misc-non-private-member-variables-in-classes,
   -readability-implicit-bool-conversion,
-  -modernize-use-using
+  -modernize-use-using,
+  -modernize-use-nodiscard
 
 WarningsAsErrors: '*'
 

--- a/controller/lib/debug/vars.cpp
+++ b/controller/lib/debug/vars.cpp
@@ -1,0 +1,22 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "vars.h"
+#include "debug.h"
+#include <string.h>
+
+// static member variables
+UntypedDebugVar *DebugVarRegistry::all_vars[100] = {nullptr};
+int DebugVarRegistry::var_count = 0;

--- a/controller/lib/debug/vars.h
+++ b/controller/lib/debug/vars.h
@@ -1,0 +1,141 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Defines an interface for creating debug variables.
+//
+// All debug variables must have a 32-bit value: int32_t, uint32_t, or float.
+// They are declared using DebugVar that takes a name, help string,
+// printf format string, and getter and setter lambdas:
+//
+//   DebugVar var("speed", "The vehicle speed", "%.3f",
+//     [&] { return ...; },
+//     [&](float value) { ... });
+//
+// All debug variables in the program are accessible via a static registry:
+//
+//   DebugVarRegistry::GetVar(i) is valid for all i in [0, N)
+//   where N = DebugVarRegistry::GetNumVars().
+//
+#ifndef VARS_H
+#define VARS_H
+
+#include "debug.h"
+#include <stdint.h>
+#include <type_traits>
+
+// Defines the type of variable
+enum class VarType {
+  INT32 = 1,
+  UINT32 = 2,
+  FLOAT = 3,
+};
+
+#define ARRAY_CT(a) (sizeof(a) / sizeof((a)[0]))
+
+class UntypedDebugVar;
+
+class DebugVarRegistry {
+public:
+  static uint16_t Register(UntypedDebugVar *var) {
+    if (var_count < static_cast<int>(ARRAY_CT(all_vars)))
+      all_vars[var_count++] = var;
+    return static_cast<uint16_t>(var_count - 1);
+  }
+
+  static UntypedDebugVar *GetVar(uint16_t vid) {
+    if (vid >= ARRAY_CT(all_vars))
+      return nullptr;
+    return all_vars[vid];
+  }
+
+  static int GetNumVars() { return var_count; }
+
+private:
+  // List of all the variables in the system.
+  // Increase size as necessary
+  static UntypedDebugVar *all_vars[100];
+  static int var_count;
+};
+
+#undef ARRAY_CT
+
+class UntypedDebugVar {
+public:
+  UntypedDebugVar(const char *name, const char *help, const char *fmt,
+                  VarType type)
+      : name_(name), help_(help), fmt_(fmt), type_(type),
+        id_(DebugVarRegistry::Register(this)) {}
+
+  virtual uint32_t as_uint32() = 0;
+  virtual void set_uint32(uint32_t value) = 0;
+
+  const char *name() const { return name_; }
+  const char *help() const { return help_; }
+  const char *fmt() const { return fmt_; }
+  VarType type() const { return type_; }
+  uint16_t id() const { return id_; }
+
+private:
+  const char *const name_;
+  const char *const help_;
+  const char *const fmt_;
+  const VarType type_;
+  const uint16_t id_;
+};
+
+template <typename X> VarType type_to_enum();
+template <> inline constexpr VarType type_to_enum<int32_t>() {
+  return VarType::INT32;
+}
+template <> inline constexpr VarType type_to_enum<uint32_t>() {
+  return VarType::UINT32;
+}
+template <> inline constexpr VarType type_to_enum<float>() {
+  return VarType::FLOAT;
+}
+
+template <typename GetFn, typename SetFn>
+class DebugVar : public UntypedDebugVar {
+public:
+  using ValueT = std::invoke_result_t<GetFn>;
+
+  // @param name Name of the variable
+  // @param help String that the Python code displays describing the variable.
+  // @param fmt printf style format string.  This is a hint to the Python code
+  // as to how the variable data should be displayed.
+  // @param get A lambda for returning the current value with signature: T get()
+  // @param set A lambda for setting the value with signature: void set(T value)
+  DebugVar(const char *name, const char *help, const char *fmt, GetFn get,
+           SetFn set)
+      : UntypedDebugVar(name, help, fmt, type_to_enum<ValueT>()), get_fn_(get),
+        set_fn_(set) {}
+
+  ValueT Get() { return get_fn_(); }
+  void Set(ValueT t) { set_fn_(t); }
+
+  uint32_t as_uint32() override {
+    ValueT res = Get();
+    return *reinterpret_cast<uint32_t *>(&res);
+  }
+  void set_uint32(uint32_t value) override {
+    Set(*reinterpret_cast<ValueT *>(&value));
+  }
+
+private:
+  GetFn get_fn_;
+  SetFn set_fn_;
+};
+
+#endif

--- a/controller/test/debug/vars_test.cpp
+++ b/controller/test/debug/vars_test.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "vars.h"
+#include "gtest/gtest.h"
+#include <stdint.h>
+
+TEST(DebugVar, DebugVarInt32) {
+  int32_t value = 5;
+  DebugVar var(
+      "var", "help", "fmt", [&] { return value; },
+      [&](int32_t v) { value = v; });
+  EXPECT_EQ(5, var.Get());
+  EXPECT_EQ(5, var.as_uint32());
+
+  var.Set(7);
+  EXPECT_EQ(7, var.Get());
+  EXPECT_EQ(7, var.as_uint32());
+
+  var.set_uint32(42);
+  EXPECT_EQ(42, var.Get());
+  EXPECT_EQ(42, var.as_uint32());
+}
+
+TEST(DebugVar, DebugVarFloatRoundtrip) {
+  float value = 42.37f;
+  DebugVar var(
+      "var", "help", "fmt", [&] { return value; }, [&](float v) { value = v; });
+
+  EXPECT_EQ(42.37f, var.Get());
+
+  var.Set(var.Get());
+  EXPECT_EQ(42.37f, var.Get());
+
+  var.set_uint32(var.as_uint32());
+  EXPECT_EQ(42.37f, var.Get());
+
+  var.set_uint32(0xDEADBEEF);
+  EXPECT_EQ(0xDEADBEEF, var.as_uint32());
+
+  float new_value = var.Get();
+  var.Set(new_value);
+  EXPECT_EQ(new_value, var.Get());
+  EXPECT_EQ(0xDEADBEEF, var.as_uint32());
+}
+
+TEST(DebugVar, Registration) {
+  int32_t int_value = 5;
+  DebugVar var1(
+      "var1", "help1", "fmt1", [&] { return int_value; },
+      [&](int32_t v) { int_value = v; });
+
+  float float_value = 7;
+  DebugVar var2(
+      "var2", "help2", "fmt2", [&] { return float_value; },
+      [&](float v) { float_value = v; });
+
+  auto *untyped_var1 = DebugVarRegistry::GetVar(var1.id());
+  EXPECT_EQ("var1", untyped_var1->name());
+  EXPECT_EQ("help1", untyped_var1->help());
+  EXPECT_EQ("fmt1", untyped_var1->fmt());
+  EXPECT_EQ(VarType::INT32, untyped_var1->type());
+  EXPECT_EQ(var1.id(), untyped_var1->id());
+
+  auto *untyped_var2 = DebugVarRegistry::GetVar(var2.id());
+  EXPECT_EQ("var2", untyped_var2->name());
+  EXPECT_EQ("help2", untyped_var2->help());
+  EXPECT_EQ("fmt2", untyped_var2->fmt());
+  EXPECT_EQ(VarType::FLOAT, untyped_var2->type());
+  EXPECT_EQ(var2.id(), untyped_var2->id());
+}


### PR DESCRIPTION
This begins the disassembly of https://github.com/RespiraWorks/VentilatorSoftware/pull/302 into more easily reviewable chunks in order to get it into master.

Based on @sglow 's code but:
* has lambdas instead of pointers or virtual methods - this ends up being both more concise and more versatile. C++17 template deduction helps us do this without std::function, which would have incurred allocation.
* has tests
* does not have integration with any debug commands (because there are no debug commands at master yet)

Part of #301 .