### PR TITLE
[GUI] Fix run_eglfs.sh

### DIFF
--- a/gui/kms.json
+++ b/gui/kms.json
@@ -1,5 +1,5 @@
 {
-  "device": "/dev/dri/card1",
+  "device": "/dev/dri/card0",
   "hwcursor": false,
   "pbuffers": true,
   "outputs": [

--- a/gui/run_eglfs.sh
+++ b/gui/run_eglfs.sh
@@ -7,11 +7,17 @@
 # started on the rPi.
 
 # Provides Rendering debug information
-QT_LOGGING_RULES=qt.qpa.*=true
+export QT_LOGGING_RULES=qt.qpa.*=true
 
 # Tells Qt which display to be used.
-DISPLAY=:0
+export DISPLAY=:0
 
-# Run GUI APP forcing to use eglfs with a particular configuration
-# defined in kms.json
-QT_QPA_EGLFS_KMS_CONFIG=kms.json QT_QPA_EGLFS_INTEGRATION=eglfs_kms build/ProjectVentilatorGUI -platform eglfs
+# Please note, the configuration variable for specific HDMI mode is removed
+# because it changes according to the display you plug your raspberry. To
+# force a specific mode, uncomment the line below and update kms.json to
+# use the desired mode
+#export QT_QPA_EGLFS_KMS_CONFIG=kms.json
+export QT_QPA_EGLFS_INTEGRATION=eglfs_kms
+
+# Run GUI APP forcing to use eglfs
+build/ProjectVentilatorGUI -platform eglfs


### PR DESCRIPTION
The bash script environment variables were not properly configured.

Also depending on the screen you plug your device, the mode selected
in kms.json might not be available, causing the app to segfault.

We are commenting the variable that forces the specific mode, letting
Qt decide with mode to use.