### PR TITLE
Move setpoint_pressure field into ControllerState.

### DIFF
--- a/controller/lib/core/actuators.h
+++ b/controller/lib/core/actuators.h
@@ -24,11 +24,6 @@ limitations under the License.
 #include <optional>
 
 struct ActuatorsState {
-  // Pressure set point in cm H2O.
-  // Not really an actuator state (maybe it should move?)
-  // Only meaningful in pressure control mode.
-  float setpoint_cm_h2o{0.0f};
-
   // Valve setting for the FIO2 proportional solenoid
   // Range 0 to 1 where 0 is fully closed and 1 is fully open.
   float fio2_valve{0.0f};

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -42,6 +42,7 @@ Controller::Run(Time now, const VentParams &params,
   ActuatorsState actuator_state;
   ControllerState controller_state = {
       .is_new_breath = desired_state.is_new_breath,
+      .setpoint_pressure = desired_state.setpoint_pressure,
   };
 
   pid_.SetKP(dbg_kp.Get());
@@ -60,7 +61,6 @@ Controller::Run(Time now, const VentParams &params,
   // statement; we shouldn't be switching on the VentMode here.
   switch (params.mode) {
   case VentMode_OFF:
-    actuator_state.setpoint_cm_h2o = 0.0f;
     actuator_state.blower_valve = std::nullopt;
     actuator_state.exhale_valve = std::nullopt;
     actuator_state.blower_power = 0.0f;
@@ -78,7 +78,6 @@ Controller::Run(Time now, const VentParams &params,
       break;
     }
 
-    actuator_state.setpoint_cm_h2o = desired_state.setpoint_pressure.cmH2O();
     if (desired_state.expire_valve_state == ValveState::OPEN)
       actuator_state.exhale_valve = 1.0f;
     else

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -11,6 +11,9 @@
 struct ControllerState {
   // True if this is the first breath of a new cycle.
   bool is_new_breath;
+
+  // Patient pressure the controller wants to achieve.
+  Pressure setpoint_pressure;
 };
 
 // This class is here to allow integration of our controller into Modelica

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -138,7 +138,8 @@ static void high_priority_task(void *arg) {
 
   // Update some status info
   controller_status.fan_power = actuators_state.blower_power;
-  controller_status.fan_setpoint_cm_h2o = actuators_state.setpoint_cm_h2o;
+  controller_status.fan_setpoint_cm_h2o =
+      controller_state.setpoint_pressure.cmH2O();
 
   // Sample any trace variables that are enabled
   trace.MaybeSample();


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Move setpoint_pressure field into ControllerState.
    
    It doesn't belong in ActuatorState because the setpoint is not an
    actuator!

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #481 Move setpoint_pressure field into ControllerState. 👈 **YOU ARE HERE**
1. #482 Sleep for a few seconds at startup.
1. #480 Use nullptr instead of 0 for a void* param.
1. #475 Update to new 3/4" Venturi specifications.
1. #483 Move flow zeroing into TVIntegrator.


</git-pr-chain>



