### PR TITLE
Clean up build flags.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,17 @@ test_dir = controller/test
 lib_dir = controller/lib
 default_envs = stm32
 
+# Scope for variables that we reference below, but which don't have meaning to
+# platformio.
+[respiraworks]
+stm32_build_flags =
+  -fstrict-volatile-bitfields
+  -mfpu=fpv4-sp-d16
+  -mfloat-abi=hard
+  -Wl,-Map,stm32.map
+  -Wl,-u,vectors
+  -Wl,-u,_init
+
 [env]
 lib_ldf_mode = deep+
 lib_extra_dirs =
@@ -40,24 +51,22 @@ platform = ststm32
 board = custom_stm32
 build_flags =
   ${env.build_flags}
-  -fstrict-volatile-bitfields
+  ${respiraworks.stm32_build_flags}
   -DBARE_STM32
-  -mfpu=fpv4-sp-d16
-  -mfloat-abi=hard
-  -Wl,-Map,stm32.map
-  -Wl,-u,vectors
-  -Wl,-u,_init
 board_build.ldscript = boards/stm32_ldscript.ld
-build_unflags = -std=gnu11 -std=gnu++14
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src_test/>
 
+# Experimental integration test for STM32 with DMA-based communication.
 [env:stm32-test]
 platform = ststm32
 board = custom_stm32
-build_flags = ${env.build_flags} -Wconversion -Wno-sign-conversion -Wno-error=register -mfpu=fpv4-sp-d16 -mfloat-abi=hard -DBARE_STM32 -DUART_VIA_DMA -Wl,-Map,stm32.map -Wl,-u,vectors -Wl,-u,_init
+build_flags =
+  ${env.build_flags}
+  ${respiraworks.stm32_build_flags}
+  -DBARE_STM32
+  -DUART_VIA_DMA
 board_build.ldscript = boards/stm32_ldscript.ld
-build_unflags = -std=gnu11 -std=gnu++14
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> +<src_test/>
 
@@ -74,6 +83,7 @@ lib_deps =
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
 extra_scripts = platformio_sanitizers.py
+src_filter = ${env.src_filter} -<src_test/>
 
 ; Run clang-tidy only on native: it seems to get confused by headers that can
 ; only be parsed by gcc.


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Clean up build flags.
    
    - Make stm32_build_flags variable, shared between the two STM32 builds.
      This causes `-e stm32-test` to run with -fstrict-volatile.
    
    - Filter src_test out of `native` build, so `pio run -e native` now
      doesn't try to build src_test.  (This isn't a standard command,
      usually we do `pio test -e native`.)

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #410 Clean up build flags. 👈 **YOU ARE HERE**
1. #411 Build with -fno-exceptions.
1. #412 Build with -fno-rtti.
1. #413 Add an implementation of __cxa_pure_virtual.

</git-pr-chain>









