### PR TITLE
Cache latest gui docker image & spin up on boot

### DIFF
--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -52,12 +52,6 @@
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/
 
-#TODO:
-# - name: Add script to update locally cached gui docker image
-#   lineinfile:
-#     dest: /home/pi/.config/openbox/autostart
-#     line: docker pull respiraworks/gui
-
   - name: Add script to spin up gui docker instance on boot
     lineinfile:
       dest: /home/pi/.config/openbox/autostart

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -45,9 +45,8 @@
       line: 'exec openbox-session'
       create: yes
 
-#TODO:
-# - name: Cache most recent gui docker image from dockerhub
-#   shell: docker pull respiraworks/gui
+  - name: Cache most recent gui docker image from dockerhub
+    shell: docker pull respiraworks/gui
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -44,3 +44,21 @@
       dest: /home/pi/.xsession
       line: 'exec openbox-session'
       create: yes
+
+#TODO:
+# - name: Cache most recent gui docker image from dockerhub
+#   shell: docker pull respiraworks/gui
+
+  - name: Copy openbox autostart folder from root to pi
+    shell: cp -r /etc/xdg/openbox /home/pi/.config/
+
+#TODO:
+# - name: Add script to update locally cached gui docker image
+#   lineinfile:
+#     dest: /home/pi/.config/openbox/autostart
+#     line: docker pull respiraworks/gui
+
+  - name: Add script to spin up gui docker instance on boot
+    lineinfile:
+      dest: /home/pi/.config/openbox/autostart
+      line: 'docker run --name=gui -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui &'

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -46,7 +46,7 @@
       create: yes
 
   - name: Cache most recent gui docker image from dockerhub
-    shell: docker pull respiraworks/gui
+    shell: docker pull respiraworks/gui:8b771524c20789caf0f8a003bb9e1b3a71fc4544
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/
@@ -54,4 +54,4 @@
   - name: Add script to spin up gui docker instance on boot
     lineinfile:
       dest: /home/pi/.config/openbox/autostart
-      line: 'docker run --name=gui -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui &'
+      line: 'docker run --name=gui -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui:8b771524c20789caf0f8a003bb9e1b3a71fc4544 /gui/build/ProjectVentilatorGUI &'

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -46,7 +46,7 @@
       create: yes
 
   - name: Cache most recent gui docker image from dockerhub
-    shell: docker pull respiraworks/gui:8b771524c20789caf0f8a003bb9e1b3a71fc4544
+    shell: docker pull respiraworks/gui
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/
@@ -54,4 +54,4 @@
   - name: Add script to spin up gui docker instance on boot
     lineinfile:
       dest: /home/pi/.config/openbox/autostart
-      line: 'docker run --name=gui -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui:8b771524c20789caf0f8a003bb9e1b3a71fc4544 /gui/build/ProjectVentilatorGUI &'
+      line: 'docker run --name=gui -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui /gui/build/ProjectVentilatorGUI &'


### PR DESCRIPTION
Added steps to cache the latest respiraworks/gui docker image from docker hub into the raspbian image and spin it up on boot.