### PR TITLE
BlowerFsm API cleanups.

### DIFF
--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -67,9 +67,9 @@ void PressureControlFsm::Update(Time now, const SensorReadings &readings) {
 
 BlowerSystemState PressureControlFsm::DesiredState() const {
   if (inspire_finished_) {
-    return {.blower_enabled = true, expire_pressure_, ValveState::OPEN};
+    return {expire_pressure_, FlowDirection::EXPIRATORY};
   }
-  return {.blower_enabled = true, setpoint_, ValveState::CLOSED};
+  return {setpoint_, FlowDirection::INSPIRATORY};
 }
 
 PressureAssistFsm::PressureAssistFsm(Time now, const VentParams &params)
@@ -89,9 +89,9 @@ void PressureAssistFsm::Update(Time now, const SensorReadings &readings) {
 
 BlowerSystemState PressureAssistFsm::DesiredState() const {
   if (inspire_finished_) {
-    return {.blower_enabled = true, expire_pressure_, ValveState::OPEN};
+    return {expire_pressure_, FlowDirection::EXPIRATORY};
   }
-  return {.blower_enabled = true, inspire_pressure_, ValveState::CLOSED};
+  return {inspire_pressure_, FlowDirection::INSPIRATORY};
 }
 
 // TODO don't rely on fsm inner states to make this usable in any fsm


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. BlowerFsm API cleanups.
    
    - Rename ValveState -> FlowDirection.  We no longer have an expiratory
      solenoid.
    - Make pressure_setpoint an std::optional instead of a Pressure plus a
      boolean.
    - Update out-of-date comments.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #504 BlowerFsm API cleanups. 👈 **YOU ARE HERE**
1. #505 Move volume sensing into controller.
1. #506 Delete unused VentParams.rise_time_ms.
1. #507 Rename FlowIntegrator::GetTV -> GetVolume.
1. #508 Much better flow error correction.


</git-pr-chain>

















