### PR TITLE
Makes ./test.sh pass with clang.

### DIFF
--- a/controller/lib/debug/pb_read.cpp
+++ b/controller/lib/debug/pb_read.cpp
@@ -13,37 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
- * This file implements a command that allows the contents of the
- * print buffer data to be read.  The print buffer buffer is
- * where strings go when you call debug.Print
- */
+#include "pb_read.h"
 
-#include "debug.h"
-#include <optional>
-#include <string.h>
-
-class PrintBuffReadCmd : public DebugCmd {
-public:
-  PrintBuffReadCmd() : DebugCmd(DbgCmdCode::PRINT_BUFF_READ) {}
-
-  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
-    // No data needs to be passed in to this command.
-
-    // Read bytes from the print buffer until I hit my
-    // max or the buffer is empty.
-
-    int i;
-    for (i = 0; i < max; i++) {
-      std::optional<uint8_t> ch = debug.PrintBuffGet();
-      if (ch = std::nullopt)
-        break;
-      *data++ = *ch;
-    }
-
-    *len = i;
-    return DbgErrCode::OK;
-  }
-};
-
-PrintBuffReadCmd pbRead;
+PrintBuffReadCmd pbReadCmd;

--- a/controller/lib/debug/pb_read.h
+++ b/controller/lib/debug/pb_read.h
@@ -1,0 +1,50 @@
+
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * This file implements a command that allows the contents of the
+ * print buffer data to be read.  The print buffer buffer is
+ * where strings go when you call debug.Print
+ */
+
+#include "debug.h"
+#include <optional>
+#include <string.h>
+
+class PrintBuffReadCmd : public DebugCmd {
+public:
+  PrintBuffReadCmd() : DebugCmd(DbgCmdCode::PRINT_BUFF_READ) {}
+
+  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
+    // No data needs to be passed in to this command.
+
+    // Read bytes from the print buffer until I hit my
+    // max or the buffer is empty.
+
+    int i;
+    for (i = 0; i < max; i++) {
+      std::optional<uint8_t> ch = debug.PrintBuffGet();
+      if (ch == std::nullopt)
+        break;
+      *data++ = *ch;
+    }
+
+    *len = i;
+    return DbgErrCode::OK;
+  }
+};
+
+extern PrintBuffReadCmd pbReadCmd;

--- a/controller/lib/debug/peek.cpp
+++ b/controller/lib/debug/peek.cpp
@@ -13,57 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
- * This file implements a 'peek' command which allows us
- * to read raw memory values.
- *
- * The data passed to the command consists of a 32-bit
- * starting address and an 16-bit byte count.
- */
+#include "peek.h"
 
-#include "debug.h"
-#include <string.h>
-
-class PeekCmd : public DebugCmd {
-public:
-  PeekCmd() : DebugCmd(DbgCmdCode::PEEK) {}
-  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
-    // The data passed to this command consists of a 4 byte address
-    // and a two byte count of how many bytes to return
-    // Length should be exactly 6, but if more data is passed
-    // I'll just ignore it.
-    if (*len < 6)
-      return DbgErrCode::MISSING_DATA;
-
-    uint32_t addr = u8_to_u32(&data[0]);
-    int ct = u8_to_u16(&data[4]);
-
-    // Limit the number of output bytes based on buffer size
-    if (ct > max)
-      ct = max;
-
-    // Some registers can't handle byte accesses, so rather then just
-    // use a simple memcpy here I will do 32-bit or 16-bit accesses
-    // as long as both the address and count are aligned to 32 or 16 bits.
-    if (!(addr & 3) && !(ct & 3)) {
-      uint32_t *ptr = reinterpret_cast<uint32_t *>(addr);
-
-      for (int i = 0; i < ct / 4; i++) {
-        uint32_t x = *ptr++;
-        u32_to_u8(x, &data[4 * i]);
-      }
-    } else if (!(addr & 1) && !(ct & 1)) {
-      uint16_t *ptr = reinterpret_cast<uint16_t *>(addr);
-      for (int i = 0; i < ct / 2; i++) {
-        uint16_t x = *ptr++;
-        u16_to_u8(x, &data[2 * i]);
-      }
-    } else
-      memcpy(data, reinterpret_cast<void *>(addr), ct);
-
-    *len = ct;
-    return DbgErrCode::OK;
-  }
-};
-
-PeekCmd peek;
+PeekCmd peekCmd;

--- a/controller/lib/debug/peek.h
+++ b/controller/lib/debug/peek.h
@@ -1,0 +1,69 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * This file implements a 'peek' command which allows us
+ * to read raw memory values.
+ *
+ * The data passed to the command consists of a 32-bit
+ * starting address and an 16-bit byte count.
+ */
+
+#include "debug.h"
+#include <string.h>
+
+class PeekCmd : public DebugCmd {
+public:
+  PeekCmd() : DebugCmd(DbgCmdCode::PEEK) {}
+  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
+    // The data passed to this command consists of a 4 byte address
+    // and a two byte count of how many bytes to return
+    // Length should be exactly 6, but if more data is passed
+    // I'll just ignore it.
+    if (*len < 6)
+      return DbgErrCode::MISSING_DATA;
+
+    uint32_t addr = u8_to_u32(&data[0]);
+    int ct = u8_to_u16(&data[4]);
+
+    // Limit the number of output bytes based on buffer size
+    if (ct > max)
+      ct = max;
+
+    // Some registers can't handle byte accesses, so rather then just
+    // use a simple memcpy here I will do 32-bit or 16-bit accesses
+    // as long as both the address and count are aligned to 32 or 16 bits.
+    if (!(addr & 3) && !(ct & 3)) {
+      uint32_t *ptr = reinterpret_cast<uint32_t *>(addr);
+
+      for (int i = 0; i < ct / 4; i++) {
+        uint32_t x = *ptr++;
+        u32_to_u8(x, &data[4 * i]);
+      }
+    } else if (!(addr & 1) && !(ct & 1)) {
+      uint16_t *ptr = reinterpret_cast<uint16_t *>(addr);
+      for (int i = 0; i < ct / 2; i++) {
+        uint16_t x = *ptr++;
+        u16_to_u8(x, &data[2 * i]);
+      }
+    } else
+      memcpy(data, reinterpret_cast<void *>(addr), ct);
+
+    *len = ct;
+    return DbgErrCode::OK;
+  }
+};
+
+extern PeekCmd peekCmd;

--- a/controller/lib/debug/poke.cpp
+++ b/controller/lib/debug/poke.cpp
@@ -23,50 +23,6 @@ limitations under the License.
  * given address
  */
 
-#include "debug.h"
-#include <string.h>
+#include "poke.h"
 
-class PokeCmd : public DebugCmd {
-public:
-  PokeCmd() : DebugCmd(DbgCmdCode::POKE) {}
-  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
-
-    // Total command length must be at least 5.  That's
-    // four for the address and at least one data byte.
-    if (*len < 5)
-      return DbgErrCode::MISSING_DATA;
-
-    uint32_t addr = u8_to_u32(&data[0]);
-
-    int ct = *len - 4;
-
-    // If both the address and count are multiples of 4, I write
-    // 32-bit values.  This is useful when poking into registers
-    // that need to be written as longs.
-    if (!(addr & 3) && !(ct & 3)) {
-      uint32_t *ptr = reinterpret_cast<uint32_t *>(addr);
-      ct /= 4;
-      for (int i = 0; i < ct; i++)
-        *ptr++ = u8_to_u32(&data[4 + i * 4]);
-    }
-
-    // Same idea for multiples of 2
-    else if (!(addr & 1) && !(ct & 1)) {
-      uint16_t *ptr = reinterpret_cast<uint16_t *>(addr);
-      ct /= 2;
-      for (int i = 0; i < ct; i++)
-        *ptr++ = u8_to_u16(&data[4 + i * 2]);
-    }
-
-    else {
-      uint8_t *ptr = reinterpret_cast<uint8_t *>(addr);
-      for (int i = 0; i < ct; i++)
-        *ptr++ = data[4 + i];
-    }
-
-    *len = 0;
-    return DbgErrCode::OK;
-  }
-};
-
-PokeCmd poke;
+PokeCmd pokeCmd;

--- a/controller/lib/debug/poke.h
+++ b/controller/lib/debug/poke.h
@@ -1,0 +1,72 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+ * This file implements a 'poke' command which allows us
+ * to write to wrap values in memory.  Use with caution!
+ *
+ * The data passed to the command consists of a 32-bit
+ * starting address and one or more data bytes to be
+ * written to consecutive addresses starting at the
+ * given address
+ */
+
+#include "debug.h"
+#include <string.h>
+
+class PokeCmd : public DebugCmd {
+public:
+  PokeCmd() : DebugCmd(DbgCmdCode::POKE) {}
+  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
+
+    // Total command length must be at least 5.  That's
+    // four for the address and at least one data byte.
+    if (*len < 5)
+      return DbgErrCode::MISSING_DATA;
+
+    uint32_t addr = u8_to_u32(&data[0]);
+
+    int ct = *len - 4;
+
+    // If both the address and count are multiples of 4, I write
+    // 32-bit values.  This is useful when poking into registers
+    // that need to be written as longs.
+    if (!(addr & 3) && !(ct & 3)) {
+      uint32_t *ptr = reinterpret_cast<uint32_t *>(addr);
+      ct /= 4;
+      for (int i = 0; i < ct; i++)
+        *ptr++ = u8_to_u32(&data[4 + i * 4]);
+    }
+
+    // Same idea for multiples of 2
+    else if (!(addr & 1) && !(ct & 1)) {
+      uint16_t *ptr = reinterpret_cast<uint16_t *>(addr);
+      ct /= 2;
+      for (int i = 0; i < ct; i++)
+        *ptr++ = u8_to_u16(&data[4 + i * 2]);
+    }
+
+    else {
+      uint8_t *ptr = reinterpret_cast<uint8_t *>(addr);
+      for (int i = 0; i < ct; i++)
+        *ptr++ = data[4 + i];
+    }
+
+    *len = 0;
+    return DbgErrCode::OK;
+  }
+};
+
+extern PokeCmd pokeCmd;

--- a/controller/lib/debug/trace.cpp
+++ b/controller/lib/debug/trace.cpp
@@ -25,6 +25,7 @@ limitations under the License.
  * could be done using simple printouts over a serial port.
  */
 
+#include "trace.h"
 #include "debug.h"
 #include "vars.h"
 #include <optional>
@@ -149,95 +150,92 @@ static int CountActiveVars(DebugVar *vptr[]) {
   return vct;
 }
 
-class TraceCmd : public DebugCmd {
-public:
-  TraceCmd() : DebugCmd(DbgCmdCode::TRACE) {
-    // Disable all trace varaibles initially
-    for (int i = 0; i < TRACE_VAR_CT; i++)
-      traceVar[i] = -1;
-  }
+TraceCmd::TraceCmd() : DebugCmd(DbgCmdCode::TRACE) {
+  // Disable all trace varaibles initially
+  for (int i = 0; i < TRACE_VAR_CT; i++)
+    traceVar[i] = -1;
+}
 
-  // The trace command is used to download data from the trace buffer.
-  DbgErrCode HandleCmd(uint8_t *data, int *len, int max) {
+// The trace command is used to download data from the trace buffer.
+DbgErrCode TraceCmd::HandleCmd(uint8_t *data, int *len, int max) {
 
-    // The first byte of data is always required, this
-    // gives the sub-command.
-    if (*len < 1)
-      return DbgErrCode::MISSING_DATA;
+  // The first byte of data is always required, this
+  // gives the sub-command.
+  if (*len < 1)
+    return DbgErrCode::MISSING_DATA;
 
-    switch (data[0]) {
+  switch (data[0]) {
 
-    // Sub-command 0 is used to flush the trace buffer
-    // It also disables the trace
-    case 0: {
-      traceCtrl = 0;
-      traceSamp = 0;
+  // Sub-command 0 is used to flush the trace buffer
+  // It also disables the trace
+  case 0: {
+    traceCtrl = 0;
+    traceSamp = 0;
 
-      std::optional<uint32_t> tmp;
-      while ((tmp = traceBuffer.Get()) != std::nullopt) {
-      }
-      *len = 0;
-      return DbgErrCode::OK;
+    std::optional<uint32_t> tmp;
+    while ((tmp = traceBuffer.Get()) != std::nullopt) {
     }
-
-    // Sub-command 1 is used to read data from the buffer
-    case 1:
-      return ReadTraceBuff(data, len, max);
-
-    default:
-      return DbgErrCode::RANGE;
-    }
-  }
-
-  DbgErrCode ReadTraceBuff(uint8_t *data, int *len, int max) {
-    // See how many active trace variables there are
-    // This gives us our sample size;
-    DebugVar *vptr[TRACE_VAR_CT];
-    int vct = CountActiveVars(vptr);
-
-    // If there aren't any active variables, I'm done
-    if (!vct) {
-      *len = 0;
-      return DbgErrCode::OK;
-    }
-
-    // See how many samples I can return
-    // First, find out how many I could based on the max value
-    max /= static_cast<int>((vct * sizeof(uint32_t)));
-
-    // If there's not room for even one sample, return an error.
-    // That really shouldn't happen
-    if (!max)
-      return DbgErrCode::NO_MEMORY;
-
-    // Find the total number of samples in the buffer
-    int tot = traceBuffer.FullCt() / vct;
-    if (tot > max)
-      tot = max;
-
-    for (int i = 0; i < tot; i++) {
-      BlockInterrupts block;
-      // Grab one sample with interrupts disabled.
-      // There's a chance the trace is still running, so we
-      // could get interrupted by the high priority thread
-      // that adds to the buffer.  I want to make sure I
-      // read a full sample without being interrupted
-      for (int j = 0; j < vct; j++) {
-
-        // This shouldn't fail since I've already confirmed
-        // the number of elements in the buffer.  If it does
-        // fail it's a bug.
-        std::optional<uint32_t> dat = traceBuffer.Get();
-        u32_to_u8(*dat, data);
-        data += sizeof(uint32_t);
-      }
-      traceSamp--;
-    }
-
-    *len = static_cast<int>(tot * vct * sizeof(uint32_t));
+    *len = 0;
     return DbgErrCode::OK;
   }
-};
+
+  // Sub-command 1 is used to read data from the buffer
+  case 1:
+    return ReadTraceBuff(data, len, max);
+
+  default:
+    return DbgErrCode::RANGE;
+  }
+}
+
+DbgErrCode TraceCmd::ReadTraceBuff(uint8_t *data, int *len, int max) {
+  // See how many active trace variables there are
+  // This gives us our sample size;
+  DebugVar *vptr[TRACE_VAR_CT];
+  int vct = CountActiveVars(vptr);
+
+  // If there aren't any active variables, I'm done
+  if (!vct) {
+    *len = 0;
+    return DbgErrCode::OK;
+  }
+
+  // See how many samples I can return
+  // First, find out how many I could based on the max value
+  max /= static_cast<int>((vct * sizeof(uint32_t)));
+
+  // If there's not room for even one sample, return an error.
+  // That really shouldn't happen
+  if (!max)
+    return DbgErrCode::NO_MEMORY;
+
+  // Find the total number of samples in the buffer
+  int tot = traceBuffer.FullCt() / vct;
+  if (tot > max)
+    tot = max;
+
+  for (int i = 0; i < tot; i++) {
+    BlockInterrupts block;
+    // Grab one sample with interrupts disabled.
+    // There's a chance the trace is still running, so we
+    // could get interrupted by the high priority thread
+    // that adds to the buffer.  I want to make sure I
+    // read a full sample without being interrupted
+    for (int j = 0; j < vct; j++) {
+
+      // This shouldn't fail since I've already confirmed
+      // the number of elements in the buffer.  If it does
+      // fail it's a bug.
+      std::optional<uint32_t> dat = traceBuffer.Get();
+      u32_to_u8(*dat, data);
+      data += sizeof(uint32_t);
+    }
+    traceSamp--;
+  }
+
+  *len = static_cast<int>(tot * vct * sizeof(uint32_t));
+  return DbgErrCode::OK;
+}
 
 DbgErrCode TraceCtrlVar::SetValue(uint8_t *buff, int len) {
 

--- a/controller/lib/debug/trace.h
+++ b/controller/lib/debug/trace.h
@@ -16,7 +16,19 @@ limitations under the License.
 #ifndef TRACE_H
 #define TRACE_H
 
+#include "debug.h"
+
 // Called from the main loop
 void TraceSample();
+
+class TraceCmd : public DebugCmd {
+public:
+  TraceCmd();
+  // The trace command is used to download data from the trace buffer.
+  DbgErrCode HandleCmd(uint8_t *data, int *len, int max);
+  DbgErrCode ReadTraceBuff(uint8_t *data, int *len, int max);
+};
+
+extern TraceCmd traceCmd;
 
 #endif

--- a/controller/lib/debug/vars.h
+++ b/controller/lib/debug/vars.h
@@ -113,4 +113,44 @@ private:
   }
 };
 
+// Command handler for variable access
+//
+// The first byte of data passed to the command gives a sub-command
+// which defines what the command does and the structure of it's data.
+//
+// Sub-commands:
+//  0 - Used to read info about a variable.  The debug interface calls
+//      this repeatedly on startup to enumerate the variables currently
+//      supported by the code.  This way new debug variables can be added
+//      on the fly without modifying the Python code to match.
+//
+//      Input data to this command is a 16-bit variable ID (assigned
+//      dynamically as variables are created).  The output is info about
+//      the variable.  See the code below for details of the output format
+//
+//  1 - Read the variables value.
+//
+//  2 - Set the variables value.
+//
+class VarCmd : public DebugCmd {
+public:
+  VarCmd() : DebugCmd(DbgCmdCode::VAR) {}
+
+  DbgErrCode HandleCmd(uint8_t *data, int *len, int max);
+
+  // Return info about one of the variables.
+  // The 16-bit variable ID is passed in.  These IDs are
+  // automatically assigned as variables are registered in the
+  // system starting with 0.  The Python code can read them
+  // all out until it gets an error code indicating that the
+  // passed ID is invalid.
+  DbgErrCode GetVarInfo(uint8_t *data, int *len, int max);
+
+  DbgErrCode GetVar(uint8_t *data, int *len, int max);
+
+  DbgErrCode SetVar(uint8_t *data, int *len, int max);
+};
+
+extern VarCmd varCmd;
+
 #endif


### PR DESCRIPTION
This includes one bug (= instead of ==) and something that is most likely undefined behavior but somehow worked: all the debug cmds were declared as static variables of type "FooCmd" in their respective sources, but then as "extern DebugCmd" (different type) in debug.cpp.

This PR contains no code changes except to the body of one function in debug.cpp where the extern vars were declared. Everything else is just moving code around verbatim.