### PR TITLE
Add readline to list of imports.

### DIFF
--- a/utils/controller_debug.py
+++ b/utils/controller_debug.py
@@ -13,6 +13,7 @@ import glob
 import math
 import matplotlib.pyplot as plt
 import os
+import readline
 import serial
 import struct
 import sys


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Add readline to list of imports.
    
    This makes the cmd module use readline for handling inputs, so things
    like ctrl+A work.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #432 Add readline to list of imports. 👈 **YOU ARE HERE**
1. #433 Get rid of most "global" statements.
1. #434 Get rid of crc16 global variable.
1. #436 Add documentation for `exec` command.
1. #437 Tighten up trace documentation a bit.
1. #438 Use argparse for `trace download` and `console`.

</git-pr-chain>










