### PR TITLE
Remove sample-time checking from PID.

### DIFF
--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #include "vars.h"
 #include <math.h>
 
-static constexpr Duration PID_SAMPLE_PERIOD = milliseconds(10);
+static constexpr Duration LOOP_PERIOD = milliseconds(10);
 
 static DebugFloat dbg_setpoint("setpoint", "Setpoint pressure, kPa");
 
@@ -29,10 +29,10 @@ static DebugFloat dbg_kd("kd", "Derivative gain for main loop");
 static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint (cmH2O)");
 
 Controller::Controller()
-    : pid_(0.0f, 0.0f, 0.0f, ProportionalTerm::ON_ERROR,
-           DifferentialTerm::ON_MEASUREMENT, 0.f, 1.0f, PID_SAMPLE_PERIOD) {}
+    : pid_(dbg_kp.Get(), dbg_ki.Get(), dbg_kd.Get(), ProportionalTerm::ON_ERROR,
+           DifferentialTerm::ON_MEASUREMENT, /*output_min=*/0.f, /*output_max=*/1.0f) {}
 
-Duration Controller::GetLoopPeriod() { return PID_SAMPLE_PERIOD; }
+Duration Controller::GetLoopPeriod() { return LOOP_PERIOD; }
 
 std::pair<ActuatorsState, ControllerState>
 Controller::Run(Time now, const VentParams &params,

--- a/controller/lib/core/sensors.cpp
+++ b/controller/lib/core/sensors.cpp
@@ -75,20 +75,6 @@ static constexpr Duration VOLUME_INTEGRAL_INTERVAL = milliseconds(5);
 // the constructor are for the "classic PID" control type, which seemed to work
 // well.
 //
-// Note that we have to choose a nominal sample period for the PID.  In reality
-// we sample the PID once per breath; the exact value we use for the sample
-// period is not important so long as it's shorter than our breath period.  If
-// we were to choose a value longer than our breath period, then the PID
-// wouldn't update on some breaths, which is not desirable!
-//
-// TODO: Consider updating the PID interface so that instead of taking sample
-// time as a constructor parameter and rejecting calls that occur before the
-// designated time, it always recomputes based on the new data.  Doing this
-// would require improving the resolution of our clock from milliseconds to
-// microseconds so we don't break the main controller loop's PID, which runs
-// once every few ms, and so wouldn't be happy with rounding errors between x
-// and x+1 ms.
-//
 // FLOW_PID_OUTPUT_MAX is a sanity check, preventing us from using absurdly
 // high flow corrections.  The value below may strike you as absurdly high, but
 // we've seen corrections of 40ml/s be necessary, and 100ml/s gives a safety
@@ -108,7 +94,6 @@ static constexpr Duration VOLUME_INTEGRAL_INTERVAL = milliseconds(5);
 // want to handle the low-flow case as best we can.
 static constexpr float FLOW_PID_KU = 0.20f;
 static constexpr float FLOW_PID_TU = 5;
-static constexpr Duration FLOW_PID_SAMPLE_PERIOD = seconds(1);
 static constexpr VolumetricFlow FLOW_PID_OUTPUT_MAX = ml_per_sec(100);
 
 Sensors::Sensors()
@@ -122,8 +107,7 @@ Sensors::Sensors()
           ProportionalTerm::ON_ERROR,        //
           DifferentialTerm::ON_MEASUREMENT,  //
           -FLOW_PID_OUTPUT_MAX.ml_per_sec(), //
-          FLOW_PID_OUTPUT_MAX.ml_per_sec(),  //
-          FLOW_PID_SAMPLE_PERIOD) {}
+          FLOW_PID_OUTPUT_MAX.ml_per_sec()) {}
 
 // NOTE - I can't do this in the constructor now because it gets called before
 // the HAL is set up, so the busy wait never finishes.

--- a/controller/lib/pid/pid.h
+++ b/controller/lib/pid/pid.h
@@ -36,15 +36,11 @@ class PID {
 public:
   // Constructs the PID using the given parameters.
   PID(float kp, float ki, float kd, ProportionalTerm p_term,
-      DifferentialTerm d_term, float output_min, float output_max,
-      Duration sample_period)
+      DifferentialTerm d_term, float output_min, float output_max)
       : kp_(kp), ki_(ki), kd_(kd), p_term_(p_term), d_term_(d_term),
-        out_min_(output_min), out_max_(output_max),
-        sample_period_(sample_period) {}
+        out_min_(output_min), out_max_(output_max) {}
 
   // Performs one step of the PID calculation.
-  // If this call was ignored due to being within sample time
-  // of the previous call, returns the last returned value.
   float Compute(Time now, float input, float setpoint);
 
   // Call this instead of Compute in case on this step of the control loop
@@ -71,10 +67,7 @@ private:
   const float out_min_;
   const float out_max_;
 
-  const Duration sample_period_;
-
   bool initialized_ = false;
-  Time next_sample_time_ = microsSinceStartup(0);
   Time last_update_time_ = microsSinceStartup(0);
   float output_sum_ = 0;
   float last_input_ = 0;


### PR DESCRIPTION
This is step 3 of my evil plan: https://github.com/RespiraWorks/VentilatorSoftware/pull/462#discussion_r436893099<git-pr-chain>

#### Commits in this PR
1. Remove sample-time checking from PID.
    
    Now PID recomputes every time you call Compute().  Don't want that?
    Then don't call compute!
    
    This is made possible by #465, which changes the timer granularity from
    1ms to 1us.  Without that change, the clock is too granular to be used
    for the high-priority loop, which runs every 10ms -- due to jitter, we
    might read 9ms or 10ms when the actual values are more like 9.999ms or
    10.0001ms, resulting in an amplification of error.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #467 Remove sample-time checking from PID. 👈 **YOU ARE HERE**


</git-pr-chain>








