### PR TITLE
Declare cmd_ptr_ a volatile pointer to volatile data 

### DIFF
--- a/controller/lib/hal/stepper.h
+++ b/controller/lib/hal/stepper.h
@@ -309,7 +309,7 @@ private:
   // This pointer and count are used to hold the command being
   // sent to the motor and its response.
   // They're volatile because the interrupt handler updates them
-  volatile uint8_t *cmd_ptr_{0};
+  volatile uint8_t *volatile cmd_ptr_{0};
   volatile int cmd_remain_{0};
   bool save_response_{false};
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,7 +47,6 @@ build_flags =
   -Wl,-Map,stm32.map
   -Wl,-u,vectors
   -Wl,-u,_init
-  -Og
 board_build.ldscript = boards/stm32_ldscript.ld
 build_unflags = -std=gnu11 -std=gnu++14
 extra_scripts = pre:boards/stm32_scripts.py


### PR DESCRIPTION
…to avoid compiler optimizing out busy wait in StepMotor::SenCmd. Fixes #393