### PR TITLE
Disable sign-compare by using -Wno.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -42,7 +42,7 @@ build_flags =
   -Werror
   -Wconversion
   -Wno-sign-conversion
-  -Wno-error=sign-compare
+  -Wno-sign-compare
 build_unflags =
   -std=gnu++11
   -std=gnu++14


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Disable sign-compare by using -Wno.
    
    Rather than disabling it via -Wno-error.  This way it's totally silent.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #476 Disable sign-compare by using -Wno. 👈 **YOU ARE HERE**
1. #474 Fix units errors in sensors_test.
1. #475 Update to new 3/4" Venturi specifications.
1. #477 Move setpoint_pressure field into ControllerState.


</git-pr-chain>






