### PR TITLE
Build with -wno-error=sign-compare.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -42,6 +42,7 @@ build_flags =
   -Werror
   -Wconversion
   -Wno-sign-conversion
+  -Wno-error=sign-compare
 build_unflags =
   -std=gnu++11
   -std=gnu++14


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Build with -wno-error=sign-compare.
    
    This warning is about doing (int)x < (unsigned int)y.
    
    AFAICT this is all noise for us, and in fact clang doesn't even enable
    it with -Wall.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #470 Build with -wno-error=sign-compare. 👈 **YOU ARE HERE**
1. #471 Remove unnecessary DbgPrint param from GetResp function.
1. #462 Revert "Removed time checks from PID library."
1. #465 Granularity of Time and Duration 1ms -> 1us.
1. #463 First pass at TV zeroing.
1. #467 Remove sample-time checking from PID.


</git-pr-chain>


