### PR TITLE
Rise from PIP to PEEP in 100ms.

### DIFF
--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -113,6 +113,10 @@ public:
 // an acceptable waveform, although it remains to be seen.
 class PressureControlFsm {
 public:
+  // Transition from PEEP to PIP pressure over this length of time.  Citation:
+  // https://respiraworks.slack.com/archives/C011CJQV4Q7/p1591763842312500?thread_ts=1591759016.310200&cid=C011CJQV4Q7
+  static constexpr inline Duration RISE_TIME = milliseconds(100);
+
   explicit PressureControlFsm(Time now, const VentParams &params);
   BlowerSystemState desired_state(Time now);
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Rise from PIP to PEEP in 100ms.
    
    Instead of going directly from PIP to PEEP, transition over 100ms.
    
    Citation: https://respiraworks.slack.com/archives/C011CJQV4Q7/p1591763842312500?thread_ts=1591759016.310200&cid=C011CJQV4Q7

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #488 Rise from PIP to PEEP in 100ms. 👈 **YOU ARE HERE**
1. #496 Bump gcc version to 9.2.1.
1. #497 Eagerly home pinch valves
1. #498 Rename SensorReadings proto -> SensorsProto.
1. #499 SensorReadings from SensorsProto.


</git-pr-chain>















