### PR TITLE
Use nullptr instead of 0 for a void* param.

### DIFF
--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -176,7 +176,7 @@ static void background_loop() {
 
   // After all initialization is done, ask the HAL
   // to start our high priority thread.
-  Hal.startLoopTimer(controller.GetLoopPeriod(), high_priority_task, 0);
+  Hal.startLoopTimer(controller.GetLoopPeriod(), high_priority_task, nullptr);
 
   while (true) {
     controller_status.uptime_ms = Hal.now().microsSinceStartup() / 1000;


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Use nullptr instead of 0 for a void* param.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #480 Use nullptr instead of 0 for a void* param. 👈 **YOU ARE HERE**
1. #475 Update to new 3/4" Venturi specifications.
1. #483 Move flow zeroing into TVIntegrator.


</git-pr-chain>





