### PR TITLE
Pass -fno-threadsafe-statics.

### DIFF
--- a/boards/stm32_scripts.py
+++ b/boards/stm32_scripts.py
@@ -1,13 +1,18 @@
 # This script is called as part of the platformio build sequence for
 # the stm32 controller firmware.
 #
-# It's purpose is to add some additional linker options which can't be
+# Its purpose is to add some additional linker options which can't be
 # directly added to the platformio.ini line for some reason.
 #
-# These link flags tell the linker that the processor we're using has
-# hardware floating point, so the software floating point libraries aren't
-# needed.
 #
 Import("env")
 
+# Threadsafe-statics ends up calling malloc.  But we don't need them to be
+# thread-safe because we don't have threads!  This flag can't be in
+# platformio.ini because gcc raises an error if it's provided to C code.
+env.Append(CXXFLAGS=["-fno-threadsafe-statics"])
+
+# These link flags tell the linker that the processor we're using has
+# hardware floating point, so the software floating point libraries aren't
+# needed.
 env.Append(LINKFLAGS=["-mfpu=fpv4-sp-d16", "-mfloat-abi=hard"])

--- a/platformio.ini
+++ b/platformio.ini
@@ -49,7 +49,7 @@ build_flags =
   -Wl,-u,_init
 board_build.ldscript = boards/stm32_ldscript.ld
 build_unflags = -std=gnu11 -std=gnu++14
-extra_scripts = boards/stm32_scripts.py
+extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src_test/>
 
 [env:stm32-test]
@@ -58,7 +58,7 @@ board = custom_stm32
 build_flags = ${env.build_flags} -Wconversion -Wno-sign-conversion -Wno-error=register -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DBARE_STM32 -DUART_VIA_DMA -Wl,-Map,stm32.map -Wl,-u,vectors -Wl,-u,_init
 board_build.ldscript = boards/stm32_ldscript.ld
 build_unflags = -std=gnu11 -std=gnu++14
-extra_scripts = boards/stm32_scripts.py
+extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> +<src_test/>
 
 [env:native]


### PR DESCRIPTION
This lets us use `static` variables inside of functions with types that
have nontrivial initializers.  Without this, you'll get a mysterious
error of the form

```
  sp/hard/libnosys.a(sbrk.o): In function `_sbrk':
  sbrk.c:(.text._sbrk+0x18): undefined reference to `end'
```

which indicates that something is trying to call malloc.