### PR TITLE
Changes debug vars to be adapters over uint32_t and adds basic tests

### DIFF
--- a/controller/lib/debug/debug.h
+++ b/controller/lib/debug/debug.h
@@ -137,6 +137,4 @@ inline void u32_to_u8(uint32_t val, uint8_t *buff) {
   buff[3] = static_cast<uint8_t>(val >> 24);
 }
 
-#define ARRAY_CT(x) (sizeof(x) / sizeof(x[0]))
-
 #endif

--- a/controller/lib/debug/trace.cpp
+++ b/controller/lib/debug/trace.cpp
@@ -116,7 +116,7 @@ int CountActiveVars(DebugVar *vptr[]) {
 
     // Find the debug variable associated
     // with this ID
-    vptr[vct] = DebugVar::findVar(static_cast<uint16_t>(traceVar[i]));
+    vptr[vct] = DebugVar::FindVar(static_cast<uint16_t>(traceVar[i]));
 
     // If the ID wasn't valid, disable this trace variable
     if (!vptr[vct])
@@ -134,11 +134,11 @@ DbgErrCode TraceCtrlVar::SetValue(uint8_t *buff, int len) {
   // so the setting doesn't take effect immediately
   // Then call the standard SetValue function
   int32_t new_ctrl;
-  addr = &new_ctrl;
+  addr_ = &new_ctrl;
 
   DbgErrCode err = DebugVar::SetValue(buff, len);
 
-  addr = &traceCtrl;
+  addr_ = &traceCtrl;
 
   if (err != DbgErrCode::OK)
     return err;

--- a/controller/lib/debug/trace.cpp
+++ b/controller/lib/debug/trace.cpp
@@ -40,16 +40,14 @@ int32_t traceVar[TRACE_VAR_CT];
 
 class TraceCtrlVar : public DebugVar {
 public:
-  TraceCtrlVar(const char *name, int32_t *data, const char *help,
-               const char *fmt)
-      : DebugVar(name, data, help, fmt) {}
-  DbgErrCode SetValue(uint8_t *buff, int len);
+  TraceCtrlVar()
+      : DebugVar("trace_ctrl", &traceCtrl,
+                 "Used to start/stop the trace function", "0x%08x") {}
+  void SetValue(uint32_t value) override;
 };
 
 // These variables are used control the trace function
-static TraceCtrlVar varTraceCtrl("trace_ctrl", &traceCtrl,
-                                 "Used to start/stop the trace function",
-                                 "0x%08x");
+static TraceCtrlVar varTraceCtrl;
 static DebugVar
     varTracePeriod("trace_period", &tracePeriod,
                    "Period that data will be captured.  Loop cycle units");
@@ -93,7 +91,7 @@ void TraceSample() {
   // Sample each enabled varible and store the
   // result to the buffer
   for (int i = 0; i < vct; i++) {
-    bool ok = traceBuffer.Put(vptr[i]->getDataForTrace());
+    bool ok = traceBuffer.Put(vptr[i]->GetValue());
 
     // Note that this can't fail as we've already checked for sufficient
     // space above.  I still need to check it though, becuase it's marked
@@ -128,7 +126,7 @@ int CountActiveVars(DebugVar *vptr[]) {
   return vct;
 }
 
-DbgErrCode TraceCtrlVar::SetValue(uint8_t *buff, int len) {
+void TraceCtrlVar::SetValue(uint32_t value) {
 
   // Temporarily replace the address with a local variable
   // so the setting doesn't take effect immediately
@@ -136,12 +134,7 @@ DbgErrCode TraceCtrlVar::SetValue(uint8_t *buff, int len) {
   int32_t new_ctrl;
   addr_ = &new_ctrl;
 
-  DbgErrCode err = DebugVar::SetValue(buff, len);
-
-  addr_ = &traceCtrl;
-
-  if (err != DbgErrCode::OK)
-    return err;
+  DebugVar::SetValue(value);
 
   // When a new trace is started, flush the buffer first
   if ((new_ctrl & 1) && !(traceCtrl & 1)) {
@@ -149,6 +142,5 @@ DbgErrCode TraceCtrlVar::SetValue(uint8_t *buff, int len) {
     traceSamp = 0;
   }
   traceCtrl = new_ctrl;
-
-  return DbgErrCode::OK;
+  addr_ = &traceCtrl;
 }

--- a/controller/lib/debug/var_cmd.cpp
+++ b/controller/lib/debug/var_cmd.cpp
@@ -119,7 +119,12 @@ DbgErrCode VarCmd::GetVar(uint8_t *data, int *len, int max) {
   if (!var)
     return DbgErrCode::BAD_VARID;
 
-  return var->GetValue(data, len, max);
+  if (max < 4)
+    return DbgErrCode::NO_MEMORY;
+
+  u32_to_u8(var->GetValue(), data);
+  *len = 4;
+  return DbgErrCode::OK;
 }
 
 DbgErrCode VarCmd::SetVar(uint8_t *data, int *len, int max) {
@@ -134,8 +139,13 @@ DbgErrCode VarCmd::SetVar(uint8_t *data, int *len, int max) {
     return DbgErrCode::BAD_VARID;
 
   int ct = *len - 3;
+
+  if (ct < 4)
+    return DbgErrCode::MISSING_DATA;
+
+  var->SetValue(u8_to_u32(data + 3));
   *len = 0;
-  return var->SetValue(&data[3], ct);
+  return DbgErrCode::OK;
 }
 
 VarCmd varCmd;

--- a/controller/lib/debug/var_cmd.cpp
+++ b/controller/lib/debug/var_cmd.cpp
@@ -57,7 +57,7 @@ DbgErrCode VarCmd::GetVarInfo(uint8_t *data, int *len, int max) {
 
   uint16_t vid = u8_to_u16(&data[1]);
 
-  const DebugVar *var = DebugVar::findVar(vid);
+  const DebugVar *var = DebugVar::FindVar(vid);
   if (!var)
     return DbgErrCode::BAD_VARID;
 
@@ -72,9 +72,9 @@ DbgErrCode VarCmd::GetVarInfo(uint8_t *data, int *len, int max) {
   // <fmt>  - variable length format string
   // <help> - variable length format string
   // The strings are not null terminated.
-  int nLen = static_cast<int>(strlen(var->getName()));
-  int fLen = static_cast<int>(strlen(var->getFormat()));
-  int hLen = static_cast<int>(strlen(var->getHelp()));
+  int nLen = static_cast<int>(strlen(var->GetName()));
+  int fLen = static_cast<int>(strlen(var->GetFormat()));
+  int hLen = static_cast<int>(strlen(var->GetHelp()));
 
   if (nLen > 255)
     nLen = 255;
@@ -88,7 +88,7 @@ DbgErrCode VarCmd::GetVarInfo(uint8_t *data, int *len, int max) {
     return DbgErrCode::NO_MEMORY;
 
   int n = 0;
-  data[n++] = static_cast<uint8_t>(var->getType());
+  data[n++] = static_cast<uint8_t>(var->GetType());
   data[n++] = 0;
   data[n++] = 0;
   data[n++] = 0;
@@ -96,13 +96,13 @@ DbgErrCode VarCmd::GetVarInfo(uint8_t *data, int *len, int max) {
   data[n++] = static_cast<uint8_t>(fLen);
   data[n++] = static_cast<uint8_t>(hLen);
   data[n++] = 0;
-  memcpy(&data[n], var->getName(), nLen);
+  memcpy(&data[n], var->GetName(), nLen);
   n += nLen;
 
-  memcpy(&data[n], var->getFormat(), fLen);
+  memcpy(&data[n], var->GetFormat(), fLen);
   n += fLen;
 
-  memcpy(&data[n], var->getHelp(), hLen);
+  memcpy(&data[n], var->GetHelp(), hLen);
   n += hLen;
   *len = n;
   return DbgErrCode::OK;
@@ -115,7 +115,7 @@ DbgErrCode VarCmd::GetVar(uint8_t *data, int *len, int max) {
 
   uint16_t vid = u8_to_u16(&data[1]);
 
-  DebugVar *var = DebugVar::findVar(vid);
+  DebugVar *var = DebugVar::FindVar(vid);
   if (!var)
     return DbgErrCode::BAD_VARID;
 
@@ -129,7 +129,7 @@ DbgErrCode VarCmd::SetVar(uint8_t *data, int *len, int max) {
 
   uint16_t vid = u8_to_u16(&data[1]);
 
-  DebugVar *var = DebugVar::findVar(vid);
+  DebugVar *var = DebugVar::FindVar(vid);
   if (!var)
     return DbgErrCode::BAD_VARID;
 

--- a/controller/lib/debug/vars.cpp
+++ b/controller/lib/debug/vars.cpp
@@ -15,65 +15,9 @@ limitations under the License.
 
 #include "vars.h"
 #include "debug.h"
+#include <cstring>
 #include <string.h>
 
 // static member variables
 DebugVar *DebugVar::varList[100];
 int DebugVar::varCount = 0;
-
-// Used to read a debug variable's value over the debug serial interface
-DbgErrCode DebugVar::GetValue(uint8_t *buff, int *len, int max) {
-  switch (type_) {
-  // We can actually treat 32-bit ints and floats exactly the same way.
-  // We're just grabbing their value directly from memory and treating it
-  // as an integer so we can split it up and send it out.
-  case VarType::INT32:
-  case VarType::UINT32:
-  case VarType::FLOAT:
-    *len = 4;
-    if (max < 4)
-      return DbgErrCode::NO_MEMORY;
-
-    u32_to_u8(*reinterpret_cast<uint32_t *>(addr_), buff);
-    return DbgErrCode::OK;
-
-  // For other types we just generate an error.
-  // Anything exotic needs to override this function
-  default:
-    return DbgErrCode::INTERNAL;
-  }
-}
-
-// Used to set a debug variable's value over the debug serial interface
-DbgErrCode DebugVar::SetValue(uint8_t *buff, int len) {
-  switch (type_) {
-  // Like with the get, we actually handle both floats and ints the same here.
-  case VarType::INT32:
-  case VarType::UINT32:
-  case VarType::FLOAT:
-    if (len < 4)
-      return DbgErrCode::MISSING_DATA;
-
-    *reinterpret_cast<uint32_t *>(addr_) = u8_to_u32(buff);
-    return DbgErrCode::OK;
-
-  default:
-    return DbgErrCode::INTERNAL;
-  }
-}
-
-// Return the variable as a 32-bit integer.
-// We just return zero for any type we don't understand
-uint32_t DebugVar::getDataForTrace() {
-  switch (type_) {
-
-  // Like above, we treat 32-bit ints and floats the same here
-  case VarType::INT32:
-  case VarType::UINT32:
-  case VarType::FLOAT:
-    return *reinterpret_cast<uint32_t *>(addr_);
-
-  default:
-    return 0;
-  }
-}

--- a/controller/lib/debug/vars.cpp
+++ b/controller/lib/debug/vars.cpp
@@ -19,5 +19,5 @@ limitations under the License.
 #include <string.h>
 
 // static member variables
-DebugVar *DebugVar::varList[100];
-int DebugVar::varCount = 0;
+DebugVar *DebugVar::var_list[100];
+uint16_t DebugVar::var_count = 0;

--- a/controller/lib/debug/vars.h
+++ b/controller/lib/debug/vars.h
@@ -46,22 +46,18 @@ public:
   // @param fmt printf style format string.  This is a hint to the Python code
   // as to how the variable data should be displayed.
   DebugVar(const char *name, int32_t *data, const char *help = "",
-           const char *fmt = "%d");
+           const char *fmt = "%d")
+      : DebugVar(VarType::INT32, name, data, help, fmt) {}
 
   // Like above, but unsigned
   DebugVar(const char *name, uint32_t *data, const char *help = "",
-           const char *fmt = "%d");
+           const char *fmt = "%d")
+      : DebugVar(VarType::INT32, name, data, help, fmt) {}
 
-  // float variable.  The default get/set functions will probably be fine
-  // @param name Name of the variable
-  // @param data Pointer to the actual variable in C++ code that this will
-  // access
-  // @param fmt printf style format string.  This is a hint to the Python code
-  // as to how
-  //            the variable data should be displayed.
-  // @param help String that the Python code displays describing the variable.
+  // Like above, but float
   DebugVar(const char *name, float *data, const char *help = "",
-           const char *fmt = "%.3f");
+           const char *fmt = "%.3f")
+      : DebugVar(VarType::FLOAT, name, data, help, fmt) {}
 
   // Gets the current value of the variable.
   // @param buff The variable's value is stored here
@@ -83,34 +79,36 @@ public:
   // program handles converting it back into a float.
   virtual uint32_t getDataForTrace();
 
-  const char *getName() const { return name; }
-  const char *getFormat() const { return fmt; }
-  const char *getHelp() const { return help; }
-  VarType getType() const { return type; }
+  const char *GetName() const { return name_; }
+  const char *GetFormat() const { return fmt_; }
+  const char *GetHelp() const { return help_; }
+  VarType GetType() const { return type_; }
 
-  static DebugVar *findVar(uint16_t vid) {
+  static DebugVar *FindVar(uint16_t vid) {
     if (vid >= ARRAY_CT(varList))
       return 0;
     return varList[vid];
   }
 
 protected:
-  VarType type;
-  const char *name;
-  const char *fmt;
-  const char *help;
-  void *addr;
+  const VarType type_;
+  const char *const name_;
+  const char *const fmt_;
+  const char *const help_;
+  void *addr_;
 
 private:
+  DebugVar(VarType type, const char *name, void *data, const char *help,
+           const char *fmt)
+      : type_(type), name_(name), fmt_(fmt), help_(help), addr_(data) {
+    if (varCount < static_cast<int>(ARRAY_CT(varList)))
+      varList[varCount++] = this;
+  }
+
   // List of all the variables in the system.
   // Increase size as necessary
   static DebugVar *varList[100];
   static int varCount;
-
-  void RegisterVar() {
-    if (varCount < static_cast<int>(ARRAY_CT(varList)))
-      varList[varCount++] = this;
-  }
 };
 
 #endif

--- a/controller/lib/debug/vars.h
+++ b/controller/lib/debug/vars.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define VARS_H
 
 #include "debug.h"
+#include <array>
 #include <cstring>
 
 // Defines the type of variable
@@ -52,7 +53,7 @@ public:
   // Like above, but unsigned
   DebugVar(const char *name, uint32_t *data, const char *help = "",
            const char *fmt = "%u")
-      : DebugVar(VarType::INT32, name, data, help, fmt) {}
+      : DebugVar(VarType::UINT32, name, data, help, fmt) {}
 
   // Like above, but float
   DebugVar(const char *name, float *data, const char *help = "",
@@ -73,11 +74,12 @@ public:
   const char *GetFormat() const { return fmt_; }
   const char *GetHelp() const { return help_; }
   VarType GetType() const { return type_; }
+  uint16_t GetId() const { return id_; }
 
   static DebugVar *FindVar(uint16_t vid) {
-    if (vid >= ARRAY_CT(varList))
-      return 0;
-    return varList[vid];
+    if (vid >= std::size(var_list))
+      return nullptr;
+    return var_list[vid];
   }
 
 protected:
@@ -86,19 +88,22 @@ protected:
   const char *const fmt_;
   const char *const help_;
   void *addr_;
+  const uint16_t id_;
 
 private:
   DebugVar(VarType type, const char *name, void *data, const char *help,
            const char *fmt)
-      : type_(type), name_(name), fmt_(fmt), help_(help), addr_(data) {
-    if (varCount < static_cast<int>(ARRAY_CT(varList)))
-      varList[varCount++] = this;
+      : type_(type), name_(name), fmt_(fmt), help_(help), addr_(data),
+        id_(var_count) {
+    if (var_count < static_cast<uint16_t>(std::size(var_list)))
+      var_list[id_] = this;
+    var_count++;
   }
 
   // List of all the variables in the system.
   // Increase size as necessary
-  static DebugVar *varList[100];
-  static int varCount;
+  static DebugVar *var_list[100];
+  static uint16_t var_count;
 };
 
 #endif

--- a/controller/lib/debug/vars.h
+++ b/controller/lib/debug/vars.h
@@ -17,10 +17,10 @@ limitations under the License.
 #define VARS_H
 
 #include "debug.h"
+#include <cstring>
 
 // Defines the type of variable
 enum class VarType {
-  UNKNOWN = 0,
   INT32 = 1,
   UINT32 = 2,
   FLOAT = 3,
@@ -51,7 +51,7 @@ public:
 
   // Like above, but unsigned
   DebugVar(const char *name, uint32_t *data, const char *help = "",
-           const char *fmt = "%d")
+           const char *fmt = "%u")
       : DebugVar(VarType::INT32, name, data, help, fmt) {}
 
   // Like above, but float
@@ -59,25 +59,15 @@ public:
            const char *fmt = "%.3f")
       : DebugVar(VarType::FLOAT, name, data, help, fmt) {}
 
-  // Gets the current value of the variable.
-  // @param buff The variable's value is stored here
-  // @param len Return the length (in bytes) of the value here
-  // @param max Maximum number of bytes we can write to buff
-  // @return An error code, 0 on success
-  virtual DbgErrCode GetValue(uint8_t *buff, int *len, int max);
+  // Gets the current value of the variable as an uint32_t.
+  virtual uint32_t GetValue() {
+    uint32_t res;
+    std::memcpy(&res, addr_, 4);
+    return res;
+  }
 
-  // Sets the current value of the variable.
-  // @param buff Holds the data to be written to the variable
-  // @param len Number of valid bytes in buffer
-  // @return An error code, 0 on success
-  virtual DbgErrCode SetValue(uint8_t *buff, int len);
-
-  // Returns a representation of this variable as a 32-bit integer.
-  // This is used when capturing the variables value to the trace buffer.
-  // Only variables that can be represented by 32-bits can be traced.
-  // For floats, this returns the raw bits of the float, the Python
-  // program handles converting it back into a float.
-  virtual uint32_t getDataForTrace();
+  // Sets the current value of the variable as an uint32_t.
+  virtual void SetValue(uint32_t value) { std::memcpy(addr_, &value, 4); }
 
   const char *GetName() const { return name_; }
   const char *GetFormat() const { return fmt_; }

--- a/controller/lib/hal/hal.h
+++ b/controller/lib/hal/hal.h
@@ -480,6 +480,7 @@ inline uint16_t HalApi::debugWrite(const char *buf, uint16_t len) {
   return len;
 }
 inline uint16_t HalApi::debugRead(char *buf, uint16_t len) { return 0; }
+inline uint16_t HalApi::debugBytesAvailableForWrite() { return 0; }
 
 inline void HalApi::startLoopTimer(const Duration &period,
                                    void (*callback)(void *), void *arg) {}

--- a/controller/test/debug/var_cmd_test.cpp
+++ b/controller/test/debug/var_cmd_test.cpp
@@ -1,0 +1,67 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "var_cmd.h"
+#include "vars.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <array>
+#include <stdint.h>
+
+TEST(VarCmd, GetVar) {
+  uint32_t value = 0xDEADBEEF;
+  DebugVar var("name", &value, "help", "fmt");
+
+  // Test that a GET command obtains the variable's value.
+  VarCmd cmd;
+  uint8_t id[2];
+  u16_to_u8(var.GetId(), id);
+  std::array get_cmd = {
+      uint8_t{1},   // GET
+      id[0], id[1], // Var id
+      uint8_t{0}    // Placeholder
+  };
+  int len = std::size(get_cmd);
+  cmd.HandleCmd(get_cmd.data(), &len, len);
+  EXPECT_EQ(4, len);
+
+  std::array<uint8_t, 4> expected_result;
+  u32_to_u8(value, expected_result.data());
+  EXPECT_EQ(get_cmd, expected_result);
+}
+
+TEST(VarCmd, SetVar) {
+  uint32_t value = 0xDEADBEEF;
+  DebugVar var("name", &value, "help", "fmt");
+
+  uint32_t new_value = 0xCAFEBABE;
+  std::array<uint8_t, 4> new_bytes;
+  u32_to_u8(new_value, new_bytes.data());
+
+  // Test that a SET command changes the variable's value.
+  VarCmd cmd;
+  uint8_t id[2];
+  u16_to_u8(var.GetId(), id);
+  std::array set_cmd = {
+      uint8_t{2},                                            // SET
+      id[0],        id[1],                                   // Var id
+      new_bytes[0], new_bytes[1], new_bytes[2], new_bytes[3] // Value
+  };
+  int len = std::size(set_cmd);
+  cmd.HandleCmd(set_cmd.data(), &len, len);
+  EXPECT_EQ(0, len);
+
+  EXPECT_EQ(new_value, value);
+}

--- a/controller/test/debug/vars_test.cpp
+++ b/controller/test/debug/vars_test.cpp
@@ -27,9 +27,9 @@ TEST(DebugVar, DebugVarInt32) {
   EXPECT_EQ("fmt", var.GetFormat());
   EXPECT_EQ(&var, DebugVar::FindVar(var.GetId()));
 
-  EXPECT_EQ(5, var.GetValue());
+  EXPECT_EQ(uint32_t{5}, var.GetValue());
   var.SetValue(7);
-  EXPECT_EQ(7, var.GetValue());
+  EXPECT_EQ(uint32_t{7}, var.GetValue());
   EXPECT_EQ(7, value);
 
   // Test a value outside the range of int32_t.
@@ -48,7 +48,7 @@ TEST(DebugVar, DebugVarUint32Defaults) {
   uint32_t value = 5;
   // All default arguments
   DebugVar var("var", &value);
-  EXPECT_EQ(5, var.GetValue());
+  EXPECT_EQ(uint32_t{5}, var.GetValue());
   EXPECT_EQ("", var.GetHelp());
   EXPECT_EQ("%u", var.GetFormat());
   EXPECT_EQ(VarType::UINT32, var.GetType());

--- a/controller/test/debug/vars_test.cpp
+++ b/controller/test/debug/vars_test.cpp
@@ -1,0 +1,83 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "vars.h"
+#include "gtest/gtest.h"
+#include <limits>
+#include <stdint.h>
+
+TEST(DebugVar, DebugVarInt32) {
+  int32_t value = 5;
+  DebugVar var("var", &value, "help", "fmt");
+  EXPECT_EQ("var", var.GetName());
+  EXPECT_EQ("help", var.GetHelp());
+  EXPECT_EQ(VarType::INT32, var.GetType());
+  EXPECT_EQ("fmt", var.GetFormat());
+  EXPECT_EQ(&var, DebugVar::FindVar(var.GetId()));
+
+  EXPECT_EQ(5, var.GetValue());
+  var.SetValue(7);
+  EXPECT_EQ(7, var.GetValue());
+  EXPECT_EQ(7, value);
+
+  // Test a value outside the range of int32_t.
+  uint32_t max = std::numeric_limits<uint32_t>::max();
+  var.SetValue(max);
+  EXPECT_EQ(max, var.GetValue());
+  EXPECT_EQ(static_cast<int32_t>(max), value);
+
+  // All default arguments
+  DebugVar var_default("var", &value);
+  EXPECT_EQ("", var_default.GetHelp());
+  EXPECT_EQ("%d", var_default.GetFormat());
+}
+
+TEST(DebugVar, DebugVarUint32Defaults) {
+  uint32_t value = 5;
+  // All default arguments
+  DebugVar var("var", &value);
+  EXPECT_EQ(5, var.GetValue());
+  EXPECT_EQ("", var.GetHelp());
+  EXPECT_EQ("%u", var.GetFormat());
+  EXPECT_EQ(VarType::UINT32, var.GetType());
+}
+
+TEST(DebugVar, DebugVarFloatDefaults) {
+  float value = 5.0f;
+  // All default arguments
+  DebugVar var("var", &value);
+
+  EXPECT_EQ("", var.GetHelp());
+  EXPECT_EQ("%.3f", var.GetFormat());
+  EXPECT_EQ(VarType::FLOAT, var.GetType());
+
+  // Rountrip through uint32 should not change value.
+  uint32_t uint_value = var.GetValue();
+  var.SetValue(uint_value);
+  EXPECT_EQ(uint_value, var.GetValue());
+  EXPECT_EQ(5.0f, value);
+}
+
+TEST(DebugVar, Registration) {
+  int32_t int_value = 5;
+  DebugVar var1("var1", &int_value);
+
+  float float_value = 7;
+  DebugVar var2("var2", &float_value);
+
+  EXPECT_EQ(&var1, DebugVar::FindVar(var1.GetId()));
+  EXPECT_EQ(&var2, DebugVar::FindVar(var2.GetId()));
+  EXPECT_EQ(nullptr, DebugVar::FindVar(12345));
+}


### PR DESCRIPTION
They are always 32-bit, at least for now. This way they don't need to do error checking - that belongs in the higher-level comms protocol code; and the code generally becomes more concise.

Also renames a few functions/variables to follow our more common style and abbreviates the repetitive constructors.