### PR TITLE
build an armv7 (aka armhf?) image instead of arm64, since the RPi can…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,13 +77,13 @@ jobs:
           command: |
             sudo apt-get install -y binfmt-support
       - run:
-          name: Do arm64 build
+          name: Do ARMv7 build
           command: |
             export DOCKER_CLI_EXPERIMENTAL=enabled
             docker buildx create --name gui
             docker buildx use gui
             docker buildx inspect --bootstrap
-            cd ~/project/ && docker buildx build --platform linux/arm64 -t respiraworks/gui:$CIRCLE_SHA1 --load -f gui/Dockerfile .
+            cd ~/project/ && docker buildx build --platform linux/arm/v7 -t respiraworks/gui:$CIRCLE_SHA1 --load -f gui/Dockerfile .
       - run:
           name: Run tests
           command: |

--- a/gui/Dockerfile
+++ b/gui/Dockerfile
@@ -1,6 +1,6 @@
 # Important: this Dockerfile requires that the repo root be build context (in order to include the common code)
 
-FROM arm64v8/debian:buster
+FROM debian:buster
 
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
…'t run arm64

See #252 