### PR TITLE
Refactor controller_debug's `debug` command.

### DIFF
--- a/utils/controller_debug.py
+++ b/utils/controller_debug.py
@@ -111,9 +111,21 @@ class CmdLine(cmd.Cmd):
         self.GetVarInfo()
 
     def do_debug(self, line):
-        """Toggles display of low level serial data on/off"""
+        """Sets display of low level serial data on/off.
+
+        Usage:
+
+          debug on
+          debug off
+        """
         global showSerial
-        showSerial = not showSerial
+        line = line.strip().lower()
+        if line == "on":
+            showSerial = True
+        elif line == "off":
+            showSerial = False
+        else:
+            print("Unknown command; pass 'on' or 'off'.")
 
     def help_run(self):
         print(
@@ -875,15 +887,13 @@ def GetResp(DbgPrint):
 cmdLock = threading.Lock()
 
 
-def SendCmd(op, data=[], timeout=None):
-    global showSerial, ser, cmdLock
-
+def DbgPrint(*args, **kwargs):
     if showSerial:
-        DbgPrint = print
-    else:
+        print(*args, **kwargs)
 
-        def DbgPrint(S="", end="\n"):
-            pass
+
+def SendCmd(op, data=[], timeout=None):
+    global ser, cmdLock
 
     buff = [op] + data
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Refactor controller_debug's `debug` command.
    
    - Instead of a toggle, you specify 'debug on' or 'debug off'.
    - Declare a global DbgPrint function instead of using a function
      pointer.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #428 Refactor controller_debug's `debug` command. 👈 **YOU ARE HERE**
1. #429 Sort includes in controller_debug.py.
1. #430 controller_debug: Print help for trace.
1. #431 Fix typo: seperate -> separate.
1. #432 Add readline to list of imports.
1. #433 Get rid of most "global" statements.
1. #434 Get rid of crc16 global variable.
1. #436 Add documentation for `exec` command.
1. #437 Tighten up trace documentation a bit.
1. #438 Use argparse for `trace download` and `console`.

</git-pr-chain>






