### PR TITLE
First pass at TV zeroing.

### DIFF
--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -34,11 +34,15 @@ Controller::Controller()
 
 Duration Controller::GetLoopPeriod() { return PID_SAMPLE_PERIOD; }
 
-ActuatorsState Controller::Run(Time now, const VentParams &params,
-                               const SensorReadings &readings) {
+std::pair<ActuatorsState, ControllerState>
+Controller::Run(Time now, const VentParams &params,
+                const SensorReadings &readings) {
   BlowerSystemState desired_state = fsm_.DesiredState(now, params);
 
   ActuatorsState actuator_state;
+  ControllerState controller_state = {
+      .is_new_breath = desired_state.is_new_breath,
+  };
 
   pid_.SetKP(dbg_kp.Get());
   pid_.SetKI(dbg_ki.Get());
@@ -86,5 +90,5 @@ ActuatorsState Controller::Run(Time now, const VentParams &params,
     break;
   }
 
-  return actuator_state;
+  return {actuator_state, controller_state};
 }

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -6,6 +6,12 @@
 #include "network_protocol.pb.h"
 #include "pid.h"
 #include "units.h"
+#include <utility>
+
+struct ControllerState {
+  // True if this is the first breath of a new cycle.
+  bool is_new_breath;
+};
 
 // This class is here to allow integration of our controller into Modelica
 // software and run closed-loop tests in a simulated physical environment
@@ -13,8 +19,8 @@ class Controller {
 public:
   Controller();
 
-  ActuatorsState Run(Time now, const VentParams &params,
-                     const SensorReadings &readings);
+  std::pair<ActuatorsState, ControllerState>
+  Run(Time now, const VentParams &params, const SensorReadings &readings);
 
   Duration GetLoopPeriod();
 

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -102,7 +102,7 @@ static void DEV_MODE_comms_handler(const ControllerStatus &controller_status,
   debug.Print("%.2f, ", r.inflow_pressure_diff_cm_h2o);
   debug.Print("%.2f, ", r.outflow_pressure_diff_cm_h2o);
   debug.Print("%.2f, ", r.flow_ml_per_min / 1000.0f);
-  // debugPrint("%.2f, ", r.volume_ml / 10.f);
+  debug.Print("%.2f, ", r.volume_ml / 10.f);
   debug.Print("\n");
 }
 #endif
@@ -122,9 +122,13 @@ static void high_priority_task(void *arg) {
   controller_status.sensor_readings = sensors.GetSensorReadings();
 
   // Run our PID loop
-  ActuatorsState actuators_state =
+  auto [actuators_state, controller_state] =
       controller.Run(Hal.now(), controller_status.active_params,
                      controller_status.sensor_readings);
+
+  if (controller_state.is_new_breath) {
+    sensors.NoteNewBreath();
+  }
 
   // TODO update pb library to replace fan_power in ControllerStatus with
   // actuators_state, and remove fan_setpoint_cm_h2o from ControllerStatus


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. First pass at TV zeroing.
    
    Uses PID to push tidal volume to zero on each breath.
    
    The PID could use some tuning, but as a first pass, this works OK for
    me.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #463 First pass at TV zeroing. 👈 **YOU ARE HERE**
1. #467 Remove sample-time checking from PID.


</git-pr-chain>




















