### PR TITLE
Revert "Removed time checks from PID library."

### DIFF
--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -23,14 +23,21 @@ float PID::Compute(Time now, float input, float setpoint) {
   if (!initialized_) {
     last_input_ = input;
     last_error_ = setpoint - input;
-
+    next_sample_time_ = now;
     // last call time defined as now - SampleTime to enable computation on first
     // call (user should call Compute() immediately after SetMode(Auto))
+    last_update_time_ = now - sample_period_;
     initialized_ = true;
   }
 
-  float samplesTimeChangeSec = sample_period_.seconds();
-
+  // compute actual samples time-difference to take jitter into account in
+  // integral and derivative
+  Duration effectiveSampleTime = (now - last_update_time_);
+  float samplesTimeChangeSec = effectiveSampleTime.seconds();
+  // condition to update output : 1 sample time has passed and we have new data
+  if (now < next_sample_time_ || samplesTimeChangeSec <= 0) {
+    return last_output_;
+  }
   // Compute all the working error variables
   float error = setpoint - input;
   float dInput = input - last_input_;
@@ -56,6 +63,9 @@ float PID::Compute(Time now, float input, float setpoint) {
   // Remember some variables for next time
   last_input_ = input;
   last_error_ = error;
+  last_update_time_ = now;
+  // when should we expect to perform our next output calculation
+  next_sample_time_ = next_sample_time_ + sample_period_;
 
   last_output_ = std::clamp(res, out_min_, out_max_);
   return last_output_;
@@ -65,6 +75,8 @@ void PID::Observe(Time now, float input, float setpoint, float actual_output) {
   // All the observable variables are updated the same way as in Compute();
   last_input_ = input;
   last_error_ = setpoint - input;
+  last_update_time_ = now;
+  next_sample_time_ = now + sample_period_;
   // Reset output_sum_ to actual_output so that the next Compute()
   // will adjust it only slightly (as if it had been computed by a current
   // Compute() call), avoiding a spike.

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -74,6 +74,8 @@ private:
   const Duration sample_period_;
 
   bool initialized_ = false;
+  Time next_sample_time_ = millisSinceStartup(0);
+  Time last_update_time_ = millisSinceStartup(0);
   float output_sum_ = 0;
   float last_input_ = 0;
   float last_error_ = 0;


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Revert "Removed time checks from PID library."
    
    This reverts commit be574eaddb12501e9bfff7f74b8f7210dbe554af.
    
    The time checks were removed from PID because we were only calling PID
    from the precisely-timed control loop.  We tried to update the PID every
    (say) 10ms, and we were confident we *would* call every 10ms, plus or
    minus a few microseconds.  But if we happened to call with a delta of
    9.99ms, the PID code would skip our sample!  That's bad.
    
    However, for flow correction, we need our PID library to be able to
    handle the case when the time interval is not constant.  In this case,
    we *do* want time checks.
    
    So in this change we add time checks back.  The next commit makes time
    checking optional, so the PID library can work for both cases.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #462 Revert "Removed time checks from PID library." 👈 **YOU ARE HERE**
1. #465 Granularity of Time and Duration 1ms -> 1us.
1. #463 First pass at TV zeroing.
1. #467 Remove sample-time checking from PID.


</git-pr-chain>


















