### PR TITLE
GPIO and UART privileges for Docker

### DIFF
--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -54,4 +54,4 @@
   - name: Add script to spin up gui docker instance on boot
     lineinfile:
       dest: /home/pi/.config/openbox/autostart
-      line: 'docker run --name=gui -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui /gui/build/app/ProjectVentilatorGUI &'
+      line: 'docker run --name=gui --privileged -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui /gui/build/app/ProjectVentilatorGUI &'


### PR DESCRIPTION
This should allow the GUI in docker to access the pi's GPIO and UART pins that communicate with the nucleo.