### PR TITLE
Units: Allow x / y to return a raw ratio.

### DIFF
--- a/controller/test/units/units_test.cpp
+++ b/controller/test/units/units_test.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "units.h"
 #include "gtest/gtest.h"
+#include <type_traits>
 
 template <typename T, typename NumTy>
 void checkRelationalOperators(T (*unit)(NumTy)) {
@@ -41,6 +42,60 @@ void checkRelationalOperators(T (*unit)(NumTy)) {
   EXPECT_TRUE(unit(2) > unit(1));
 }
 
+template <typename T, typename NumTy>
+void checkArithmeticOperators(T (*unit)(NumTy), NumTy (T::*get)() const) {
+  // x / y is defined only for Ts backed by floats (in practice, everything
+  // other than Duration).
+  constexpr bool is_fp_based =
+      std::is_base_of_v<units_detail::ArithScalar<T, float>, T>;
+
+  // Make t const to check that these operators work with const operands.
+  const T t = unit(2.1f);
+  EXPECT_FLOAT_EQ(((t + unit(1.2f)).*get)(), 3.3f);
+  EXPECT_FLOAT_EQ(((t - unit(1.2f)).*get)(), 0.9f);
+  EXPECT_FLOAT_EQ(((t * 2).*get)(), 4.2f);
+  if constexpr (is_fp_based) {
+    EXPECT_FLOAT_EQ(((t * 2.1f).*get)(), 4.41f);
+    EXPECT_FLOAT_EQ(((t / .1f).*get)(), 21.f);
+  }
+  EXPECT_FLOAT_EQ(1, t / t);
+  EXPECT_FLOAT_EQ(2, t * 2 / t);
+  EXPECT_FLOAT_EQ(0.25, t / (4 * t));
+
+  T u = unit(2.1f);
+  EXPECT_FLOAT_EQ((u.*get)(), 2.1f);
+  u += unit(1.2f);
+  EXPECT_FLOAT_EQ((u.*get)(), 3.3f);
+  u -= unit(5.3f);
+  EXPECT_FLOAT_EQ((u.*get)(), -2.0f);
+  u *= 2.f;
+  EXPECT_FLOAT_EQ((u.*get)(), -4.0f);
+  if constexpr (is_fp_based) {
+    u /= -0.5f;
+    EXPECT_FLOAT_EQ((u.*get)(), 8.0f);
+    u *= -0.5f; // undo our change.
+    EXPECT_FLOAT_EQ((u.*get)(), -4.0f);
+  }
+
+  // Check return type and return value of +=, -=, *=, and /=.
+  T v(u += unit(1));
+  EXPECT_FLOAT_EQ((u.*get)(), -3.0f);
+  EXPECT_FLOAT_EQ((v.*get)(), -3.0f);
+  v = (u -= unit(1));
+  EXPECT_FLOAT_EQ((u.*get)(), -4.0f);
+  EXPECT_FLOAT_EQ((v.*get)(), -4.0f);
+  v = (u *= 2);
+  EXPECT_FLOAT_EQ((u.*get)(), -8.0f);
+  EXPECT_FLOAT_EQ((v.*get)(), -8.0f);
+  // x /= y is defined only for Ts backed by floats.
+  if constexpr (is_fp_based) {
+    v = (u /= 2);
+    EXPECT_FLOAT_EQ((u.*get)(), -4.0f);
+    EXPECT_FLOAT_EQ((v.*get)(), -4.0f);
+    v = (u *= 2); // undo our change.
+  }
+}
+
 TEST(Units, Pressure) {
   EXPECT_FLOAT_EQ(kPa(1).kPa(), 1);
   EXPECT_FLOAT_EQ(kPa(1).cmH2O(), 10.1972f);
@@ -51,16 +106,7 @@ TEST(Units, Pressure) {
 
   checkRelationalOperators(kPa);
   checkRelationalOperators(cmH2O);
-
-  Pressure pressure = kPa(2.1f);
-  pressure += kPa(1.2f);
-  EXPECT_FLOAT_EQ(pressure.kPa(), 3.3f);
-  pressure -= kPa(5.3f);
-  EXPECT_FLOAT_EQ(pressure.kPa(), -2.0f);
-  pressure /= -0.5f;
-  EXPECT_FLOAT_EQ(pressure.kPa(), 4.0f);
-  pressure *= -2.5f;
-  EXPECT_FLOAT_EQ(pressure.kPa(), -10.0f);
+  checkArithmeticOperators(kPa, &Pressure::kPa);
 
   EXPECT_FLOAT_EQ((cmH2O(2.5f) * 101.972f).kPa(), 25);
   EXPECT_FLOAT_EQ((1.01972f * cmH2O(-5.2f)).kPa(), -0.52f);
@@ -78,16 +124,7 @@ TEST(Units, Length) {
 
   checkRelationalOperators(meters);
   checkRelationalOperators(millimeters);
-
-  Length length = meters(0.23f);
-  length += meters(1);
-  EXPECT_FLOAT_EQ(length.meters(), 1.23f);
-  length -= meters(4.92f);
-  EXPECT_FLOAT_EQ(length.meters(), -3.69f);
-  length /= -1.23f;
-  EXPECT_FLOAT_EQ(length.meters(), 3.0f);
-  length *= -1.5f;
-  EXPECT_FLOAT_EQ(length.meters(), -4.5f);
+  checkArithmeticOperators(meters, &Length::meters);
 
   EXPECT_FLOAT_EQ((millimeters(1234) * 1.5f).meters(), 1.851f);
   EXPECT_FLOAT_EQ((2.345f * millimeters(654.3f)).meters(), 1.5343335f);
@@ -123,16 +160,7 @@ TEST(Units, VolumetricFlow) {
   checkRelationalOperators(cubic_m_per_sec);
   checkRelationalOperators(ml_per_min);
   checkRelationalOperators(liters_per_sec);
-
-  VolumetricFlow flow = liters_per_sec(9.87f);
-  flow += liters_per_sec(1.23f);
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 11.1f);
-  flow -= liters_per_sec(9.87f);
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 1.23f);
-  flow /= -0.5f;
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), -2.46f);
-  flow *= -2.0f;
-  EXPECT_FLOAT_EQ(flow.liters_per_sec(), 4.92f);
+  checkArithmeticOperators(cubic_m_per_sec, &VolumetricFlow::cubic_m_per_sec);
 
   EXPECT_FLOAT_EQ((liters_per_sec(4.0f) * 500.0f).cubic_m_per_sec(), 2.0f);
   EXPECT_FLOAT_EQ((1234.0f * liters_per_sec(2.5f)).cubic_m_per_sec(), 3.085f);
@@ -153,16 +181,7 @@ TEST(Units, Volume) {
 
   checkRelationalOperators(cubic_m);
   checkRelationalOperators(ml);
-
-  Volume volume = ml(456.0f);
-  volume += ml(123.0f);
-  EXPECT_FLOAT_EQ(volume.ml(), 579.0f);
-  volume -= ml(234.0f);
-  EXPECT_FLOAT_EQ(volume.ml(), 345.0f);
-  volume /= -5.0f;
-  EXPECT_FLOAT_EQ(volume.ml(), -69.0f);
-  volume *= 3.0f;
-  EXPECT_FLOAT_EQ(volume.ml(), -207.0f);
+  checkArithmeticOperators(ml, &Volume::ml);
 
   EXPECT_FLOAT_EQ((cubic_m(0.123f) / 1e4f).ml(), 12.3f);
   EXPECT_FLOAT_EQ((ml(1234.0f) * 567.0f).cubic_m(), 0.699678f);
@@ -185,6 +204,7 @@ TEST(Units, Duration) {
   EXPECT_FLOAT_EQ((seconds(1) - milliseconds(1000)).seconds(), 0);
 
   checkRelationalOperators(seconds);
+  checkArithmeticOperators(seconds, &Duration::seconds);
 
   // Test all the overloads of the milliseconds factory function.  static_cast
   // is one of C++'s weird ways of getting the address of an overloaded


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Units: Allow x / y to return a raw ratio.
    
    In a future PR, I want to divide two Durations.
    
    Also mark more operators as const, and test that they are in fact const.
    
    Please forgive the unironic use of pointer-to-member-function.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #485 Units: Allow x / y to return a raw ratio. 👈 **YOU ARE HERE**
1. #486 Move blower_fsm implementations into cpp file.
1. #488 Rise from PIP to PEEP in 100ms.
1. #496 Bump gcc version to 9.2.1.
1. #497 Eagerly home pinch valves
1. #498 Rename SensorReadings proto -> SensorsProto.
1. #499 SensorReadings from SensorsProto.


</git-pr-chain>
















