### PR TITLE
Issue 418 pinch valve linearize

### DIFF
--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -21,7 +21,7 @@ static PinchValve blower_pinch(0);
 
 // Called once at system startup to initialize any
 // actuators that need it
-void actuators_init(void) { blower_pinch.Home(); }
+void actuators_init(void) {}
 
 void actuators_execute(const ActuatorsState &desired_state) {
   // Open/close the solenoid as appropriate.

--- a/controller/lib/core/pinch_valve.h
+++ b/controller/lib/core/pinch_valve.h
@@ -17,6 +17,21 @@ limitations under the License.
 #define PINCH_VALVE_H
 
 #include "stepper.h"
+#include "units.h"
+
+enum class PinchValveHomeState {
+  DISABLED,
+  LOWER_AMP,
+  SET_HOME_SPEED,
+  MOVE_TO_STOP,
+  WAIT_MOVE_STOP,
+  SET_NORMAL_AMP,
+  MOVE_OFFSET,
+  WAIT_MOVE_OFFSET,
+  ZERO_POS,
+  SET_NORMAL_SPEED,
+  HOMED
+};
 
 // The PinchValve represents a single stepper driven pinch
 // value in the system.
@@ -52,11 +67,15 @@ public:
   // Values outside that range will be clipped.
   void SetOutput(float value);
 
+  // Disable the valve.  It will need to be homed
+  // before it can be used
+  void Disable();
+
 private:
-  StepMtrErr WaitForMove();
+  Time move_start_time_;
 
   StepMotor *mtr_{nullptr};
-  bool homed_{false};
+  PinchValveHomeState home_state_{PinchValveHomeState::DISABLED};
 };
 
 #endif

--- a/controller/lib/hal/stepper.cpp
+++ b/controller/lib/hal/stepper.cpp
@@ -509,7 +509,7 @@ StepMtrErr StepMotor::RunAtVelocity(float vel) {
 // causing any motion
 StepMtrErr StepMotor::SoftStop() {
   uint8_t cmd = static_cast<uint8_t>(StepMtrCmd::SOFT_STOP);
-  return SendCmd(&cmd, 0);
+  return SendCmd(&cmd, 1);
 }
 
 // Stop abruptly and hold position
@@ -517,31 +517,31 @@ StepMtrErr StepMotor::SoftStop() {
 // causing any motion
 StepMtrErr StepMotor::HardStop() {
   uint8_t cmd = static_cast<uint8_t>(StepMtrCmd::HARD_STOP);
-  return SendCmd(&cmd, 0);
+  return SendCmd(&cmd, 1);
 }
 
 // Decelerate to zero velocity and disable
 StepMtrErr StepMotor::SoftDisable() {
   uint8_t cmd = static_cast<uint8_t>(StepMtrCmd::SOFT_DISABLE);
-  return SendCmd(&cmd, 0);
+  return SendCmd(&cmd, 1);
 }
 
 // Immediately disable the motor
 StepMtrErr StepMotor::HardDisable() {
   uint8_t cmd = static_cast<uint8_t>(StepMtrCmd::HARD_DISABLE);
-  return SendCmd(&cmd, 0);
+  return SendCmd(&cmd, 1);
 }
 
 // Reset the motor position to zero
 StepMtrErr StepMotor::ClearPosition() {
   uint8_t cmd = static_cast<uint8_t>(StepMtrCmd::RESET_POS);
-  return SendCmd(&cmd, 0);
+  return SendCmd(&cmd, 1);
 }
 
 // Reset the stepper chip
 StepMtrErr StepMotor::Reset() {
   uint8_t cmd = static_cast<uint8_t>(StepMtrCmd::RESET_DEVICE);
-  return SendCmd(&cmd, 0);
+  return SendCmd(&cmd, 1);
 }
 
 StepMtrErr StepMotor::GetStatus(StepperStatus *stat) {


### PR DESCRIPTION
I made a couple changes to the pinch valves as I work toward closing the loop using these.

1) I changed the homing method so that they get homed using a state machine from the high priority task rather then on startup.  This has several benefits; it allows the watchdog timer to start earlier.  It allows the pinch valves to be disabled when the ventilator is not in use and it allows multiple valves to be homed at the same time when they are enabled.

2) I added a table to roughly linearize the flow sensors so when you command 20% you should get roughly 20% of the full flow rate.  Previously you just got 20% of the pinch valve position.