### PR TITLE
Remove unnecessary DbgPrint param from GetResp function.

### DIFF
--- a/utils/controller_debug.py
+++ b/utils/controller_debug.py
@@ -874,7 +874,7 @@ def EscCmd(buff):
 # before returning.
 # See debug.cpp in the controller source for more detail on
 # command framing.
-def GetResp(DbgPrint):
+def GetResp():
     dat = []
     esc = False
     DbgPrint("Getting resp: ", end="")
@@ -949,7 +949,7 @@ def SendCmd(op, data=[], timeout=None):
             oldto = ser.timeout
             ser.timeout = timeout
 
-        rsp = GetResp(DbgPrint)
+        rsp = GetResp()
         if timeout != None:
             ser.timeout = oldto
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Remove unnecessary DbgPrint param from GetResp function.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #471 Remove unnecessary DbgPrint param from GetResp function. 👈 **YOU ARE HERE**
1. #462 Revert "Removed time checks from PID library."
1. #465 Granularity of Time and Duration 1ms -> 1us.
1. #463 First pass at TV zeroing.
1. #467 Remove sample-time checking from PID.


</git-pr-chain>



