### PR TITLE
Move flow zeroing into TVIntegrator.

### DIFF
--- a/controller/lib/core/flow_integrator.cpp
+++ b/controller/lib/core/flow_integrator.cpp
@@ -1,0 +1,76 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "flow_integrator.h"
+
+// TODO: VOLUME_INTEGRAL_INTERVAL was not chosen carefully.
+static constexpr Duration VOLUME_INTEGRAL_INTERVAL = milliseconds(5);
+
+// Tuning params for PID that calculates error in our flow measurements.
+// Calculated using the
+// https://en.wikipedia.org/wiki/Ziegler%E2%80%93Nichols_method The constants in
+// the constructor are for the "classic PID" control type, which seemed to work
+// well.
+//
+// FLOW_PID_OUTPUT_MAX is a sanity check, preventing us from using absurdly
+// high flow corrections.  The value below may strike you as absurdly high, but
+// we've seen corrections of 40ml/s be necessary, and 100ml/s gives a safety
+// margin.
+//
+// Even 40ml/s may seem way higher than should ever occur, but it's actually
+// easy to get an error this high at zero flow.  Since we have two sensors,
+// we'd need an error of +/-20ml in each.  At zero flow, this corresponds to
+// significantly less than 1 Pa of pressure, and just two or three bits in our
+// 12-bit ADC!  See
+// https://docs.google.com/spreadsheets/d/1G9Kb-ImlluK8MOx-ce2rlHUBnTOtAFQvKjjs1bEhlpM
+//
+// In theory the story is better at higher flows (because the venturi response
+// is the square root of pressure), and we may run a bias flow through our
+// device to put us into a regime where we're less sensitive to error
+// (equivalently, where the venturi response has a lower slope).  But we still
+// want to handle the low-flow case as best we can.
+static constexpr float FLOW_PID_KU = 0.20f;
+static constexpr float FLOW_PID_TU = 5;
+static constexpr VolumetricFlow FLOW_PID_OUTPUT_MAX = ml_per_sec(100);
+
+// TODO: Make PID parameters configurable.
+
+FlowIntegrator::FlowIntegrator()
+    : flow_correction_pid_(
+          /*kp=*/0.6f * FLOW_PID_KU,
+          /*ki=*/1.2f * FLOW_PID_KU / FLOW_PID_TU,
+          /*kd=*/3 * FLOW_PID_KU * FLOW_PID_TU / 40,
+          // ProportionalTerm::ON_ERROR and DifferentialTerm::ON_MEASUREMENT
+          // makes for your "standard" PID.  TODO: perhaps these shouldn't even
+          // be options.
+          ProportionalTerm::ON_ERROR,        //
+          DifferentialTerm::ON_MEASUREMENT,  //
+          -FLOW_PID_OUTPUT_MAX.ml_per_sec(), //
+          FLOW_PID_OUTPUT_MAX.ml_per_sec()) {}
+
+void FlowIntegrator::AddFlow(Time now, VolumetricFlow uncorrected_flow) {
+  VolumetricFlow flow = uncorrected_flow + flow_correction_;
+  Duration delta = now - last_flow_measurement_time_;
+  if (delta >= VOLUME_INTEGRAL_INTERVAL) {
+    volume_ += delta * (last_flow_ + flow) / 2.0f;
+    last_flow_measurement_time_ = now;
+    last_flow_ = flow;
+  }
+}
+
+void FlowIntegrator::NoteExpectedVolume(Volume v) {
+  flow_correction_ = ml_per_sec(flow_correction_pid_.Compute(
+      last_flow_measurement_time_, volume_.ml(), v.ml()));
+}

--- a/controller/lib/core/flow_integrator.h
+++ b/controller/lib/core/flow_integrator.h
@@ -1,0 +1,91 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "hal.h"
+#include "pid.h"
+#include "units.h"
+
+// Integrates flow over time to calculate volume.
+//
+// Also computes a constant correction to the flow that tries to account for
+// slow-changing error in the flow, based on certain points in time when we
+// know what the volume "should be".
+class FlowIntegrator {
+public:
+  FlowIntegrator();
+
+  // Updates the tidal volume given this flow.
+  //
+  // FlowIntegrator will correct this flow according to FlowCorrection() --
+  // don't pre-correct it yourself!
+  void AddFlow(Time now, VolumetricFlow uncorrected_flow);
+
+  Volume GetTV() const { return volume_; }
+
+  // FlowIntegrator adds this value to measured flow when computing volume, in
+  // an attempt to drive flow to the "correct" volume (as given by
+  // NoteExpectedVolume).
+  //
+  // Code that wants "corrected flow" (almost everything) should use measured
+  // flow plus this value.
+  VolumetricFlow FlowCorrection() const { return flow_correction_; }
+
+  // Informs FlowIntegrator what the tidal volume "ought to have been" as of
+  // the last time AddFlow was called.
+  //
+  // FlowIntegrator will then adjust its flow offset to try account for this in
+  // the future.
+  //
+  // TODO: How will this work with pressure assist mode?  In pressure control
+  // mode, the ventilator breathes on a precise schedule, so we know exactly
+  // when TV "should be" 0.  But in pressure assist mode, the patient triggers
+  // some breaths themselves, and it takes us some time to detect inspiratory
+  // effort.  By the point that we've detected effort, some flow has occurred,
+  // so the correct TV is not 0.  But then, what *is* it?
+  //
+  // A possible brute-force solution would be to keep history of the past N
+  // tidal volumes.
+  void NoteExpectedVolume(Volume v);
+
+private:
+  // Our flow sensors are subject to roughly two kinds of error:
+  //
+  //  - high-frequency error (i.e. "noise"), which we handle by reading the ADC
+  //    many times ("oversampling") in HAL, and
+  //
+  //  - low-frequency error, i.e. zero-point drift, meaning that the flow we
+  //    observe is equal to true flow plus an error, and that error changes
+  //    slowly relative to how quickly we can read the sensor.
+  //
+  // We use a PID controller invoked at each call to NoteExpectedVolume to
+  // estimate the zero-point drift.  If the patient is breathing normally,
+  // tidal volume should be 0 between breath.  The job of the PID is to output
+  // a flow offset so that the measured flow plus the offset takes tidal volume
+  // to its "correct" value at the next breath.
+  //
+  //  - PID input: Tidal volume in ml right between two breaths.
+  //  - PID setpoint: Desired volume between breaths, i.e. 0 ml.
+  //  - PID output: A flow in ml/sec that should be added to every measured
+  //    flow.
+  //
+  // TODO: When the ventilator blower is disabled and re-enabled, presumably we
+  // should clear some or all of these values!
+  PID flow_correction_pid_;
+  VolumetricFlow flow_correction_ = cubic_m_per_sec(0);
+
+  Time last_flow_measurement_time_ = Hal.now();
+  Volume volume_ = ml(0);
+  VolumetricFlow last_flow_ = cubic_m_per_sec(0);
+};

--- a/controller/test/sensor_tests/sensors_test.cpp
+++ b/controller/test/sensor_tests/sensors_test.cpp
@@ -155,10 +155,10 @@ static constexpr Time base = microsSinceStartup(10'000'000);
 static constexpr Duration sample_period = milliseconds(10);
 Time ticks(int num_ticks) { return base + num_ticks * sample_period; }
 
-TEST(SensorTests, TVIntegrator) {
+TEST(SensorTests, FlowIntegrator) {
   // this Hal.delay is needed to allow TV construction with proper init time
   Hal.delay(base - Hal.now());
-  TVIntegrator tidal_volume;
+  FlowIntegrator tidal_volume;
   VolumetricFlow flow = liters_per_sec(1.0f);
   int t = 0;
   tidal_volume.AddFlow(ticks(t++), flow);
@@ -201,7 +201,7 @@ TEST(SensorTests, TVIntegrator) {
   }
 }
 
-// This test checks encapsulation of TVIntegrator in getSensorReadings with
+// This test checks encapsulation of FlowIntegrator in getSensorReadings with
 // irregular sampling
 TEST(SensorTests, TidalVolume) {
   // define pressure waveforms over which integration will take place
@@ -224,9 +224,9 @@ TEST(SensorTests, TidalVolume) {
   // Note: sensors' contructor calls Hal.delay, which means reference
   // tidal_volume must be constructed before sensors in order to have the same
   // initialization time.
-  // Note outside of tests: the sensors TVintegrator's TV has a constant bias:
+  // Note outside of tests: the sensors FlowIntegrator's TV has a constant bias:
   // init value = time between sensors' init and first measure * first flow / 2
-  TVIntegrator tidal_volume;
+  FlowIntegrator tidal_volume;
   Sensors sensors;
   sensors.Calibrate();
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Move flow zeroing into TVIntegrator.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #483 Move flow zeroing into TVIntegrator. 👈 **YOU ARE HERE**
1. #485 Units: Allow x / y to return a raw ratio.
1. #486 Move blower_fsm implementations into cpp file.
1. #488 Rise from PIP to PEEP in 100ms.
1. #496 Bump gcc version to 9.2.1.
1. #497 Eagerly home pinch valves
1. #498 Rename SensorReadings proto -> SensorsProto.
1. #499 SensorReadings from SensorsProto.


</git-pr-chain>






















