### PR TITLE
Bump gcc version to 9.2.1.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,13 @@ build_unflags =
   -std=gnu++11
   -std=gnu++14
   -fpermissive
+# Use a more recent GCC than default; some designated-initializer features are
+# missing in platformio's default version.  The version named below corresponds
+# to gcc 9.2.1 20191025.
+#
+# All versions are listed at
+# https://bintray.com/platformio/dl-packages/toolchain-gccarmnoneeabi
+platform_packages = toolchain-gccarmnoneeabi@>1.80301.190214
 
 [env:stm32]
 platform = ststm32


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Bump gcc version to 9.2.1.
    
    This lets us use designated initializers with fields which have
    nontrivial constructors (e.g. std::optional).
    
    This is still not a bleeding-edge gcc, so I think we should be OK.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #496 Bump gcc version to 9.2.1. 👈 **YOU ARE HERE**
1. #497 Eagerly home pinch valves
1. #498 Rename SensorReadings proto -> SensorsProto.
1. #499 SensorReadings from SensorsProto.


</git-pr-chain>














