### PR TITLE
Basic vertical integration tests

### DIFF
--- a/controller/integration_tests/blower_test.h
+++ b/controller/integration_tests/blower_test.h
@@ -1,3 +1,5 @@
+// This test ramps the blower up and down repeatedly
+
 #include "hal.h"
 
 // test parameters

--- a/controller/integration_tests/blower_test.h
+++ b/controller/integration_tests/blower_test.h
@@ -1,0 +1,27 @@
+#include "hal.h"
+
+void run_test() {
+  Hal.init();
+
+  float fan_min{0.0};
+  float fan_max{200.0f / 255.0f};
+  float step{0.002f};
+
+  float fan_power = fan_min;
+
+  while (true) {
+    Hal.analogWrite(PwmPin::BLOWER, fan_power);
+    Hal.delay(milliseconds(10));
+
+    Hal.watchdog_handler();
+
+    fan_power += step;
+    if (fan_power >= fan_max) {
+      fan_power = fan_max;
+      step = -step;
+    } else if (fan_power <= fan_min) {
+      fan_power = fan_min;
+      step = -step;
+    }
+  }
+}

--- a/controller/integration_tests/blower_test.h
+++ b/controller/integration_tests/blower_test.h
@@ -1,25 +1,30 @@
 #include "hal.h"
 
+// test parameters
+static constexpr int64_t delay_ms{10};
+static constexpr float fan_min{0.0f};
+static constexpr float fan_max{200.0f / 255.0f};
+static constexpr float initial_step{0.002f};
+
 void run_test() {
   Hal.init();
 
-  float fan_min{0.0};
-  float fan_max{200.0f / 255.0f};
-  float step{0.002f};
-
   float fan_power = fan_min;
+  float step = initial_step;
 
   while (true) {
     Hal.analogWrite(PwmPin::BLOWER, fan_power);
-    Hal.delay(milliseconds(10));
+    Hal.delay(milliseconds(delay_ms));
 
     Hal.watchdog_handler();
 
     fan_power += step;
     if (fan_power >= fan_max) {
+      // switch to ramp-down state
       fan_power = fan_max;
       step = -step;
     } else if (fan_power <= fan_min) {
+      // switch to ramp-up state
       fan_power = fan_min;
       step = -step;
     }

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -4,7 +4,7 @@ int main() {
   Hal.init();
 
   float fan_min{0.0};
-  float fan_max{0.5};
+  float fan_max{0.75};
   float step{0.001f};
 
   float fan_power = fan_min;

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -4,8 +4,8 @@ int main() {
   Hal.init();
 
   float fan_min{0.0};
-  float fan_max{0.75};
-  float step{0.001f};
+  float fan_max{200.0f / 255.0f};
+  float step{0.005f};
 
   float fan_power = fan_min;
 

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -1,0 +1,27 @@
+#include "hal.h"
+
+int main() {
+  Hal.init();
+
+  float fan_min{0.0};
+  float fan_max{0.5};
+  float step{0.001f};
+
+  float fan_power = fan_min;
+
+  while (true) {
+    Hal.analogWrite(PwmPin::BLOWER, fan_power);
+    Hal.delay(milliseconds(10));
+
+    Hal.watchdog_handler();
+
+    fan_power += step;
+    if (fan_power >= fan_max) {
+      fan_power = fan_max;
+      step = -step;
+    } else if (fan_power <= fan_min) {
+      fan_power = fan_min;
+      step = -step;
+    }
+  }
+}

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -2,6 +2,8 @@
 #include "blower_test.h"
 #elif SOLENOID_TEST
 #include "solenoid_test.h"
+#elif STEPPER_TEST
+#include "stepper_test.h"
 #endif
 
 int main() { run_test(); }

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -1,3 +1,5 @@
+// Using these compile-time defines to avoid multiple directories and mains
+
 #ifdef BLOWER_TEST
 #include "blower_test.h"
 #elif SOLENOID_TEST

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -6,6 +6,8 @@
 #include "solenoid_test.h"
 #elif STEPPER_TEST
 #include "stepper_test.h"
+#elif PINCH_VALVE_TEST
+#include "pinch_valve_test.h"
 #endif
 
 int main() { run_test(); }

--- a/controller/integration_tests/main.cpp
+++ b/controller/integration_tests/main.cpp
@@ -1,27 +1,7 @@
-#include "hal.h"
+#ifdef BLOWER_TEST
+#include "blower_test.h"
+#elif SOLENOID_TEST
+#include "solenoid_test.h"
+#endif
 
-int main() {
-  Hal.init();
-
-  float fan_min{0.0};
-  float fan_max{200.0f / 255.0f};
-  float step{0.005f};
-
-  float fan_power = fan_min;
-
-  while (true) {
-    Hal.analogWrite(PwmPin::BLOWER, fan_power);
-    Hal.delay(milliseconds(10));
-
-    Hal.watchdog_handler();
-
-    fan_power += step;
-    if (fan_power >= fan_max) {
-      fan_power = fan_max;
-      step = -step;
-    } else if (fan_power <= fan_min) {
-      fan_power = fan_min;
-      step = -step;
-    }
-  }
-}
+int main() { run_test(); }

--- a/controller/integration_tests/pinch_valve_test.h
+++ b/controller/integration_tests/pinch_valve_test.h
@@ -1,3 +1,5 @@
+// This test repeatedly opens and closes a pinch valve
+
 #include "hal.h"
 #include "pinch_valve.h"
 

--- a/controller/integration_tests/pinch_valve_test.h
+++ b/controller/integration_tests/pinch_valve_test.h
@@ -1,0 +1,21 @@
+#include "hal.h"
+#include "pinch_valve.h"
+
+// test parameters
+static constexpr int64_t delay_ms{1000};
+
+void run_test() {
+  Hal.init();
+  PinchValve pinch_valve(0);
+  pinch_valve.Home();
+
+  bool valve_open{false};
+  while (true) {
+    pinch_valve.SetOutput(valve_open ? 1.0f : 0.0f);
+    Hal.delay(milliseconds(delay_ms));
+
+    Hal.watchdog_handler();
+
+    valve_open = !valve_open;
+  }
+}

--- a/controller/integration_tests/pure_virtual.cpp
+++ b/controller/integration_tests/pure_virtual.cpp
@@ -1,0 +1,30 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "hal.h"
+
+// Provide an implementation of __cxa_pure_virtual, which is called when you
+// try to invoke a pure-virtual function.  Without this, the default
+// implementation of __cxa_pure_virtual calls malloc.
+//
+// If we ever make unit tests run on device, this may need to move into
+// controller/lib, and every library (or, every library that has a pure virtual
+// function) will need to depend on it.  That's a little tricky since
+// platformio discovers library dependencies via header files, and all this
+// really needs is to be linked in.  But we could e.g. just include a dummy
+// header in the putative library from each file with a pure virtual function.
+// We'd probably also need to remove the dependency on hal, so this could be
+// used from libraries that don't link with hal.
+extern "C" void __cxa_pure_virtual() { Hal.reset_device(); }

--- a/controller/integration_tests/solenoid_test.h
+++ b/controller/integration_tests/solenoid_test.h
@@ -1,3 +1,5 @@
+// This test switches the binary solenoid between the open and closed position
+
 #include "hal.h"
 
 // test parameters

--- a/controller/integration_tests/solenoid_test.h
+++ b/controller/integration_tests/solenoid_test.h
@@ -1,9 +1,10 @@
 #include "hal.h"
 
+// test parameters
+static constexpr int64_t delay_ms{1000};
+
 void run_test() {
   Hal.init();
-
-  int64_t delay_ms{1000};
 
   bool solenoid_state = false;
 

--- a/controller/integration_tests/solenoid_test.h
+++ b/controller/integration_tests/solenoid_test.h
@@ -1,0 +1,20 @@
+#include "hal.h"
+
+void run_test() {
+  Hal.init();
+
+  int64_t delay_ms{1000};
+
+  bool solenoid_state = false;
+
+  while (true) {
+    Hal.digitalWrite(BinaryPin::SOLENOID,
+                     solenoid_state ? VoltageLevel::LOW : VoltageLevel::HIGH);
+
+    Hal.delay(milliseconds(delay_ms));
+
+    Hal.watchdog_handler();
+
+    solenoid_state = !solenoid_state;
+  }
+}

--- a/controller/integration_tests/stepper_test.h
+++ b/controller/integration_tests/stepper_test.h
@@ -1,0 +1,24 @@
+#include "hal.h"
+#include "stepper.h"
+#include <cmath>
+
+StepMotor *mtr_{nullptr};
+
+void run_test() {
+  float step_degrees{-30.0f};
+  int64_t delay_ms{1000};
+
+  Hal.init();
+  mtr_ = StepMotor::GetStepper(0);
+  mtr_->SetAmpAll(0.1f);
+  mtr_->SetMaxSpeed(100.0f);
+  mtr_->SetAccel(100.0f / 0.1f);
+  mtr_->ClearPosition();
+
+  while (true) {
+    mtr_->MoveRel(step_degrees);
+    Hal.delay(milliseconds(delay_ms));
+
+    Hal.watchdog_handler();
+  }
+}

--- a/controller/integration_tests/stepper_test.h
+++ b/controller/integration_tests/stepper_test.h
@@ -1,3 +1,5 @@
+// This test rotates a stepper clockwise at a predefined rate and steps
+
 #include "hal.h"
 #include "stepper.h"
 #include <cmath>

--- a/controller/integration_tests/stepper_test.h
+++ b/controller/integration_tests/stepper_test.h
@@ -2,21 +2,22 @@
 #include "stepper.h"
 #include <cmath>
 
-StepMotor *mtr_{nullptr};
+// test parameters
+static constexpr float step_degrees{-30.0f};
+static constexpr int64_t delay_ms{1000};
 
 void run_test() {
-  float step_degrees{-30.0f};
-  int64_t delay_ms{1000};
-
   Hal.init();
-  mtr_ = StepMotor::GetStepper(0);
-  mtr_->SetAmpAll(0.1f);
-  mtr_->SetMaxSpeed(100.0f);
-  mtr_->SetAccel(100.0f / 0.1f);
-  mtr_->ClearPosition();
+
+  // Configure stepper
+  StepMotor *stepper_motor = StepMotor::GetStepper(0);
+  stepper_motor->SetAmpAll(0.1f);
+  stepper_motor->SetMaxSpeed(100.0f);
+  stepper_motor->SetAccel(100.0f / 0.1f);
+  stepper_motor->ClearPosition();
 
   while (true) {
-    mtr_->MoveRel(step_degrees);
+    stepper_motor->MoveRel(step_degrees);
     Hal.delay(milliseconds(delay_ms));
 
     Hal.watchdog_handler();

--- a/platformio.ini
+++ b/platformio.ini
@@ -107,6 +107,18 @@ board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>
 
+[env:int-test-pinch-valve]
+platform = ststm32
+board = custom_stm32
+build_flags =
+  ${env.build_flags}
+  ${respiraworks.stm32_build_flags}
+  -DBARE_STM32
+  -DPINCH_VALVE_TEST
+board_build.ldscript = boards/stm32_ldscript.ld
+extra_scripts = pre:boards/stm32_scripts.py
+src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>
+
 [env:native]
 platform = native
 lib_extra_dirs =

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,6 +95,18 @@ board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>
 
+[env:int-test-stepper]
+platform = ststm32
+board = custom_stm32
+build_flags =
+  ${env.build_flags}
+  ${respiraworks.stm32_build_flags}
+  -DBARE_STM32
+  -DSTEPPER_TEST
+board_build.ldscript = boards/stm32_ldscript.ld
+extra_scripts = pre:boards/stm32_scripts.py
+src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>
+
 [env:native]
 platform = native
 lib_extra_dirs =

--- a/platformio.ini
+++ b/platformio.ini
@@ -78,7 +78,6 @@ build_flags =
   ${env.build_flags}
   ${respiraworks.stm32_build_flags}
   -DBARE_STM32
-  -DUART_VIA_DMA
 board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,7 +56,7 @@ build_flags =
   -DBARE_STM32
 board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
-src_filter = ${env.src_filter} -<test/> -<src_test/>
+src_filter = ${env.src_filter} -<test/> -<src_test/> -<integration_tests/>
 
 # Experimental integration test for STM32 with DMA-based communication.
 [env:stm32-test]
@@ -69,7 +69,19 @@ build_flags =
   -DUART_VIA_DMA
 board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
-src_filter = ${env.src_filter} -<test/> -<src/> +<src_test/>
+src_filter = ${env.src_filter} -<test/> -<src/> +<src_test/> -<integration_tests/>
+
+[env:integration-test]
+platform = ststm32
+board = custom_stm32
+build_flags =
+  ${env.build_flags}
+  ${respiraworks.stm32_build_flags}
+  -DBARE_STM32
+  -DUART_VIA_DMA
+board_build.ldscript = boards/stm32_ldscript.ld
+extra_scripts = pre:boards/stm32_scripts.py
+src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>
 
 [env:native]
 platform = native
@@ -84,7 +96,7 @@ lib_deps =
 ; https://community.platformio.org/t/gtest-not-working-on-pio-4-1/10465/7
 lib_compat_mode = off
 extra_scripts = platformio_sanitizers.py
-src_filter = ${env.src_filter} -<src_test/>
+src_filter = ${env.src_filter} -<src_test/> -<integration_tests/>
 
 ; Run clang-tidy only on native: it seems to get confused by headers that can
 ; only be parsed by gcc.

--- a/platformio.ini
+++ b/platformio.ini
@@ -71,13 +71,26 @@ board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> +<src_test/> -<integration_tests/>
 
-[env:integration-test]
+[env:int-test-blower]
 platform = ststm32
 board = custom_stm32
 build_flags =
   ${env.build_flags}
   ${respiraworks.stm32_build_flags}
   -DBARE_STM32
+  -DBLOWER_TEST
+board_build.ldscript = boards/stm32_ldscript.ld
+extra_scripts = pre:boards/stm32_scripts.py
+src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>
+
+[env:int-test-solenoid]
+platform = ststm32
+board = custom_stm32
+build_flags =
+  ${env.build_flags}
+  ${respiraworks.stm32_build_flags}
+  -DBARE_STM32
+  -DSOLENOID_TEST
 board_build.ldscript = boards/stm32_ldscript.ld
 extra_scripts = pre:boards/stm32_scripts.py
 src_filter = ${env.src_filter} -<test/> -<src/> -<src_test/> +<integration_tests/>

--- a/test.sh
+++ b/test.sh
@@ -27,6 +27,11 @@ cd "$(dirname "$0")"
 # Controller unit tests on native.
 pio test -e native
 
+# Make sure controller integration tests build for target platform.
+pio run -e int-test-blower
+pio run -e int-test-solenoid
+pio run -e int-test-stepper
+
 # Make sure controller builds for target platform.
 pio run -e stm32
 

--- a/test.sh
+++ b/test.sh
@@ -31,6 +31,7 @@ pio test -e native
 pio run -e int-test-blower
 pio run -e int-test-solenoid
 pio run -e int-test-stepper
+pio run -e int-test-pinch-valve
 
 # Make sure controller builds for target platform.
 pio run -e stm32


### PR DESCRIPTION
These look like primitive demo programs you might get with a driver library. That they are. And hopefully they can be examples to some of the hardware team for acclimating to our HAL.

But they are also test cases that we can use to confirm our software-hardware stacks behave the same from prototype to prototype. Each can be deployed to the controller and effects are easy enough to confirm visually. This we can start taking advantage of ASAP among everyone with some semblance of pizza.

The next immediate plans for this code are:
* spin up Jenkins server (or something similar) to deploy each test to a hardware unit, make this part of CI
* upon receiving some additional sensor hardware, automate confirmation of actuator work by either reading voltages or measuring some downstream effects (TBD)

Longer-term goals:
* Devise tests for sensors
* Replicate some of the calibration-data-gathering code used by hardware team, make this process reproducible and easy
* Devise more sophisticated tests
* Input welcome