### PR TITLE
Fix formatting in pid.cpp.

### DIFF
--- a/controller/lib/pid/pid.cpp
+++ b/controller/lib/pid/pid.cpp
@@ -49,11 +49,11 @@ float PID::Compute(Time now, float input, float setpoint) {
   // dt may be 0 (e.g. on the first call to Compute()), in which case we simply
   // skip using the derivative term.
   if (dt > 0) {
-  if (d_term_ == DifferentialTerm::ON_MEASUREMENT) {
-    res -= kd_ * dInput / dt;
-  } else {
-    res += kd_ * (error - last_error_) / dt;
-  }
+    if (d_term_ == DifferentialTerm::ON_MEASUREMENT) {
+      res -= kd_ * dInput / dt;
+    } else {
+      res += kd_ * (error - last_error_) / dt;
+    }
   }
 
   // Remember some variables for next time


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix formatting in pid.cpp.
    
    Somehow escaped clang-format.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #494 Fix formatting in pid.cpp. 👈 **YOU ARE HERE**
1. #495 Remove trailing whitespace in sample-data/README.md
1. #483 Move flow zeroing into TVIntegrator.
1. #485 Units: Allow x / y to return a raw ratio.
1. #486 Move blower_fsm implementations into cpp file.
1. #488 Rise from PIP to PEEP in 100ms.
1. #496 Bump gcc version to 9.2.1.
1. #497 Eagerly home pinch valves
1. #498 Rename SensorReadings proto -> SensorsProto.
1. #499 SensorReadings from SensorsProto.


</git-pr-chain>





