### PR TITLE
[GUI] Add initial implementation on Selection Mode Popup

### DIFF
--- a/gui/ModeSelectionPopup.qml
+++ b/gui/ModeSelectionPopup.qml
@@ -1,0 +1,117 @@
+import QtQuick 2.11
+import QtQuick.Layouts 1.3
+import QtQuick.Window 2.2
+import QtQuick.Controls 2.4
+
+import "controls"
+
+import "."
+
+/*!
+    \qmltype ModelSelectionPopup
+    \brief A popup used to switch ventilator's modes.
+*/
+Popup {
+    id: popup
+
+    width: 800; height: 470
+    parent: Overlay.overlay
+    x: Math.round((parent.width - width) / 2)
+    y: Math.round((parent.height - height) / 2)
+    modal: true
+    focus: true
+    padding: 0
+    margins: 0
+
+    // ListElement representing current mode in use
+    property var currentMode
+
+    // a model describing all possible modes buttons.
+    // elements should have at least two fields:
+    // model.mode, the id of the mode as a string.
+    // model.title, display on the button as a string.
+    property ListModel modesModel: ListModel{}
+
+
+    // Once clicked on "Confirm" the popup will dismiss and return a ListElement of current selection
+    // using this signal.
+    signal selectedMode(var mode)
+
+    background: Rectangle {
+        radius: 4
+        color: Style.theme.color.modalBackground
+    }
+
+    contentItem: Item {
+
+        Rectangle {
+            id: header
+            width: parent.width
+            height: 60
+            color: Style.theme.color.modalHeaderColor
+            Text {
+                anchors.centerIn: parent
+                text: qsTr("Mode Selection")
+                color: "white"
+                font {
+                    bold: true
+                    pixelSize: 38
+                }
+            }
+        }
+
+        ButtonGroup { id: buttonGroup }
+
+        ColumnLayout {
+
+            width: parent.width
+
+            anchors {
+                margins: 10
+                top: header.bottom;
+                left:parent.left
+                bottom: parent.bottom
+                right: parent.right
+            }
+
+            Repeater {
+                id: buttonsRepeater
+                model: modesModel
+
+                delegate: PopupButton {
+                    property int pos: index
+                    objectName: model.mode
+                    checked: popup.currentMode.mode === objectName
+                    Layout.fillWidth: true
+                    text: model.title
+                    ButtonGroup.group: buttonGroup
+                    checkable: true
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                PopupButton {
+                    Layout.fillWidth: true
+                    indicator: Item{}
+                    text: qsTr("Cancel")
+                    onClicked: popup.close()
+                }
+
+                PopupButton {
+                    Layout.fillWidth: true
+                    indicator: Item{}
+                    text: qsTr("Confirm")
+                    visible: modesModel.count > 0
+                    onClicked: {
+                        popup.selectedMode(modesModel.get(buttonGroup.checkedButton.pos))
+                        popup.close()
+                    }
+                    checked: true
+                }
+            }
+        }
+    }
+}

--- a/gui/Style.qml
+++ b/gui/Style.qml
@@ -18,20 +18,25 @@ import QtQuick 2.11
 */
 QtObject {
 
-    property var theme: lightTheme
+    property var theme: darkTheme
 
     property var lightTheme: QtObject {
-
-        property QtObject color: QtObject {
-            property color primary: "#466eeb"
-        }
-
+        // TODO get all values
     }
 
     property var darkTheme: QtObject {
 
         property QtObject color: QtObject {
-            property color primary: "#eeb466"
+            property color primary: "#466eeb"
+            property color windowBackground: "#1A1F32"
+            property color modalBackground: "black"
+            property color modalHeaderColor: "#1056A1"
+            property color modalButton: "#132D4D"
+            property color modalButtonHighlighted: "#498CCD"
+            property color headerButtonColor: Qt.rgba(163, 165, 172, 1)
+
+            property color radioButtonColor: "white"
+            property color radioButtonHighlightedColor: "red"
         }
 
     }

--- a/gui/controls/FpsItem.qml
+++ b/gui/controls/FpsItem.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.11
 import QtQuick.Window 2.2
+import ".."
 
 /*!
     \qmltype FPSItem
@@ -12,7 +13,7 @@ import QtQuick.Window 2.2
     calculates how many updates happens on a given interval (default 2s).
 
 */
-Rectangle {
+Item {
     id: root
 
     property bool enabled: true
@@ -24,7 +25,9 @@ Rectangle {
     property int fpsAvg: 0
 
     visible: enabled
-    color: "black"
+
+    implicitWidth: fpsText.width + 10 + spinnerImage.width
+    implicitHeight: 30
 
     Row {
 
@@ -34,8 +37,9 @@ Rectangle {
         Image {
             id: spinnerImage
             anchors.verticalCenter: parent.verticalCenter
-            source: "images/Logo.png"
+            source: "qrc:/images/Logo.png"
             width: 24; height: 24
+            opacity: 0
             NumberAnimation on rotation {
                 from:0
                 to: 360
@@ -48,7 +52,9 @@ Rectangle {
 
         // Display FPS count as Text
         Text {
+            id: fpsText
             font.pointSize: 18
+            color: "white"
             text: "Ø " + root.fpsAvg + " | " + root.fps + " fps"
         }
     }

--- a/gui/controls/HeaderButton.qml
+++ b/gui/controls/HeaderButton.qml
@@ -1,0 +1,21 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import ".."
+
+/*!
+    \qmltype HeaderButton
+    \brief A border-base button used in main header of the screen.
+*/
+Button {
+    id: control
+
+    implicitWidth:36; implicitHeight: 36
+
+    background: Rectangle {
+        antialiasing: true
+        color: "transparent"
+        border.color: Style.theme.color.headerButtonColor
+        border.width: 1
+        radius: 4
+    }
+}

--- a/gui/controls/Mode.qml
+++ b/gui/controls/Mode.qml
@@ -1,0 +1,9 @@
+import QtQuick 2.0
+
+/*!
+    \qmltype Mode
+    \brief Container element to be used as base for a Ventilator Mode.
+
+*/
+Item {
+}

--- a/gui/controls/PopupButton.qml
+++ b/gui/controls/PopupButton.qml
@@ -1,0 +1,51 @@
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import ".."
+
+/*!
+    \qmltype PopupButton
+    \brief Simple styled button to be used in popups
+*/
+RadioButton {
+    id: root
+    implicitWidth: 720
+    implicitHeight: 70
+
+    indicator: Rectangle {
+        implicitWidth: 32
+        implicitHeight: 32
+        x: 20
+        y: 19
+        radius: 32
+        smooth: true
+        color: "transparent"
+        border.color: Style.theme.color.radioButtonColor
+        border.width: 3
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: parent.width / 2
+            height: parent.height / 2
+            radius: width / 2
+            smooth: true
+            color: Style.theme.color.radioButtonColor
+            visible: root.checked
+        }
+    }
+    background: Rectangle {
+        radius: 4
+        color: root.checked || root.down ?
+                   Style.theme.color.modalButtonHighlighted :
+                   Style.theme.color.modalButton
+
+    }
+
+    contentItem: Text {
+        text: root.text
+        font.bold: true
+        font.pixelSize: 38
+        color: "white"
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+    }
+}

--- a/gui/controls/ScopeView.qml
+++ b/gui/controls/ScopeView.qml
@@ -29,6 +29,7 @@
 
 import QtQuick 2.11
 import QtCharts 2.1
+import ".."
 
 ChartView
 {

--- a/gui/controls/StepCounter.qml
+++ b/gui/controls/StepCounter.qml
@@ -1,7 +1,8 @@
 import QtQuick 2.11
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.4
-import "."
+
+import ".."
 
 /*!
     \qmltype StepCounter

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -5,17 +5,19 @@
 #include "periodic_closure.h"
 #include "respira_connected_device.h"
 
+#include <QApplication>
 #include <QCommandLineParser>
+#include <QQmlApplicationEngine>
 #include <QtCore/QDir>
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlEngine>
 #include <QtQuick/QQuickView>
-#include <QtWidgets/QApplication>
 #include <cmath>
 #include <iostream>
 #include <memory>
 
 int main(int argc, char *argv[]) {
+
   QApplication app(argc, argv);
 
   app.setWindowIcon(QIcon(":/images/Logo.png"));
@@ -23,16 +25,16 @@ int main(int argc, char *argv[]) {
   QCommandLineParser parser;
   parser.setApplicationDescription("Ventilator GUI application");
   parser.addHelpOption();
+
   // Support this option so we can verify that the GUI can start up at all,
   // e.g. load all resources and so on.
   QCommandLineOption startupOnlyOption(
       QStringList() << "startup-only",
-      QApplication::translate("main",
-                              "Start up and exit successfully (for testing)"));
+      QObject::tr("main", "Start up and exit successfully (for testing)"));
+
   QCommandLineOption serialPortOption(
       QStringList() << "serial-port",
-      QApplication::translate(
-          "main", "Serial port filename. Uses fake data if not set."));
+      QObject::tr("main", "Serial port filename. Uses fake data if not set."));
   serialPortOption.setValueName("port");
 
   parser.addOption(startupOnlyOption);
@@ -57,14 +59,14 @@ int main(int argc, char *argv[]) {
           // For now, completely ignore gui_status.
           (void)gui_status;
           /* std::cout << "uptime_ms = " << gui_status.uptime_ms << ", "
-            << "desired_params = {"
-            << "mode = " << gui_status.desired_params.mode << ", "
-            << "peep = " << gui_status.desired_params.peep_cm_h2o << ", "
-            << "rr = " << gui_status.desired_params.breaths_per_min << ", "
-            << "pip = " << gui_status.desired_params.pip_cm_h2o << ", "
-            << "ier = " <<
-            gui_status.desired_params.inspiratory_expiratory_ratio
-            << "}" << std::endl; */
+          << "desired_params = {"
+          << "mode = " << gui_status.desired_params.mode << ", "
+          << "peep = " << gui_status.desired_params.peep_cm_h2o << ", "
+          << "rr = " << gui_status.desired_params.breaths_per_min << ", "
+          << "pip = " << gui_status.desired_params.pip_cm_h2o << ", "
+          << "ier = " <<
+          gui_status.desired_params.inspiratory_expiratory_ratio
+          << "}" << std::endl; */
         },
         [&](ControllerStatus *controller_status) {
           // Fill the status with fake data.
@@ -90,16 +92,9 @@ int main(int argc, char *argv[]) {
   });
   communicate.Start();
 
-  QQuickView mainView;
-  mainView.setTitle(QStringLiteral("Ventilator"));
-
-  mainView.rootContext()->setContextProperty("guiState", &state_container);
-
-  mainView.setSource(QUrl("qrc:/main.qml"));
-  mainView.setResizeMode(QQuickView::SizeRootObjectToView);
-  mainView.setColor(QColor("#000000"));
-
-  mainView.showFullScreen();
+  QQmlApplicationEngine engine;
+  engine.rootContext()->setContextProperty("guiState", &state_container);
+  engine.load(QUrl(QStringLiteral("qrc:/main.qml")));
 
   if (parser.isSet(startupOnlyOption)) {
     return EXIT_SUCCESS;

--- a/gui/main.qml
+++ b/gui/main.qml
@@ -2,345 +2,123 @@ import QtQuick 2.11
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.4
 
-Item
-{
-    id: mainWindow
+import "modes"
+import "controls"
+
+ApplicationWindow {
+    id: window
+    visible: true
     width: 1024
     height: 600
+    title: qsTr("Ventilator")
 
-    Timer // TODO: Make data sources be updated as we get data
-    {
-        id: refreshTimer
-        interval: 1 / 15 * 1000 // 60 Hz
-        running: true
-        repeat: true
-        onTriggered: {
-            guiState.update(
-                pressureView.series(0),
-                flowView.series(0),
-                tidalVolumeView.series(0));
-        }
+    // uncomment this like if you want to see it full-screen
+    // But that shouldn't matter on rPI running on EGLFS
+    //visibility: Qt.WindowFullScreen
+
+    background: Rectangle {
+        color: Style.theme.color.windowBackground
     }
 
-    Rectangle {
-        id: rectangle
-        color: "#e3e8ee"
-        z: -1
+    header: ToolBar {
+        contentHeight: 60
+        padding: Style.margin.normal
+        background:  Item {  }
+
+        //TODO: Check with UX people how this button will look
+        // like
+        HeaderButton {
+            id: modeSelectionButton
+
+            width: 90
+
+            anchors.verticalCenter: parent.verticalCenter
+            text: pageStack.currentMode.acronym
+            onClicked: modeSelectionPopup.open()
+            contentItem: Text {
+                text: modeSelectionButton.text
+                font.pixelSize: 19
+                color: "white"
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+            }
+        }
+
+        FpsItem {
+            anchors {
+                right: parent.right
+            }
+        }
+
+        Image {
+            anchors.horizontalCenter: parent.horizontalCenter
+            // width will naturally be selected preserving ratio
+            height: parent.height
+            source: "images/respiraWorksLogoHorizontalTransparent.png"
+            fillMode: Image.PreserveAspectFit
+        }
+
+    }
+
+    ModeSelectionPopup {
+        id: modeSelectionPopup
+        currentMode: pageStack.currentMode
+        modesModel: pageStack.modesModel
+    }
+
+    StackView {
+        id: pageStack
         anchors.fill: parent
-    }
 
-    ColumnLayout {
-        id: columnLayout
-        anchors.fill: parent
+        property var currentMode: modesModel.get(0)
 
-
-
-        Item {
-            id: rowLayout1
-            width: parent.width
-            height: 100
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-
-            FpsItem {}
-
-            Image {
-                id: image
-                anchors.horizontalCenter: parent.horizontalCenter
-                width: 150
-                height: 50
-                clip: false
-                source: "images/respiraWorksLogoHorizontalTransparent.png"
-                fillMode: Image.PreserveAspectFit
+        property ListModel modesModel: ListModel {
+            ListElement {
+                mode: "command_pressure_mode"
+                title: qsTr("Command Pressure")
+                acronym: "PC"
+            }
+            ListElement {
+                mode: "pressure_assist_mode"
+                title: qsTr("Pressure Assist")
+                acronym: "A/C PC"
+            }
+            ListElement {
+                mode: "high_flow_nasal_cannula_mode"
+                title: qsTr("High-flow nasal cannula")
+                acronym: "HFNC"
             }
         }
 
-        RowLayout {
-            id: rowLayout
-            width: 100
-            height: 100
-
-            ColumnLayout {
-                id: columnLayout1
-                width: 100
-                height: 100
-                Layout.maximumHeight: 65356
-                Layout.maximumWidth: 6553
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.minimumWidth: 200
-
-                StepCounter {
-                    id: rrStepCounter
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.topMargin: 10
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-
-                    title: qsTr("RR")
-                    value: guiState.rr
-                    onValueModified: guiState.rr = value
-                }
-
-                StepCounter {
-                    id: peepStepCounter
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.topMargin: 10
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-
-                    title: qsTr("PEEP")
-                    value: guiState.peep
-                    onValueModified: guiState.peep = value
-                }
-
-                StepCounter {
-                    id: pipStepCounter
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.topMargin: 10
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-
-                    title: qsTr("PIP")
-                    value: guiState.pip
-                    onValueModified: guiState.pip = value
-                }
-
-                StepCounter {
-                    id: ierStepCounter
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumWidth: 150
-                    Layout.minimumHeight: 100
-                    Layout.topMargin: 10
-                    Layout.rightMargin: 10
-                    Layout.leftMargin: 10
-
-                    title: qsTr("I:E")
-                    stepSize: 0.1
-                    value: guiState.ier
-                    onValueModified: guiState.ier = value
-
-                    textFromValue: function (value, locale) {
-                        return Number(value).toFixed(1)
-                    }
-                }
-            }
-
-            GridLayout {
-                id: scopeGridLayout
-                columnSpacing: 0
-                rowSpacing: -20
-                Layout.minimumHeight: 400
-                Layout.minimumWidth: 500
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                flow: GridLayout.TopToBottom
-                rows: 3
-
-                ScopeView {
-                    id: pressureView
-                    name: "Pressure [cmH2O]"
-                    // TODO: Are these reasonable lower and upper bounds?
-                    // Source for current value:
-                    // https://www.rtmagazine.com/public-health/pediatrics/neonatal/selecting-appropriate-ventilator-parameters/
-                    // mentions values in the range 5-30 cmH2O.
-                    yMin: -3
-                    yMax: 30
-
-                    color: "#4f67ff"
-                    Layout.fillHeight: true
-                    Layout.fillWidth: true
-                    Layout.topMargin: 10
-                    height: parent.height/3
-                    width: parent.width
-                }
-
-                ScopeView
-                {
-                    id: flowView
-                    name: "Flow [mL/min]"
-                    // TODO: Are these reasonable lower and upper bounds?
-                    // Source for current value:
-                    // https://www.sciencedirect.com/topics/medicine-and-dentistry/peak-inspiratory-flow
-                    // "Most modern ventilators can deliver flow rates between
-                    // 60 and 120 L/min. "
-                    yMin: -150
-                    yMax: 150
-
-                    color: "green"
-                    Layout.fillHeight: true
-                    Layout.fillWidth: true
-                    Layout.topMargin: 10
-                    height: parent.height/3
-                    width: parent.width
-                }
-
-                ScopeView
-                {
-                    id: tidalVolumeView
-                    name: "Tidal Volume [mL]"
-                    // TODO: Are these reasonable lower and upper bounds?
-                    // Source for current value:
-                    // https://en.wikipedia.org/wiki/Tidal_volume
-                    // "In a healthy, young human adult, tidal volume is
-                    // approximately 500 mL per inspiration or 7 mL/kg of body mass."
-                    // Meaning, 2000 should be enough for a human of ~300kg body mass;
-                    // I don't know whether heavier humans have even larger
-                    // tidal volume.
-                    yMin: 0
-                    yMax: 2000
-
-                    color: "#ffff00"
-                    Layout.fillHeight: true
-                    Layout.fillWidth: true
-                    Layout.topMargin: 10
-                    height: parent.height/3
-                    width: parent.width
-                }
-
-
-
-            }
-
-            ColumnLayout {
-                id: sensorReadouts
-                width: 100
-                height: 100
-                Layout.maximumHeight: 65356
-                Layout.maximumWidth: 6553
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                Layout.minimumWidth: 200
-
-                Rectangle {
-                    id: pressureReadout
-                    color: "#466eeb"
-                    radius: 10
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-
-                    Text {
-                        id: pressureVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text: Number(guiState.pressureReadout, 'g', 1).toFixed(1);
-                        horizontalAlignment: Text.AlignHCenter
-                        font.family: "Times New Roman"
-                        font.weight: Font.DemiBold
-                        font.bold: true
-                        font.pixelSize: 38
-                    }
-
-                    Text {
-                        x: 3
-                        y: 13
-                        text: qsTr("Pressure (cm H2O)")
-                        font.bold: true
-                        font.pixelSize: 17
-                    }
-                    Layout.minimumWidth: 150
-                    Layout.topMargin: 10
-                    Layout.leftMargin: 10
-                }
-
-                Rectangle {
-                    id: flowReadout
-                    color: "#466eeb"
-                    radius: 10
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-
-                    Text {
-                        id: flowVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text: Number(guiState.flowReadout, 'g', 1).toFixed(1);
-                        horizontalAlignment: Text.AlignHCenter
-                        font.weight: Font.DemiBold
-                        font.family: "Times New Roman"
-                        font.pixelSize: 38
-                        font.bold: true
-                    }
-
-                    Text {
-                        x: 23
-                        y: 13
-                        text: qsTr("Flow (mL/min)")
-                        horizontalAlignment: Text.AlignHCenter
-                        font.pixelSize: 17
-                        font.bold: true
-                    }
-
-                    Layout.minimumWidth: 150
-                    Layout.topMargin: 10
-                    Layout.leftMargin: 10
-                }
-
-                Rectangle {
-                    id: tvReadout
-                    color: "#466eeb"
-                    radius: 10
-                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                    Layout.minimumHeight: 100
-                    Layout.rightMargin: 10
-
-                    Text {
-                        id: tvVal
-                        x: 45
-                        y: 39
-                        width: 60
-                        height: 44
-                        text:  Number(guiState.tvReadout, 'g', 1).toFixed(1);
-                        horizontalAlignment: Text.AlignHCenter
-                        font.weight: Font.DemiBold
-                        font.family: "Times New Roman"
-                        font.pixelSize: 38
-                        font.bold: true
-                    }
-
-                    Text {
-                        x: 41
-                        y: 13
-                        text: qsTr("TV (mL)")
-                        horizontalAlignment: Text.AlignHCenter
-                        font.pixelSize: 17
-                        font.bold: true
-                    }
-
-                    Layout.minimumWidth: 150
-                    Layout.topMargin: 10
-                    Layout.leftMargin: 10
-                }
-            }
+        property var components: {
+            "command_pressure_mode": commandPressureMode,
+            "pressure_assist_mode": pressureAssistMode,
+            "high_flow_nasal_cannula_mode": highFlowNasalCannulaMode
         }
 
-        RowLayout {
-            id: rowLayout2
-            width: 100
-            height: 50
-            Layout.minimumHeight: 50
-            Layout.maximumHeight: 65535
+        onCurrentModeChanged: {
+            pageStack.replace(components[currentMode.mode])
+        }
+
+        Connections {
+            target: modeSelectionPopup
+            onSelectedMode: pageStack.currentMode = mode
         }
     }
-}
 
-/*##^##
-Designer {
-    D{i:2;anchors_height:93;anchors_width:185}D{i:3;anchors_height:600;anchors_width:839;anchors_x:157;anchors_y:0}
+    Component {
+        id: pressureAssistMode
+        PressureAssistMode {}
+    }
+
+    Component {
+        id: commandPressureMode
+        CommandPressureMode {}
+    }
+
+    Component {
+        id: highFlowNasalCannulaMode
+        HighFlowNasalCannulaMode {}
+    }
 }
-##^##*/
-/*##^## Designer {
-    D{i:2;anchors_height:200;anchors_width:200}
-}
- ##^##*/

--- a/gui/modes/CommandPressureMode.qml
+++ b/gui/modes/CommandPressureMode.qml
@@ -1,0 +1,308 @@
+import QtQuick 2.11
+import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.4
+
+import "../controls"
+import ".."
+
+Mode {
+    Timer // TODO: Make data sources be updated as we get data
+    {
+        id: refreshTimer
+        interval: 1 / 15 * 1000 // 60 Hz
+        running: true
+        repeat: true
+        onTriggered: {
+            // TODO: guiState as a contextObject is not great
+            // as you lose autocomplete and you might infect
+            // a lot of files. Context objects will also be
+            // removed on Qt6. So better use singleton instead
+            guiState.update(
+                        pressureView.series(0),
+                        flowView.series(0),
+                        tidalVolumeView.series(0));
+        }
+    }
+
+    ColumnLayout {
+        id: columnLayout
+        anchors.fill: parent
+
+        RowLayout {
+            id: rowLayout
+            width: 100
+            height: 100
+
+            ColumnLayout {
+                id: columnLayout1
+                width: 100
+                height: 100
+                Layout.maximumHeight: 65356
+                Layout.maximumWidth: 6553
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                Layout.minimumWidth: 200
+
+                StepCounter {
+                    id: rrStepCounter
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumWidth: 150
+                    Layout.minimumHeight: 100
+                    Layout.topMargin: 10
+                    Layout.rightMargin: 10
+                    Layout.leftMargin: 10
+
+                    title: qsTr("RR")
+                    value: guiState.rr
+                    onValueModified: guiState.rr = value
+                }
+
+                StepCounter {
+                    id: peepStepCounter
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumWidth: 150
+                    Layout.minimumHeight: 100
+                    Layout.topMargin: 10
+                    Layout.rightMargin: 10
+                    Layout.leftMargin: 10
+
+                    title: qsTr("PEEP")
+                    value: guiState.peep
+                    onValueModified: guiState.peep = value
+                }
+
+                StepCounter {
+                    id: pipStepCounter
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumWidth: 150
+                    Layout.minimumHeight: 100
+                    Layout.topMargin: 10
+                    Layout.rightMargin: 10
+                    Layout.leftMargin: 10
+
+                    title: qsTr("PIP")
+                    value: guiState.pip
+                    onValueModified: guiState.pip = value
+                }
+
+                StepCounter {
+                    id: ierStepCounter
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumWidth: 150
+                    Layout.minimumHeight: 100
+                    Layout.topMargin: 10
+                    Layout.rightMargin: 10
+                    Layout.leftMargin: 10
+
+                    title: qsTr("I:E")
+                    stepSize: 0.1
+                    value: guiState.ier
+                    onValueModified: guiState.ier = value
+
+                    textFromValue: function (value, locale) {
+                        return Number(value).toFixed(1)
+                    }
+                }
+            }
+
+            GridLayout {
+                id: scopeGridLayout
+                columnSpacing: 0
+                rowSpacing: -20
+                Layout.minimumHeight: 400
+                Layout.minimumWidth: 500
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                flow: GridLayout.TopToBottom
+                rows: 3
+
+                ScopeView {
+                    id: pressureView
+                    name: "Pressure [cmH2O]"
+                    // TODO: Are these reasonable lower and upper bounds?
+                    // Source for current value:
+                    // https://www.rtmagazine.com/public-health/pediatrics/neonatal/selecting-appropriate-ventilator-parameters/
+                    // mentions values in the range 5-30 cmH2O.
+                    yMin: -3
+                    yMax: 30
+
+                    color: "#4f67ff"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.topMargin: 10
+                    height: parent.height/3
+                    width: parent.width
+                }
+
+                ScopeView
+                {
+                    id: flowView
+                    name: "Flow [mL/min]"
+                    // TODO: Are these reasonable lower and upper bounds?
+                    // Source for current value:
+                    // https://www.sciencedirect.com/topics/medicine-and-dentistry/peak-inspiratory-flow
+                    // "Most modern ventilators can deliver flow rates between
+                    // 60 and 120 L/min. "
+                    yMin: -150
+                    yMax: 150
+
+                    color: "green"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.topMargin: 10
+                    height: parent.height/3
+                    width: parent.width
+                }
+
+                ScopeView
+                {
+                    id: tidalVolumeView
+                    name: "Tidal Volume [mL]"
+                    // TODO: Are these reasonable lower and upper bounds?
+                    // Source for current value:
+                    // https://en.wikipedia.org/wiki/Tidal_volume
+                    // "In a healthy, young human adult, tidal volume is
+                    // approximately 500 mL per inspiration or 7 mL/kg of body mass."
+                    // Meaning, 2000 should be enough for a human of ~300kg body mass;
+                    // I don't know whether heavier humans have even larger
+                    // tidal volume.
+                    yMin: 0
+                    yMax: 2000
+
+                    color: "#ffff00"
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.topMargin: 10
+                    height: parent.height/3
+                    width: parent.width
+                }
+
+            }
+
+            ColumnLayout {
+                id: sensorReadouts
+                width: 100
+                height: 100
+                Layout.maximumHeight: 65356
+                Layout.maximumWidth: 6553
+                Layout.fillHeight: true
+                Layout.fillWidth: true
+                Layout.minimumWidth: 200
+
+                Rectangle {
+                    id: pressureReadout
+                    color: "#466eeb"
+                    radius: 10
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumHeight: 100
+                    Layout.rightMargin: 10
+
+                    Text {
+                        id: pressureVal
+                        x: 45
+                        y: 39
+                        width: 60
+                        height: 44
+                        text: Number(guiState.pressureReadout, 'g', 1).toFixed(1);
+                        horizontalAlignment: Text.AlignHCenter
+                        font.family: "Times New Roman"
+                        font.weight: Font.DemiBold
+                        font.bold: true
+                        font.pixelSize: 38
+                    }
+
+                    Text {
+                        x: 3
+                        y: 13
+                        text: qsTr("Pressure (cm H2O)")
+                        font.bold: true
+                        font.pixelSize: 17
+                    }
+                    Layout.minimumWidth: 150
+                    Layout.topMargin: 10
+                    Layout.leftMargin: 10
+                }
+
+                Rectangle {
+                    id: flowReadout
+                    color: "#466eeb"
+                    radius: 10
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumHeight: 100
+                    Layout.rightMargin: 10
+
+                    Text {
+                        id: flowVal
+                        x: 45
+                        y: 39
+                        width: 60
+                        height: 44
+                        text: Number(guiState.flowReadout, 'g', 1).toFixed(1);
+                        horizontalAlignment: Text.AlignHCenter
+                        font.weight: Font.DemiBold
+                        font.family: "Times New Roman"
+                        font.pixelSize: 38
+                        font.bold: true
+                    }
+
+                    Text {
+                        x: 23
+                        y: 13
+                        text: qsTr("Flow (mL/min)")
+                        horizontalAlignment: Text.AlignHCenter
+                        font.pixelSize: 17
+                        font.bold: true
+                    }
+
+                    Layout.minimumWidth: 150
+                    Layout.topMargin: 10
+                    Layout.leftMargin: 10
+                }
+
+                Rectangle {
+                    id: tvReadout
+                    color: "#466eeb"
+                    radius: 10
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    Layout.minimumHeight: 100
+                    Layout.rightMargin: 10
+
+                    Text {
+                        id: tvVal
+                        x: 45
+                        y: 39
+                        width: 60
+                        height: 44
+                        text:  Number(guiState.tvReadout, 'g', 1).toFixed(1);
+                        horizontalAlignment: Text.AlignHCenter
+                        font.weight: Font.DemiBold
+                        font.family: "Times New Roman"
+                        font.pixelSize: 38
+                        font.bold: true
+                    }
+
+                    Text {
+                        x: 41
+                        y: 13
+                        text: qsTr("TV (mL)")
+                        horizontalAlignment: Text.AlignHCenter
+                        font.pixelSize: 17
+                        font.bold: true
+                    }
+
+                    Layout.minimumWidth: 150
+                    Layout.topMargin: 10
+                    Layout.leftMargin: 10
+                }
+            }
+        }
+
+        RowLayout {
+            id: rowLayout2
+            width: 100
+            height: 50
+            Layout.minimumHeight: 50
+            Layout.maximumHeight: 65535
+        }
+    }
+}

--- a/gui/modes/HighFlowNasalCannulaMode.qml
+++ b/gui/modes/HighFlowNasalCannulaMode.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.0
+import "../controls"
+
+// TODO: Implement mode
+Mode {
+    Text {
+        anchors.centerIn: parent
+        text: "High Flow Nasal Cannula Mode"
+        color: "white"
+        font.pointSize: 38
+    }
+}

--- a/gui/modes/PressureAssistMode.qml
+++ b/gui/modes/PressureAssistMode.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.0
+import "../controls"
+
+// TODO: Implement mode
+Mode {
+    Text {
+        anchors.centerIn: parent
+        text: "Pressure Assist Mode"
+        color: "white"
+        font.pointSize: 38
+    }
+}

--- a/gui/qml.qrc
+++ b/gui/qml.qrc
@@ -1,13 +1,20 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
-        <file>FpsItem.qml</file>
-        <file>ScopeView.qml</file>
         <file>ControlPanel.qml</file>
         <file>images/respiraWorksLogoHorizontalTransparent.png</file>
         <file>images/Logo.png</file>
         <file>Style.qml</file>
         <file>qmldir</file>
-        <file>StepCounter.qml</file>
+        <file>ModeSelectionPopup.qml</file>
+        <file>controls/FpsItem.qml</file>
+        <file>controls/PopupButton.qml</file>
+        <file>controls/ScopeView.qml</file>
+        <file>controls/StepCounter.qml</file>
+        <file>controls/Mode.qml</file>
+        <file>modes/PressureAssistMode.qml</file>
+        <file>modes/CommandPressureMode.qml</file>
+        <file>modes/HighFlowNasalCannulaMode.qml</file>
+        <file>controls/HeaderButton.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
Mode selection popup will allow us to change the ventilator
operation mode. The design and copies are still
under development and will be refined later.

The organization of the QML files was also changed for easy understanding:

* control/ folder keeps all Pure UI controls, like buttons and widgets
* modes/ folder keeps the implementation of all modes. Later this could be
broken down if it gets too complex.

Add stub modes: PressureAssistMode and SupportPressureMode for
testing the mode selection