### PR TITLE
Set default params for NO_GUI_DEV_MODE.

### DIFF
--- a/controller/lib/debug/vars.h
+++ b/controller/lib/debug/vars.h
@@ -132,8 +132,9 @@ private:
 
 class DebugInt32 : public DebugVar {
 public:
-  DebugInt32(const char *name, const char *help = "", const char *fmt = "%d")
-      : DebugVar(name, &value_, help, fmt) {}
+  explicit DebugInt32(const char *name, const char *help = "", int32_t init = 0,
+                      const char *fmt = "%d")
+      : DebugVar(name, &value_, help, fmt), value_(init) {}
 
   void Set(int32_t v) { value_ = v; }
   int32_t Get() { return value_; }
@@ -144,8 +145,9 @@ private:
 
 class DebugUInt32 : public DebugVar {
 public:
-  DebugUInt32(const char *name, const char *help = "", const char *fmt = "%u")
-      : DebugVar(name, &value_, help, fmt) {}
+  explicit DebugUInt32(const char *name, const char *help = "",
+                       uint32_t init = 0, const char *fmt = "%u")
+      : DebugVar(name, &value_, help, fmt), value_(init) {}
 
   void Set(uint32_t v) { value_ = v; }
   uint32_t Get() { return value_; }
@@ -156,8 +158,9 @@ private:
 
 class DebugFloat : public DebugVar {
 public:
-  DebugFloat(const char *name, const char *help = "", const char *fmt = "%.3f")
-      : DebugVar(name, &value_, help, fmt) {}
+  explicit DebugFloat(const char *name, const char *help = "", float init = 0,
+                      const char *fmt = "%.3f")
+      : DebugVar(name, &value_, help, fmt), value_(init) {}
 
   void Set(float v) { value_ = v; }
   float Get() { return value_; }

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -72,12 +72,15 @@ limitations under the License.
 //
 // "Sends" data to the "GUI" via a simple serial protocol.  This can be parsed
 // and graphed by e.g. the Arduino IDE (tools -> serial plotter).
-static DebugUInt32 gui_mode("gui_mode", "Mode setting for GUI free testing");
-static DebugUInt32 gui_bpm("gui_bpm", "Breaths/min for GUI free testing");
-static DebugUInt32 gui_peep("gui_peep", "PEEP (cm/h2O) for GUI free testing");
-static DebugUInt32 gui_pip("gui_pip", "PIP (cm/h2O) for GUI free testing");
-static DebugFloat gui_ie_ratio("gui_ie_ratio",
-                               "I/E ratio for GUI free testing");
+static DebugUInt32
+    gui_mode("gui_mode", "Mode setting for GUI free testing",
+             static_cast<uint32_t>(VentMode::VentMode_PRESSURE_CONTROL));
+static DebugUInt32 gui_bpm("gui_bpm", "Breaths/min for GUI free testing", 15);
+static DebugUInt32 gui_peep("gui_peep", "PEEP (cm/h2O) for GUI free testing",
+                            5);
+static DebugUInt32 gui_pip("gui_pip", "PIP (cm/h2O) for GUI free testing", 15);
+static DebugFloat gui_ie_ratio("gui_ie_ratio", "I/E ratio for GUI free testing",
+                               0.66f);
 static void DEV_MODE_comms_handler(const ControllerStatus &controller_status,
                                    GuiStatus *gui_status) {
   gui_status->desired_params.mode = static_cast<VentMode>(gui_mode.Get());


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Set default params for NO_GUI_DEV_MODE.
    
    Rather than starting the ventilator off, set some default values for the
    NO_GUI_DEV_MODE params.
    
    To do this, we had to modify the DebugT classes to let you specify a
    default value on construction.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #427 Set default params for NO_GUI_DEV_MODE. 👈 **YOU ARE HERE**
1. #428 Refactor controller_debug's `debug` command.
1. #429 Sort includes in controller_debug.py.
1. #430 controller_debug: Print help for trace.
1. #431 Fix typo: seperate -> separate.
1. #432 Add readline to list of imports.
1. #433 Get rid of most "global" statements.
1. #434 Get rid of crc16 global variable.
1. #436 Add documentation for `exec` command.
1. #437 Tighten up trace documentation a bit.
1. #438 Use argparse for `trace download` and `console`.

</git-pr-chain>




