### PR TITLE
Use strongly typed sensor readings throughout the controller.

### DIFF
--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -35,8 +35,7 @@ Controller::Controller()
 Duration Controller::GetLoopPeriod() { return LOOP_PERIOD; }
 
 std::pair<ActuatorsState, ControllerState>
-Controller::Run(Time now, const VentParams &params,
-                const SensorReadings &readings) {
+Controller::Run(Time now, const VentParams &params, Sensors *sensors) {
   BlowerSystemState desired_state = fsm_.DesiredState(now, params);
 
   ActuatorsState actuator_state;
@@ -51,7 +50,7 @@ Controller::Run(Time now, const VentParams &params,
   // Not used yet
   actuator_state.fio2_valve = 0.0f;
 
-  float pressure = cmH2O(readings.patient_pressure_cm_h2o).kPa();
+  float pressure = sensors->GetPatientPressure().kPa();
   float setpoint = desired_state.setpoint_pressure.kPa();
   dbg_sp.Set(desired_state.setpoint_pressure.cmH2O());
 

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -35,7 +35,8 @@ Controller::Controller()
 Duration Controller::GetLoopPeriod() { return LOOP_PERIOD; }
 
 std::pair<ActuatorsState, ControllerState>
-Controller::Run(Time now, const VentParams &params, Sensors *sensors) {
+Controller::Run(Time now, const VentParams &params,
+                const SensorValues &sensor_values) {
   BlowerSystemState desired_state = fsm_.DesiredState(now, params);
 
   ActuatorsState actuator_state;
@@ -50,7 +51,7 @@ Controller::Run(Time now, const VentParams &params, Sensors *sensors) {
   // Not used yet
   actuator_state.fio2_valve = 0.0f;
 
-  float pressure = sensors->GetPatientPressure().kPa();
+  float pressure = sensor_values.patient_pressure.kPa();
   float setpoint = desired_state.setpoint_pressure.kPa();
   dbg_sp.Set(desired_state.setpoint_pressure.cmH2O());
 

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -21,7 +21,7 @@ public:
   Controller();
 
   std::pair<ActuatorsState, ControllerState>
-  Run(Time now, const VentParams &params, Sensors *sensors);
+  Run(Time now, const VentParams &params, const SensorValues &sensor_values);
 
   Duration GetLoopPeriod();
 

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -5,6 +5,7 @@
 #include "blower_fsm.h"
 #include "network_protocol.pb.h"
 #include "pid.h"
+#include "sensors.h"
 #include "units.h"
 #include <utility>
 
@@ -20,18 +21,11 @@ public:
   Controller();
 
   std::pair<ActuatorsState, ControllerState>
-  Run(Time now, const VentParams &params, const SensorReadings &readings);
+  Run(Time now, const VentParams &params, Sensors *sensors);
 
   Duration GetLoopPeriod();
 
 private:
-  // Computes the fan power necessary to match pressure setpoint in desired
-  // state by running the necessary step of the pid with input = current
-  // pressure fan power represents the necessary power between 0 (Off) and 1
-  // (full power)
-  float ComputeFanPower(Time now, const BlowerSystemState &desired_state,
-                        const SensorReadings &sensor_readings);
-
   BlowerFsm fsm_;
   PID pid_;
 };

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -28,6 +28,16 @@ Arduino Nano and the MPXV5004GP and MPXV7002DP pressure sensors.
 #include "units.h"
 #include <optional>
 
+// Structure for strongly typed sensor readings, denoted as Values, as opposed
+// to Readings which are generically typed to be readable in serial link
+struct SensorValues {
+  Pressure patient_pressure;
+  VolumetricFlow inflow;
+  VolumetricFlow outflow;
+  VolumetricFlow flow;
+  Volume tidal_volume;
+};
+
 class TVIntegrator {
 public:
   void AddFlow(Time now, VolumetricFlow flow);
@@ -44,8 +54,6 @@ private:
 class Sensors {
 public:
   Sensors();
-
-  Pressure GetPatientPressure() const { return patient_pressure_; };
 
   // Perform some initial sensor calibration.  This function should
   // be called on system startup before any other sensor functions
@@ -68,12 +76,10 @@ public:
   // have been 0.  That should be enough for us to calibrate to.
   void NoteNewBreath();
 
-  // Update sensors values
-  void UpdateValues();
-
-  // format the sensor readings (patient pressure, volumetric flow and tidal
-  // volume) to the SensorReadings structure destined to the GUI.
-  SensorReadings GetSensorReadings();
+  // get the sensor readings (patient pressure, volumetric flow and tidal
+  // volume) to the SensorValues struct destined to the controller and to the
+  // SensorReadings structure destined to the GUI.
+  std::pair<SensorValues, SensorReadings> GetSensorReadings();
 
   // min/max possible reading from MPXV5004GP pressure sensors
   // The canonical list of hardware in the device is: https://bit.ly/3aERr69
@@ -108,14 +114,6 @@ private:
 
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[NUM_SENSORS];
-
-  // Values of sensor readings
-  Pressure patient_pressure_;
-  Pressure inflow_delta_;
-  Pressure outflow_delta_;
-  VolumetricFlow inflow_;
-  VolumetricFlow outflow_;
-  VolumetricFlow corrected_flow_;
 
   // Our flow sensors are subject to roughly two kinds of error:
   //

--- a/controller/lib/core/sensors.h
+++ b/controller/lib/core/sensors.h
@@ -45,6 +45,8 @@ class Sensors {
 public:
   Sensors();
 
+  Pressure GetPatientPressure() const { return patient_pressure_; };
+
   // Perform some initial sensor calibration.  This function should
   // be called on system startup before any other sensor functions
   // are called.
@@ -66,8 +68,11 @@ public:
   // have been 0.  That should be enough for us to calibrate to.
   void NoteNewBreath();
 
-  // get the sensor readings (patient pressure, volumetric flow and tidal
-  // volume) from the sensors
+  // Update sensors values
+  void UpdateValues();
+
+  // format the sensor readings (patient pressure, volumetric flow and tidal
+  // volume) to the SensorReadings structure destined to the GUI.
   SensorReadings GetSensorReadings();
 
   // min/max possible reading from MPXV5004GP pressure sensors
@@ -103,6 +108,14 @@ private:
 
   // Calibrated average sensor values in a zero state.
   Voltage sensors_zero_vals_[NUM_SENSORS];
+
+  // Values of sensor readings
+  Pressure patient_pressure_;
+  Pressure inflow_delta_;
+  Pressure outflow_delta_;
+  VolumetricFlow inflow_;
+  VolumetricFlow outflow_;
+  VolumetricFlow corrected_flow_;
 
   // Our flow sensors are subject to roughly two kinds of error:
   //

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -119,11 +119,11 @@ static Sensors sensors;
 static void high_priority_task(void *arg) {
 
   // Read the sensors
-  sensors.UpdateValues();
+  auto [sensor_values, sensor_readings] = sensors.GetSensorReadings();
 
   // Run our PID loop
   auto [actuators_state, controller_state] =
-      controller.Run(Hal.now(), controller_status.active_params, &sensors);
+      controller.Run(Hal.now(), controller_status.active_params, sensor_values);
 
   if (controller_state.is_new_breath) {
     sensors.NoteNewBreath();
@@ -136,7 +136,7 @@ static void high_priority_task(void *arg) {
   actuators_execute(actuators_state);
 
   // Update some status info
-  controller_status.sensor_readings = sensors.GetSensorReadings();
+  controller_status.sensor_readings = sensor_readings;
   controller_status.fan_power = actuators_state.blower_power;
   controller_status.fan_setpoint_cm_h2o = actuators_state.setpoint_cm_h2o;
 

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -119,12 +119,11 @@ static Sensors sensors;
 static void high_priority_task(void *arg) {
 
   // Read the sensors
-  controller_status.sensor_readings = sensors.GetSensorReadings();
+  sensors.UpdateValues();
 
   // Run our PID loop
   auto [actuators_state, controller_state] =
-      controller.Run(Hal.now(), controller_status.active_params,
-                     controller_status.sensor_readings);
+      controller.Run(Hal.now(), controller_status.active_params, &sensors);
 
   if (controller_state.is_new_breath) {
     sensors.NoteNewBreath();
@@ -137,6 +136,7 @@ static void high_priority_task(void *arg) {
   actuators_execute(actuators_state);
 
   // Update some status info
+  controller_status.sensor_readings = sensors.GetSensorReadings();
   controller_status.fan_power = actuators_state.blower_power;
   controller_status.fan_setpoint_cm_h2o = actuators_state.setpoint_cm_h2o;
 

--- a/controller/test/sensor_tests/sensors_test.cpp
+++ b/controller/test/sensor_tests/sensors_test.cpp
@@ -70,6 +70,7 @@ static SensorReadings update_readings(Duration dt, Pressure patient_pressure,
   Hal.test_setAnalogPin(AnalogPin::OUTFLOW_PRESSURE_DIFF,
                         MPXV5004_PressureToVoltage(outflow_pressure));
   Hal.delay(dt);
+  sensors->UpdateValues();
   return sensors->GetSensorReadings();
 }
 
@@ -99,6 +100,7 @@ TEST(SensorTests, FullScaleReading) {
     SCOPED_TRACE("Pressure " + std::to_string(p.kPa()));
     Hal.test_setAnalogPin(AnalogPin::PATIENT_PRESSURE,
                           MPXV5004_PressureToVoltage(p));
+    sensors.UpdateValues();
     auto readings = sensors.GetSensorReadings();
     EXPECT_PRESSURE_NEAR(cmH2O(readings.patient_pressure_cm_h2o), p);
   }


### PR DESCRIPTION
This is an attempt to keep our data strongly typed as much as possible throughout controller computation.
It converts this data to float_unit only before feeding to the serial link.

I am not 100% satisfied with this solution, but it should help getting our units right.
If someone sees a better solution or a way to make this one better, please comment so we can improve upon this!

For now I just made the existing unit tests pass, but this may require new unit tests as well (for the inevitably many getters we will have when the controller needs access to more stuff from the sensors).
--> with the updated policy, no getters involved and updating the tests was easy enough that I did it already.