### PR TITLE
Add functionality to units

### DIFF
--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -112,26 +112,21 @@ protected:
 
 // Represents a Scalar where:
 // - addition and subtraction are well-defined
-// - multiplication by an external factor of type ValTy is defined
-// This is what mathematicians call a "module":
-// https://en.wikipedia.org/wiki/Module_(mathematics)
-// Note that multiplication by an external factor requires multiplication to be
-// well defined on ValTy type.
-// Be aware that dividing by 0.0f yields Inf and needs to be protected.
+// - multiplication and division by an external factor of type ValTy is defined
+//
+// Note that multiplication and division by an external factor require
+// multiplication and division to be well defined on ValTy type.
+// Be aware that dividing by 0 yields Inf and needs to be protected.
 template <class Q, class ValTy> class ArithScalar : public Scalar<Q, ValTy> {
 public:
   constexpr Q operator+(const ArithScalar &a) { return Q(this->val_ + a.val_); }
   constexpr Q operator-(const ArithScalar &a) { return Q(this->val_ - a.val_); }
-  inline ArithScalar &operator+=(const ArithScalar &a) {
-    return *this = *this + a;
-  }
-  inline ArithScalar &operator-=(const ArithScalar &a) {
-    return *this = *this - a;
-  }
+  ArithScalar &operator+=(const ArithScalar &a) { return *this = *this + a; }
+  ArithScalar &operator-=(const ArithScalar &a) { return *this = *this - a; }
   constexpr Q operator*(const ValTy &a) { return Q(this->val_ * a); }
   constexpr Q operator/(const ValTy &a) { return Q(this->val_ / a); }
-  inline ArithScalar &operator*=(const ValTy &a) { return *this = *this * a; }
-  inline ArithScalar &operator/=(const ValTy &a) { return *this = *this / a; }
+  ArithScalar &operator*=(const ValTy &a) { return *this = *this * a; }
+  ArithScalar &operator/=(const ValTy &a) { return *this = *this / a; }
   constexpr friend Q operator*(const ValTy &a, const Q &b) {
     return Q(b.val_ * a);
   }
@@ -152,10 +147,6 @@ protected:
 //  - cm h2o (centimeters of water)
 //
 // Native unit (implementation detail): kPa
-//
-// Note that multiplying and dividing pressure by a float makes little sense,
-// as they are not an absolute value.
-// Division may be used to define an average.
 class Pressure : public units_detail::ArithScalar<Pressure, float> {
 public:
   [[nodiscard]] constexpr float kPa() const { return val_; }
@@ -212,8 +203,8 @@ constexpr Length millimeters(float mm) { return Length(mm / 1000); }
 //
 // Native unit (implementation detail): meters^3/sec
 //
-// Dividing a Volume (see below) by a Duration gives you a VolumetricFlow
-// Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume
+// Dividing a Volume by a Duration (see below) gives you a VolumetricFlow.
+// Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
 class VolumetricFlow : public units_detail::ArithScalar<VolumetricFlow, float> {
 public:
   [[nodiscard]] constexpr float cubic_m_per_sec() { return val_; }
@@ -251,8 +242,8 @@ constexpr VolumetricFlow liters_per_sec(float lps) {
 //
 // Native unit (implementation detail): meters^3
 //
-// Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume
-// Dividing a Volume by a Duration gives you a VolumetricFlow
+// Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume.
+// Dividing a Volume by a Duration gives you a VolumetricFlow.
 class Volume : public units_detail::ArithScalar<Volume, float> {
 public:
   [[nodiscard]] constexpr float cubic_m() { return val_; }
@@ -313,8 +304,8 @@ class Time;
 //
 // Native unit (implementation detail): int64_t miliseconds
 //
-// Multiplying a VolumetricFlow by a Duration gives you a Volume
-// Dividing a Volume by a Duration gives you a VolumetricFlow
+// Multiplying a VolumetricFlow by a Duration gives you a Volume.
+// Dividing a Volume by a Duration gives you a VolumetricFlow.
 class Duration : public units_detail::Scalar<Duration, int64_t> {
 public:
   [[nodiscard]] constexpr int64_t milliseconds() const { return val_; }
@@ -404,7 +395,7 @@ constexpr inline Volume operator*(Duration b, VolumetricFlow a) {
   return ml(a.ml_per_min() * b.minutes());
 }
 
-// Be aware that dividing by zero leads to Inf and needs to be protected
+// Be aware that dividing by zero leads to Inf and needs to be protected.
 constexpr inline VolumetricFlow operator/(Volume a, Duration b) {
   return ml_per_min(a.ml() / b.minutes());
 }

--- a/common/libs/units/units.h
+++ b/common/libs/units/units.h
@@ -115,10 +115,36 @@ template <class Q, class ValTy> class ArithScalar : public Scalar<Q, ValTy> {
 public:
   constexpr Q operator+(const ArithScalar &a) { return Q(this->val_ + a.val_); }
   constexpr Q operator-(const ArithScalar &a) { return Q(this->val_ - a.val_); }
+  inline ArithScalar &operator+=(const ArithScalar &a) {
+    return *this = *this + a;
+  }
+  inline ArithScalar &operator-=(const ArithScalar &a) {
+    return *this = *this - a;
+  }
 
 protected:
   // Pull in base class's constructor.
   using Scalar<Q, ValTy>::Scalar;
+};
+
+// Represents an ArithScalar where multiplication by an external factor of type
+// ValTy is defined, creating what mathematicians call a "module":
+// https://en.wikipedia.org/wiki/Module_(mathematics)
+// Multiplication by a ValTy factor follows the rules of multiplication for
+// ValTy, and requires multiplication to be well defined on ValTy type, except
+// that it does not commute: float*ModuleScalar is undefined
+// This is especially useful for things that need averaging.
+// Be aware that dividing by 0.0f yields Inf and needs to be protected.
+template <class Q, class ValTy>
+class ModuleScalar : public ArithScalar<Q, ValTy> {
+public:
+  constexpr Q operator*(const ValTy &a) { return Q(this->val_ * a); }
+  constexpr Q operator/(const ValTy &a) { return Q(this->val_ / a); }
+  inline ModuleScalar &operator*=(const ValTy &a) { return *this = *this * a; }
+  inline ModuleScalar &operator/=(const ValTy &a) { return *this = *this / a; }
+
+protected:
+  using ArithScalar<Q, ValTy>::ArithScalar;
 };
 
 } // namespace units_detail
@@ -176,6 +202,10 @@ private:
 constexpr Length meters(float meters) { return Length(meters); }
 constexpr Length millimeters(float mm) { return Length(mm / 1000); }
 
+// pre-declare duration and volume in order to reference them in VolumetricFlow
+// definition
+class Duration;
+class Volume;
 // Represents flow over time, the rate of air passing through a tube.
 //
 // Precision: float.
@@ -187,20 +217,28 @@ constexpr Length millimeters(float mm) { return Length(mm / 1000); }
 //   - liters/sec
 //
 // Native unit (implementation detail): meters^3/sec
-class VolumetricFlow : public units_detail::ArithScalar<VolumetricFlow, float> {
+//
+// Dividing a Volume (see below) by a Duration gives you a VolumetricFlow
+// Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume
+class VolumetricFlow
+    : public units_detail::ModuleScalar<VolumetricFlow, float> {
 public:
   [[nodiscard]] constexpr float cubic_m_per_sec() { return val_; }
   [[nodiscard]] constexpr float ml_per_min() {
     return val_ * 1000.0f * 1000.0f * 60.0f;
   }
   [[nodiscard]] constexpr float liters_per_sec() { return val_ * 1000.0f; }
+  constexpr friend Volume operator*(const VolumetricFlow &a, const Duration &b);
+  constexpr friend Volume operator*(const Duration &b, const VolumetricFlow &a);
+  // Be aware that deviding by 0 yields Inf and needs to be protected.
+  constexpr friend VolumetricFlow operator/(const Volume &a, const Duration &b);
 
 private:
   constexpr friend VolumetricFlow cubic_m_per_sec(float m3ps);
   constexpr friend VolumetricFlow ml_per_min(float ml_per_min);
   constexpr friend VolumetricFlow liters_per_sec(float lps);
 
-  using units_detail::ArithScalar<VolumetricFlow, float>::ArithScalar;
+  using units_detail::ModuleScalar<VolumetricFlow, float>::ModuleScalar;
 };
 
 constexpr VolumetricFlow cubic_m_per_sec(float m3ps) {
@@ -223,16 +261,23 @@ constexpr VolumetricFlow liters_per_sec(float lps) {
 //   - mL
 //
 // Native unit (implementation detail): meters^3
-class Volume : public units_detail::ArithScalar<Volume, float> {
+//
+// Multiplying a VolumetricFlow by a Duration (see below) gives you a Volume
+// Dividing a Volume by a Duration gives you a VolumetricFlow
+class Volume : public units_detail::ModuleScalar<Volume, float> {
 public:
   [[nodiscard]] constexpr float cubic_m() { return val_; }
   [[nodiscard]] constexpr float ml() { return val_ * 1000.0f * 1000.0f; }
+  constexpr friend Volume operator*(const VolumetricFlow &a, const Duration &b);
+  constexpr friend Volume operator*(const Duration &b, const VolumetricFlow &a);
+  // Be aware that deviding by seconds(0) yields Inf and needs to be protected.
+  constexpr friend VolumetricFlow operator/(const Volume &a, const Duration &b);
 
 private:
   constexpr friend Volume cubic_m(float m3);
   constexpr friend Volume ml(float ml);
 
-  using units_detail::ArithScalar<Volume, float>::ArithScalar;
+  using units_detail::ModuleScalar<Volume, float>::ModuleScalar;
 };
 
 constexpr Volume cubic_m(float m3) { return Volume(m3); }
@@ -282,6 +327,9 @@ class Time;
 //  - milliseconds
 //
 // Native unit (implementation detail): int64_t miliseconds
+//
+// Multiplying a VolumetricFlow by a Duration gives you a Volume
+// Dividing a Volume by a Duration gives you a VolumetricFlow
 class Duration : public units_detail::Scalar<Duration, int64_t> {
 public:
   [[nodiscard]] constexpr int64_t milliseconds() const { return val_; }
@@ -296,6 +344,10 @@ public:
   constexpr friend Time operator+(const Duration &a, const Time &b);
   constexpr friend Time operator-(const Time &a, const Duration &b);
   constexpr friend Duration operator-(const Time &a, const Time &b);
+  constexpr friend Volume operator*(const VolumetricFlow &a, const Duration &b);
+  constexpr friend Volume operator*(const Duration &b, const VolumetricFlow &a);
+  // Be aware that deviding by 0 yields Inf and needs to be protected.
+  constexpr friend VolumetricFlow operator/(const Volume &a, const Duration &b);
 
 private:
   constexpr friend Duration milliseconds(int64_t millis);
@@ -361,6 +413,18 @@ constexpr inline Time operator-(const Time &t, const Duration &dt) {
 }
 constexpr inline Duration operator-(const Time &a, const Time &b) {
   return Duration(static_cast<int64_t>(a.val_ - b.val_));
+}
+
+constexpr inline Volume operator*(const VolumetricFlow &a, const Duration &b) {
+  return Volume(a.val_ * static_cast<float>(b.val_) / 1000.0f);
+}
+
+constexpr inline Volume operator*(const Duration &b, const VolumetricFlow &a) {
+  return Volume(a.val_ * static_cast<float>(b.val_) / 1000.0f);
+}
+
+constexpr inline VolumetricFlow operator/(const Volume &a, const Duration &b) {
+  return VolumetricFlow(a.val_ / static_cast<float>(b.val_) * 1000.0f);
 }
 
 #endif // UNITS_H

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -125,8 +125,7 @@ void TVIntegrator::AddFlow(Time now, VolumetricFlow flow) {
   //  - Measure time with better than millisecond granularity.
   Duration delta = now - last_flow_measurement_time_;
   if (delta >= VOLUME_INTEGRAL_INTERVAL) {
-    volume_ =
-        volume_ + ml(delta.minutes() * (last_flow_ + flow).ml_per_min() / 2.0f);
+    volume_ += (delta * ((last_flow_ + flow) / 2.0f));
     last_flow_measurement_time_ = now;
     last_flow_ = flow;
   }

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -125,7 +125,7 @@ void TVIntegrator::AddFlow(Time now, VolumetricFlow flow) {
   //  - Measure time with better than millisecond granularity.
   Duration delta = now - last_flow_measurement_time_;
   if (delta >= VOLUME_INTEGRAL_INTERVAL) {
-    volume_ += (delta * ((last_flow_ + flow) / 2.0f));
+    volume_ += delta * (last_flow_ + flow) / 2.0f;
     last_flow_measurement_time_ = now;
     last_flow_ = flow;
   }

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -57,6 +57,14 @@ TEST(Units, Pressure) {
   EXPECT_FLOAT_EQ(pressure.kPa(), 3.0f);
   pressure -= kPa(5);
   EXPECT_FLOAT_EQ(pressure.kPa(), -2.0f);
+  pressure /= -2.0f;
+  EXPECT_FLOAT_EQ(pressure.kPa(), 1.0f);
+  pressure *= -5.0f;
+  EXPECT_FLOAT_EQ(pressure.kPa(), -5.0f);
+
+  EXPECT_FLOAT_EQ((cmH2O(1) * 10.1972f).kPa(), 1);
+  EXPECT_FLOAT_EQ((10.1972f * cmH2O(1)).kPa(), 1);
+  EXPECT_FLOAT_EQ((kPa(1) / 10.1972f).cmH2O(), 1);
 }
 
 TEST(Units, Length) {
@@ -76,6 +84,14 @@ TEST(Units, Length) {
   EXPECT_FLOAT_EQ(length.meters(), 3.0f);
   length -= meters(5);
   EXPECT_FLOAT_EQ(length.meters(), -2.0f);
+  length /= -2.0f;
+  EXPECT_FLOAT_EQ(length.meters(), 1.0f);
+  length *= -5.0f;
+  EXPECT_FLOAT_EQ(length.meters(), -5.0f);
+
+  EXPECT_FLOAT_EQ((millimeters(1) * 1000.0f).meters(), 1);
+  EXPECT_FLOAT_EQ((1000.0f * millimeters(1)).meters(), 1);
+  EXPECT_FLOAT_EQ((meters(1) / 1000.0f).millimeters(), 1);
 }
 
 TEST(Units, VolumetricFlow) {
@@ -112,6 +128,7 @@ TEST(Units, VolumetricFlow) {
   EXPECT_FLOAT_EQ(flow.liters_per_sec(), -5.0f);
 
   EXPECT_FLOAT_EQ((liters_per_sec(1) * 1000.0f).cubic_m_per_sec(), 1);
+  EXPECT_FLOAT_EQ((1000.0f * liters_per_sec(1)).cubic_m_per_sec(), 1);
   EXPECT_FLOAT_EQ((cubic_m_per_sec(1) / 1000.0f).liters_per_sec(), 1);
 
   EXPECT_FLOAT_EQ((cubic_m(1) / seconds(1)).cubic_m_per_sec(), 1);

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -51,6 +51,12 @@ TEST(Units, Pressure) {
 
   checkRelationalOperators(kPa);
   checkRelationalOperators(cmH2O);
+
+  Pressure pressure = kPa(2);
+  pressure += kPa(1);
+  EXPECT_FLOAT_EQ(pressure.kPa(), 3.0f);
+  pressure -= kPa(5);
+  EXPECT_FLOAT_EQ(pressure.kPa(), -2.0f);
 }
 
 TEST(Units, Length) {
@@ -64,6 +70,12 @@ TEST(Units, Length) {
 
   checkRelationalOperators(meters);
   checkRelationalOperators(millimeters);
+
+  Length length = meters(2);
+  length += meters(1);
+  EXPECT_FLOAT_EQ(length.meters(), 3.0f);
+  length -= meters(5);
+  EXPECT_FLOAT_EQ(length.meters(), -2.0f);
 }
 
 TEST(Units, VolumetricFlow) {
@@ -87,6 +99,22 @@ TEST(Units, VolumetricFlow) {
 
   checkRelationalOperators(cubic_m_per_sec);
   checkRelationalOperators(ml_per_min);
+  checkRelationalOperators(liters_per_sec);
+
+  VolumetricFlow flow = liters_per_sec(2);
+  flow += liters_per_sec(1);
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 3.0f);
+  flow -= liters_per_sec(5);
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), -2.0f);
+  flow /= -2.0f;
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 1.0f);
+  flow *= -5.0f;
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), -5.0f);
+
+  EXPECT_FLOAT_EQ((liters_per_sec(1) * 1000.0f).cubic_m_per_sec(), 1);
+  EXPECT_FLOAT_EQ((cubic_m_per_sec(1) / 1000.0f).liters_per_sec(), 1);
+
+  EXPECT_FLOAT_EQ((cubic_m(1) / seconds(1)).cubic_m_per_sec(), 1);
 }
 
 TEST(Units, Volume) {
@@ -100,6 +128,22 @@ TEST(Units, Volume) {
 
   checkRelationalOperators(cubic_m);
   checkRelationalOperators(ml);
+
+  Volume volume = ml(2);
+  volume += ml(1);
+  EXPECT_FLOAT_EQ(volume.ml(), 3.0f);
+  volume -= ml(5);
+  EXPECT_FLOAT_EQ(volume.ml(), -2.0f);
+  volume /= -2.0f;
+  EXPECT_FLOAT_EQ(volume.ml(), 1.0f);
+  volume *= -5.0f;
+  EXPECT_FLOAT_EQ(volume.ml(), -5.0f);
+
+  EXPECT_FLOAT_EQ((cubic_m(1) / 1e6f).ml(), 1);
+  EXPECT_FLOAT_EQ((ml(1) * 1e6f).cubic_m(), 1);
+
+  EXPECT_FLOAT_EQ((cubic_m_per_sec(1) * seconds(1)).cubic_m(), 1);
+  EXPECT_FLOAT_EQ((seconds(1) * cubic_m_per_sec(1)).cubic_m(), 1);
 }
 
 TEST(Units, Duration) {
@@ -131,6 +175,11 @@ TEST(Units, Time) {
   EXPECT_FLOAT_EQ((ms(1000) - millisSinceStartup(500)).seconds(), 0.5f);
   // Negative times are not supported:
   // EXPECT_EQ((ms(500) - ms(1000)).seconds(), ???);
+  Time time = ms(2000);
+  time += milliseconds(1000);
+  EXPECT_EQ(time.millisSinceStartup(), static_cast<uint64_t>(3000));
+  time -= milliseconds(2000);
+  EXPECT_EQ(time.millisSinceStartup(), static_cast<uint64_t>(1000));
 
   checkRelationalOperators(millisSinceStartup);
 }

--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -52,19 +52,19 @@ TEST(Units, Pressure) {
   checkRelationalOperators(kPa);
   checkRelationalOperators(cmH2O);
 
-  Pressure pressure = kPa(2);
-  pressure += kPa(1);
-  EXPECT_FLOAT_EQ(pressure.kPa(), 3.0f);
-  pressure -= kPa(5);
+  Pressure pressure = kPa(2.1f);
+  pressure += kPa(1.2f);
+  EXPECT_FLOAT_EQ(pressure.kPa(), 3.3f);
+  pressure -= kPa(5.3f);
   EXPECT_FLOAT_EQ(pressure.kPa(), -2.0f);
-  pressure /= -2.0f;
-  EXPECT_FLOAT_EQ(pressure.kPa(), 1.0f);
-  pressure *= -5.0f;
-  EXPECT_FLOAT_EQ(pressure.kPa(), -5.0f);
+  pressure /= -0.5f;
+  EXPECT_FLOAT_EQ(pressure.kPa(), 4.0f);
+  pressure *= -2.5f;
+  EXPECT_FLOAT_EQ(pressure.kPa(), -10.0f);
 
-  EXPECT_FLOAT_EQ((cmH2O(1) * 10.1972f).kPa(), 1);
-  EXPECT_FLOAT_EQ((10.1972f * cmH2O(1)).kPa(), 1);
-  EXPECT_FLOAT_EQ((kPa(1) / 10.1972f).cmH2O(), 1);
+  EXPECT_FLOAT_EQ((cmH2O(2.5f) * 101.972f).kPa(), 25);
+  EXPECT_FLOAT_EQ((1.01972f * cmH2O(-5.2f)).kPa(), -0.52f);
+  EXPECT_FLOAT_EQ((kPa(12.345f) / 10.1972f).cmH2O(), 12.345f);
 }
 
 TEST(Units, Length) {
@@ -79,19 +79,19 @@ TEST(Units, Length) {
   checkRelationalOperators(meters);
   checkRelationalOperators(millimeters);
 
-  Length length = meters(2);
+  Length length = meters(0.23f);
   length += meters(1);
+  EXPECT_FLOAT_EQ(length.meters(), 1.23f);
+  length -= meters(4.92f);
+  EXPECT_FLOAT_EQ(length.meters(), -3.69f);
+  length /= -1.23f;
   EXPECT_FLOAT_EQ(length.meters(), 3.0f);
-  length -= meters(5);
-  EXPECT_FLOAT_EQ(length.meters(), -2.0f);
-  length /= -2.0f;
-  EXPECT_FLOAT_EQ(length.meters(), 1.0f);
-  length *= -5.0f;
-  EXPECT_FLOAT_EQ(length.meters(), -5.0f);
+  length *= -1.5f;
+  EXPECT_FLOAT_EQ(length.meters(), -4.5f);
 
-  EXPECT_FLOAT_EQ((millimeters(1) * 1000.0f).meters(), 1);
-  EXPECT_FLOAT_EQ((1000.0f * millimeters(1)).meters(), 1);
-  EXPECT_FLOAT_EQ((meters(1) / 1000.0f).millimeters(), 1);
+  EXPECT_FLOAT_EQ((millimeters(1234) * 1.5f).meters(), 1.851f);
+  EXPECT_FLOAT_EQ((2.345f * millimeters(654.3f)).meters(), 1.5343335f);
+  EXPECT_FLOAT_EQ((meters(2.46f) / 2000.0f).millimeters(), 1.23f);
 }
 
 TEST(Units, VolumetricFlow) {
@@ -117,21 +117,22 @@ TEST(Units, VolumetricFlow) {
   checkRelationalOperators(ml_per_min);
   checkRelationalOperators(liters_per_sec);
 
-  VolumetricFlow flow = liters_per_sec(2);
-  flow += liters_per_sec(1);
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 3.0f);
-  flow -= liters_per_sec(5);
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), -2.0f);
-  flow /= -2.0f;
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 1.0f);
-  flow *= -5.0f;
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), -5.0f);
+  VolumetricFlow flow = liters_per_sec(9.87f);
+  flow += liters_per_sec(1.23f);
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 11.1f);
+  flow -= liters_per_sec(9.87f);
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 1.23f);
+  flow /= -0.5f;
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), -2.46f);
+  flow *= -2.0f;
+  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 4.92f);
 
-  EXPECT_FLOAT_EQ((liters_per_sec(1) * 1000.0f).cubic_m_per_sec(), 1);
-  EXPECT_FLOAT_EQ((1000.0f * liters_per_sec(1)).cubic_m_per_sec(), 1);
-  EXPECT_FLOAT_EQ((cubic_m_per_sec(1) / 1000.0f).liters_per_sec(), 1);
+  EXPECT_FLOAT_EQ((liters_per_sec(4.0f) * 500.0f).cubic_m_per_sec(), 2.0f);
+  EXPECT_FLOAT_EQ((1234.0f * liters_per_sec(2.5f)).cubic_m_per_sec(), 3.085f);
+  EXPECT_FLOAT_EQ((cubic_m_per_sec(6.283f) / 2000.0f).liters_per_sec(),
+                  3.1415f);
 
-  EXPECT_FLOAT_EQ((cubic_m(1) / seconds(1)).cubic_m_per_sec(), 1);
+  EXPECT_FLOAT_EQ((cubic_m(3.198f) / seconds(2.6f)).cubic_m_per_sec(), 1.23f);
 }
 
 TEST(Units, Volume) {
@@ -146,21 +147,21 @@ TEST(Units, Volume) {
   checkRelationalOperators(cubic_m);
   checkRelationalOperators(ml);
 
-  Volume volume = ml(2);
-  volume += ml(1);
-  EXPECT_FLOAT_EQ(volume.ml(), 3.0f);
-  volume -= ml(5);
-  EXPECT_FLOAT_EQ(volume.ml(), -2.0f);
-  volume /= -2.0f;
-  EXPECT_FLOAT_EQ(volume.ml(), 1.0f);
-  volume *= -5.0f;
-  EXPECT_FLOAT_EQ(volume.ml(), -5.0f);
+  Volume volume = ml(456.0f);
+  volume += ml(123.0f);
+  EXPECT_FLOAT_EQ(volume.ml(), 579.0f);
+  volume -= ml(234.0f);
+  EXPECT_FLOAT_EQ(volume.ml(), 345.0f);
+  volume /= -5.0f;
+  EXPECT_FLOAT_EQ(volume.ml(), -69.0f);
+  volume *= 3.0f;
+  EXPECT_FLOAT_EQ(volume.ml(), -207.0f);
 
-  EXPECT_FLOAT_EQ((cubic_m(1) / 1e6f).ml(), 1);
-  EXPECT_FLOAT_EQ((ml(1) * 1e6f).cubic_m(), 1);
+  EXPECT_FLOAT_EQ((cubic_m(0.123f) / 1e4f).ml(), 12.3f);
+  EXPECT_FLOAT_EQ((ml(1234.0f) * 567.0f).cubic_m(), 0.699678f);
 
-  EXPECT_FLOAT_EQ((cubic_m_per_sec(1) * seconds(1)).cubic_m(), 1);
-  EXPECT_FLOAT_EQ((seconds(1) * cubic_m_per_sec(1)).cubic_m(), 1);
+  EXPECT_FLOAT_EQ((liters_per_sec(1.47f) * seconds(2.58f)).ml(), 3792.6f);
+  EXPECT_FLOAT_EQ((seconds(4.56f) * liters_per_sec(3.1415f)).ml(), 14325.24f);
 }
 
 TEST(Units, Duration) {


### PR DESCRIPTION
+= and -= operators for ArithScalar
New ModuleScalar template for averaging/applying a multiplying factor (e.g calibration of flow?) right now only for flow and volume
Define Volume = VolumetricFlow\*Duration = Duration\*VolumetricFlow and VolumetricFlow = Volume/Duration

Thought those might come in handy to allow us some more advanced calculations, especially for flow and volume, as it looks like we are going to have to get some correcting factors somewhere, and constantly calling those unit(something.unit()*CORRECTION) is going to get harder and harder to follow.
Also added Time+=Duration and Time-=Duration unit tests, which looked to be missing.