### PR TITLE
Rename setpoint_pressure -> pressure_setpoint.

### DIFF
--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -61,17 +61,17 @@ enum class ValveState {
 struct BlowerSystemState {
   // Is the blower on?
   //
-  // Note: blower_enabled == false isn't the same as setpoint_pressure == 0:
+  // Note: blower_enabled == false isn't the same as pressure_setpoint == 0:
   //
   //  - If blower_enabled is false, we shut down the fan immediately, whereas
-  //  - if setpoint_pressure == 0, PID spins down the fan to attempt to read 0
+  //  - if pressure_setpoint == 0, PID spins down the fan to attempt to read 0
   //    kPa measured patient pressure.
   //
-  // TODO: Combine this field with setpoint_pressure into an
+  // TODO: Combine this field with pressure_setpoint into an
   // std::optional<Pressure>.
   bool blower_enabled;
 
-  Pressure setpoint_pressure;
+  Pressure pressure_setpoint;
   ValveState expire_valve_state;
 
   // Is this the first BlowerSystemState returned for a brand-new breath cycle?

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -52,12 +52,12 @@ Controller::Run(Time now, const VentParams &params,
   pid_.SetKD(dbg_kd.Get());
 
   float pressure = sensor_readings.patient_pressure.kPa();
-  float setpoint = desired_state.setpoint_pressure.kPa();
-  dbg_sp.Set(desired_state.setpoint_pressure.cmH2O());
+  float setpoint = desired_state.pressure_setpoint.kPa();
+  dbg_sp.Set(desired_state.pressure_setpoint.cmH2O());
 
   ControllerState controller_state = {
       .is_new_breath = desired_state.is_new_breath,
-      .setpoint_pressure = desired_state.setpoint_pressure,
+      .pressure_setpoint = desired_state.pressure_setpoint,
   };
 
   ActuatorsState actuators_state = [&]() -> ActuatorsState {

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -14,7 +14,7 @@ struct ControllerState {
   bool is_new_breath;
 
   // Patient pressure the controller wants to achieve.
-  Pressure setpoint_pressure;
+  Pressure pressure_setpoint;
 };
 
 // This class is here to allow integration of our controller into Modelica

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -149,7 +149,7 @@ static void high_priority_task(void *arg) {
   controller_status.sensor_readings = AsSensorsProto(sensor_readings);
   controller_status.fan_power = actuators_state.blower_power;
   controller_status.pressure_setpoint_cm_h2o =
-      controller_state.setpoint_pressure.cmH2O();
+      controller_state.pressure_setpoint.cmH2O();
 
   // Sample any trace variables that are enabled
   trace.MaybeSample();

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -22,20 +22,21 @@ limitations under the License.
 
 namespace {
 
-static constexpr SensorReadings readings_zero = {.patient_pressure = kPa(0),
-                                                 .inflow_pressure_diff = kPa(0),
-                                                 .outflow_pressure_diff =
-                                                     kPa(0),
-                                                 .inflow = ml_per_min(0),
-                                                 .outflow = ml_per_min(0),
-                                                 .volume = ml(0),
-                                                 .net_flow = ml_per_min(0)};
+constexpr SensorReadings readings_zero = {
+    .patient_pressure = kPa(0),
+    .inflow_pressure_diff = kPa(0),
+    .outflow_pressure_diff = kPa(0),
+    .inflow = ml_per_min(0),
+    .outflow = ml_per_min(0),
+    .volume = ml(0),
+    .net_flow = ml_per_min(0),
+};
 
 TEST(BlowerFsmTest, InitiallyOff) {
   BlowerFsm fsm;
   VentParams p = VentParams_init_zero;
   BlowerSystemState s = fsm.DesiredState(Hal.now(), p, readings_zero);
-  EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
+  EXPECT_FLOAT_EQ(s.pressure_setpoint.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);
 }
 
@@ -44,7 +45,7 @@ TEST(BlowerFsmTest, StaysOff) {
   VentParams p = VentParams_init_zero;
   Hal.delay(milliseconds(1000));
   BlowerSystemState s = fsm.DesiredState(Hal.now(), p, readings_zero);
-  EXPECT_FLOAT_EQ(s.setpoint_pressure.cmH2O(), 0);
+  EXPECT_FLOAT_EQ(s.pressure_setpoint.cmH2O(), 0);
   EXPECT_EQ(s.expire_valve_state, ValveState::OPEN);
 }
 
@@ -56,7 +57,7 @@ void testSequence(
                    /*sensor_readings*/ SensorReadings,
                    /*blower_enabled*/ bool,
                    /*time_millis*/ uint64_t,
-                   /*expected_setpoint_pressure*/ Pressure,
+                   /*expected_pressure_setpoint*/ Pressure,
                    /*expected_expiratory_valve_state*/ ValveState>> &seq) {
   BlowerFsm fsm;
   for (const auto &[params, readings, blower_enabled, time_millis,
@@ -67,7 +68,7 @@ void testSequence(
 
     BlowerSystemState s = fsm.DesiredState(Hal.now(), params, readings);
     EXPECT_EQ(s.blower_enabled, blower_enabled);
-    EXPECT_EQ(s.setpoint_pressure.cmH2O(), expected_pressure.cmH2O());
+    EXPECT_EQ(s.pressure_setpoint.cmH2O(), expected_pressure.cmH2O());
     EXPECT_EQ(s.expire_valve_state, expected_valve_state);
   }
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Rename setpoint_pressure -> pressure_setpoint.
    
    To be consistent with the proto
    ControllerStatus.pressure_setpoint_cm_h2o.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #502 Rename setpoint_pressure -> pressure_setpoint. 👈 **YOU ARE HERE**
1. #504 BlowerFsm API cleanups.
1. #505 Move volume sensing into controller.
1. #506 Delete unused VentParams.rise_time_ms.
1. #507 Rename FlowIntegrator::GetTV -> GetVolume.
1. #508 Much better flow error correction.


</git-pr-chain>

















