### PR TITLE
Move volume sensing into controller.

### DIFF
--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -21,73 +21,113 @@ limitations under the License.
 
 static constexpr Duration LOOP_PERIOD = milliseconds(10);
 
-static DebugFloat dbg_setpoint("setpoint", "Setpoint pressure, kPa");
+// Inputs - set from external debug program, read but never modified here.
+static DebugFloat dbg_blower_valve_kp("blower_valve_kp",
+                                      "Proportional gain for blower valve PID",
+                                      0.7f);
+static DebugFloat dbg_blower_valve_ki("blower_valve_ki",
+                                      "Integral gain for blower valve PID",
+                                      1.0f);
+static DebugFloat dbg_blower_valve_kd("blower_valve_kd",
+                                      "Derivative gain for blower valve PID");
 
-static DebugFloat dbg_kp("kp", "Proportional gain for main loop", 0.7f);
-static DebugFloat dbg_ki("ki", "Integral gain for main loop", 1.0f);
-static DebugFloat dbg_kd("kd", "Derivative gain for main loop");
-static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint (cmH2O)");
-static DebugUInt32 dbg_per("loop_period", "Loop period (usec)",
+// Unchanging outputs - read from external debug program, never modified here.
+static DebugUInt32 dbg_per("loop_period", "Loop period, read-only (usec)",
                            static_cast<uint32_t>(LOOP_PERIOD.microseconds()));
 
+// Outputs - read from external debug program, modified here.
+static DebugFloat dbg_sp("pc_setpoint", "Pressure control setpoint (cmH2O)");
+static DebugFloat dbg_net_flow("net_flow", "Net flow rate, cc/sec");
+static DebugFloat dbg_volume("volume", "Patient volume, ml");
+static DebugFloat
+    dbg_net_flow_uncorrected("net_flow_uncorrected",
+                             "Net flow rate w/o correction, cc/sec");
+static DebugFloat dbg_volume_uncorrected("uncorrected_volume",
+                                         "Patient volume w/o correction, ml");
+
 Controller::Controller()
-    : pid_(dbg_kp.Get(), dbg_ki.Get(), dbg_kd.Get(), ProportionalTerm::ON_ERROR,
-           DifferentialTerm::ON_MEASUREMENT, /*output_min=*/0.f,
-           /*output_max=*/1.0f) {}
+    : blower_valve_pid_(dbg_blower_valve_kp.Get(), dbg_blower_valve_ki.Get(),
+                        dbg_blower_valve_kd.Get(), ProportionalTerm::ON_ERROR,
+                        DifferentialTerm::ON_MEASUREMENT, /*output_min=*/0.f,
+                        /*output_max=*/1.0f) {}
 
 /*static*/ Duration Controller::GetLoopPeriod() { return LOOP_PERIOD; }
 
 std::pair<ActuatorsState, ControllerState>
 Controller::Run(Time now, const VentParams &params,
                 const SensorReadings &sensor_readings) {
-  BlowerSystemState desired_state =
-      fsm_.DesiredState(now, params, sensor_readings);
+  blower_valve_pid_.SetKP(dbg_blower_valve_kp.Get());
+  blower_valve_pid_.SetKI(dbg_blower_valve_ki.Get());
+  blower_valve_pid_.SetKD(dbg_blower_valve_kd.Get());
 
-  if (desired_state.pressure_setpoint == std::nullopt) {
-    pid_.Reset();
+  VolumetricFlow uncorrected_net_flow =
+      sensor_readings.inflow - sensor_readings.outflow;
+  flow_integrator_->AddFlow(now, uncorrected_net_flow);
+  uncorrected_flow_integrator_->AddFlow(now, uncorrected_net_flow);
+
+  Volume patient_volume = flow_integrator_->GetTV();
+  VolumetricFlow net_flow =
+      uncorrected_net_flow + flow_integrator_->FlowCorrection();
+
+  BlowerSystemState desired_state = fsm_.DesiredState(
+      now, params, {.patient_volume = patient_volume, .net_flow = net_flow});
+
+  if (desired_state.is_new_breath) {
+    // The "correct" volume at the breath boundary is 0.
+    flow_integrator_->NoteExpectedVolume(ml(0));
   }
 
-  pid_.SetKP(dbg_kp.Get());
-  pid_.SetKI(dbg_ki.Get());
-  pid_.SetKD(dbg_kd.Get());
+  ActuatorsState actuators_state;
+  if (desired_state.pressure_setpoint == std::nullopt) {
+    // System disabled.  Disable blower, close inspiratory pinch valve, and
+    // open expiratory pinch valve.  This way if someone is hooked up, they can
+    // breathe through the expiratory branch, and they can't contaminate the
+    // inspiratory branch.
+    //
+    // If the pinch valves are not yet homed, this will home them and then move
+    // them to the desired positions.
+    blower_valve_pid_.Reset();
 
-  float pressure = sensor_readings.patient_pressure.kPa();
-  dbg_sp.Set(desired_state.pressure_setpoint.value_or(kPa(0)).cmH2O());
+    // Reset the two flow integrators, forcing volume to 0.
+    //
+    // TODO: This isn't ideal; if the blower is off, we should still be able to
+    // report volume.
+    flow_integrator_.emplace();
+    uncorrected_flow_integrator_.emplace();
 
-  ControllerState controller_state = {
-      .is_new_breath = desired_state.is_new_breath,
-      .pressure_setpoint = desired_state.pressure_setpoint.value_or(kPa(0)),
-  };
-
-  ActuatorsState actuators_state = [&]() -> ActuatorsState {
-    if (desired_state.pressure_setpoint == std::nullopt) {
-      // System disabled.  Disable blower, close inspiratory pinch valve, and
-      // open expiratory pinch valve.  This way if someone is hooked up, they
-      // can breathe through the expiratory branch, and they can't contaminate
-      // the inspiratory branch.
-      //
-      // If the pinch valves are not yet homed, this will home them and then
-      // move them to the desired positions.
-      return {
-          .fio2_valve = 0,
-          .blower_power = 0,
-          .blower_valve = 0,
-          .exhale_valve = 1,
-      };
-    }
-
+    actuators_state = {
+        .fio2_valve = 0,
+        .blower_power = 0,
+        .blower_valve = 0,
+        .exhale_valve = 1,
+    };
+  } else {
     // Start controlling pressure.
-    return {
+    actuators_state = {
         .fio2_valve = 0, // not used yet
         // In normal mode, blower is always full power; pid controls pressure by
         // actuating the blower pinch valve.
         .blower_power = 1,
-        .blower_valve =
-            pid_.Compute(now, pressure, desired_state.pressure_setpoint->kPa()),
+        .blower_valve = blower_valve_pid_.Compute(
+            now, sensor_readings.patient_pressure.kPa(),
+            desired_state.pressure_setpoint->kPa()),
         .exhale_valve =
             desired_state.flow_direction == FlowDirection::EXPIRATORY ? 1 : 0,
     };
-  }();
+  }
+
+  ControllerState controller_state = {
+      .pressure_setpoint = desired_state.pressure_setpoint.value_or(kPa(0)),
+      .patient_volume = patient_volume,
+      .net_flow = net_flow,
+  };
+
+  dbg_sp.Set(desired_state.pressure_setpoint.value_or(kPa(0)).cmH2O());
+  dbg_net_flow.Set(controller_state.net_flow.ml_per_sec());
+  dbg_net_flow_uncorrected.Set(
+      (sensor_readings.inflow - sensor_readings.outflow).ml_per_sec());
+  dbg_volume.Set(controller_state.patient_volume.ml());
+  dbg_volume_uncorrected.Set(uncorrected_flow_integrator_->GetTV().ml());
 
   return {actuators_state, controller_state};
 }

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -3,18 +3,28 @@
 
 #include "actuators.h"
 #include "blower_fsm.h"
+#include "flow_integrator.h"
 #include "network_protocol.pb.h"
 #include "pid.h"
 #include "sensors.h"
 #include "units.h"
+#include <optional>
 #include <utility>
 
+// TODO: This name is too close to the ControllerStatus proto.
 struct ControllerState {
-  // True if this is the first breath of a new cycle.
-  bool is_new_breath;
-
   // Patient pressure the controller wants to achieve.
   Pressure pressure_setpoint;
+
+  // Patient volume and net flow (inflow minus outflow) are properties of
+  // ControllerState, not SensorReadings, because flow and volume measurement
+  // require error corrections that can only happen at the controller level.
+  //
+  // The "correct" volume after a normal breath is 0, and it's the controller
+  // that knows when breaths occur.  We use this info to drive flow (and
+  // therefore volume) to 0 at each breath boundary.
+  Volume patient_volume;
+  VolumetricFlow net_flow;
 };
 
 // This class is here to allow integration of our controller into Modelica
@@ -31,7 +41,17 @@ public:
 
 private:
   BlowerFsm fsm_;
-  PID pid_;
+  PID blower_valve_pid_;
+
+  // These objects accumulate flow to calculate volume.
+  //
+  // For debugging, we accumulate flow with and without error correction.  See
+  // FlowIntegrator definition for description of errors.
+  //
+  // These are never nullopt; we use std::optional to let us clear/reset these
+  // objects.
+  std::optional<FlowIntegrator> flow_integrator_ = FlowIntegrator();
+  std::optional<FlowIntegrator> uncorrected_flow_integrator_ = FlowIntegrator();
 };
 
 #endif // CONTROLLER_H_

--- a/controller/test/controller/controller_test.cpp
+++ b/controller/test/controller/controller_test.cpp
@@ -1,0 +1,74 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "controller.h"
+#include "gtest/gtest.h"
+#include <cmath>
+#include <tuple>
+
+// TODO: There ought to be many more tests in here.
+
+TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
+  constexpr Time start = microsSinceStartup(0);
+  constexpr int breaths_to_test = 5;
+  constexpr int steps_per_breath = 6;
+  constexpr Duration breath_duration = seconds(6);
+  constexpr Duration step_duration =
+      microseconds(breath_duration.microseconds() / steps_per_breath);
+  static_assert(breath_duration.microseconds() % steps_per_breath == 0);
+
+  Controller c;
+  VentParams params = VentParams_init_zero;
+  params.mode = VentMode::VentMode_PRESSURE_CONTROL;
+  params.peep_cm_h2o = 5;
+  params.breaths_per_min =
+      static_cast<uint32_t>(std::round(1.f / breath_duration.minutes()));
+  params.pip_cm_h2o = 15;
+  params.inspiratory_expiratory_ratio = 1;
+
+  FlowIntegrator flow_integrator;
+  for (int i = 0; i < breaths_to_test * steps_per_breath; i++) {
+    Time now = start + i * step_duration;
+    SCOPED_TRACE("i = " + std::to_string(i) +
+                 ", time = " + std::to_string((now - start).seconds()));
+
+    // Where are we in this breath, [0, 1]?
+    float breath_pos =
+        static_cast<float>(i % steps_per_breath) / steps_per_breath;
+    Pressure inflow_pressure = cmH2O(0.5f + (breath_pos < 0.5 ? 1.f : 0.f));
+    Pressure outflow_pressure = cmH2O(0.4f + (breath_pos >= 0.5 ? 1.f : 0.f));
+    SensorReadings readings = {
+        .patient_pressure = kPa(0),
+        .inflow_pressure_diff = inflow_pressure,
+        .outflow_pressure_diff = outflow_pressure,
+        .inflow = Sensors::PressureDeltaToFlow(inflow_pressure),
+        .outflow = Sensors::PressureDeltaToFlow(outflow_pressure),
+    };
+    VolumetricFlow uncorrected_flow = readings.inflow - readings.outflow;
+    flow_integrator.AddFlow(now, uncorrected_flow);
+
+    auto [unused_actuator_status, status] = c.Run(now, params, readings);
+    (void)unused_actuator_status;
+
+    EXPECT_FLOAT_EQ(
+        status.net_flow.ml_per_sec(),
+        (uncorrected_flow + flow_integrator.FlowCorrection()).ml_per_sec());
+    EXPECT_FLOAT_EQ(status.patient_volume.ml(), flow_integrator.GetTV().ml());
+
+    if (breath_pos == 0) {
+      flow_integrator.NoteExpectedVolume(ml(0));
+    }
+  }
+}

--- a/controller/test/flow_integrator/flow_integrator_test.cpp
+++ b/controller/test/flow_integrator/flow_integrator_test.cpp
@@ -1,0 +1,77 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "flow_integrator.h"
+#include "gtest/gtest.h"
+
+static const Volume COMPARISON_TOLERANCE_VOLUME = ml(1);
+
+#define EXPECT_VOLUME_NEAR(a, b)                                               \
+  EXPECT_NEAR((a).ml(), (b).ml(), COMPARISON_TOLERANCE_VOLUME.ml())
+
+static constexpr Time base = microsSinceStartup(10'000'000);
+static constexpr Duration sample_period = milliseconds(10);
+Time ticks(int num_ticks) { return base + num_ticks * sample_period; }
+
+// TODO: There ought to be more tests in here, e.g. of NoteExpectedVolume.
+// TODO: Convert this test into a TEST_F.
+// TODO: Move EXPECT_VOLUME_NEAR into a common header, for use here, in
+// sensors_test, etc?
+
+TEST(FlowIntegrator, FlowIntegrator) {
+  // this Hal.delay is needed to allow TV construction with proper init time
+  Hal.delay(base - Hal.now());
+  FlowIntegrator tidal_volume;
+  VolumetricFlow flow = liters_per_sec(1.0f);
+  int t = 0;
+  tidal_volume.AddFlow(ticks(t++), flow);
+  // first call to AddFlow ==> initialization and TV is 0, even if flow is not
+  EXPECT_EQ(tidal_volume.GetTV().ml(), 0.0f);
+  tidal_volume.AddFlow(ticks(t++), flow);
+  // integrate 1 l/s flow over 10 ms ==> 5 ml (rectangle rule with initial flow
+  // set to 0)
+  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(5));
+
+  tidal_volume.AddFlow(ticks(t++), cubic_m_per_sec(2e-3f));
+  // add 2 l/s flow over 10 ms ==> 20 ml ()
+  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(20));
+
+  tidal_volume.AddFlow(ticks(t++), ml_per_min(0.0f));
+  // add 0 l/s flow over 10 ms ==> 30 ml (rectangle rule)
+  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(30.0f));
+
+  // integrate 0 for some time ==> still 30 ms
+  while (t < 100) {
+    tidal_volume.AddFlow(ticks(t++), ml_per_min(0.0f));
+  }
+
+  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(30.0f));
+
+  // reverse flow
+  flow = liters_per_sec(-1.0f);
+  // this does not increment t in order to allow oversampling (following test)
+  tidal_volume.AddFlow(ticks(t), flow);
+  // remove 1 l/s flow over 10 ms ==> 25 ml (rectangle rule)
+  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(25.0f));
+
+  // oversampling and expect volume to not change except on multiples of 5 ms
+  for (int i = 0; i < 50; i++) {
+    tidal_volume.AddFlow(ticks(t) + milliseconds(i), flow);
+
+    // remove 1l/s flow over 5 ms only when i is a multiple of 5
+    int j = i / 5 * 5;
+    EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(25.0f - static_cast<float>(j)));
+  }
+}

--- a/controller/test/sensor_tests/sensors_test.cpp
+++ b/controller/test/sensor_tests/sensors_test.cpp
@@ -21,6 +21,7 @@ limitations under the License.
  * on an Arduino platform.
  */
 
+#include "flow_integrator.h"
 #include "hal.h"
 #include "sensors.h"
 #include "gtest/gtest.h"
@@ -33,7 +34,6 @@ limitations under the License.
 // Maximum allowable delta between calculated sensor readings and the input.
 static const Pressure COMPARISON_TOLERANCE_PRESSURE = kPa(0.005f);
 static const VolumetricFlow COMPARISON_TOLERANCE_FLOW = ml_per_sec(50);
-static const Volume COMPARISON_TOLERANCE_VOLUME = ml(1);
 
 #define EXPECT_PRESSURE_NEAR(a, b)                                             \
   EXPECT_NEAR((a).kPa(), (b).kPa(), COMPARISON_TOLERANCE_PRESSURE.kPa())
@@ -41,9 +41,6 @@ static const Volume COMPARISON_TOLERANCE_VOLUME = ml(1);
 #define EXPECT_FLOW_NEAR(a, b)                                                 \
   EXPECT_NEAR((a).ml_per_sec(), (b).ml_per_sec(),                              \
               COMPARISON_TOLERANCE_FLOW.ml_per_sec())
-
-#define EXPECT_VOLUME_NEAR(a, b)                                               \
-  EXPECT_NEAR((a).ml(), (b).ml(), COMPARISON_TOLERANCE_VOLUME.ml())
 
 //@TODO: Finish writing more specific unit tests for this module
 
@@ -152,94 +149,6 @@ static constexpr Time base = microsSinceStartup(10'000'000);
 static constexpr Duration sample_period = milliseconds(10);
 Time ticks(int num_ticks) { return base + num_ticks * sample_period; }
 
-TEST(SensorTests, FlowIntegrator) {
-  // this Hal.delay is needed to allow TV construction with proper init time
-  Hal.delay(base - Hal.now());
-  FlowIntegrator tidal_volume;
-  VolumetricFlow flow = liters_per_sec(1.0f);
-  int t = 0;
-  tidal_volume.AddFlow(ticks(t++), flow);
-  // first call to AddFlow ==> initialization and TV is 0, even if flow is not
-  EXPECT_EQ(tidal_volume.GetTV().ml(), 0.0f);
-  tidal_volume.AddFlow(ticks(t++), flow);
-  // integrate 1 l/s flow over 10 ms ==> 5 ml (rectangle rule with initial flow
-  // set to 0)
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(5));
-
-  tidal_volume.AddFlow(ticks(t++), cubic_m_per_sec(2e-3f));
-  // add 2 l/s flow over 10 ms ==> 20 ml ()
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(20));
-
-  tidal_volume.AddFlow(ticks(t++), ml_per_min(0.0f));
-  // add 0 l/s flow over 10 ms ==> 30 ml (rectangle rule)
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(30.0f));
-
-  // integrate 0 for some time ==> still 30 ms
-  while (t < 100) {
-    tidal_volume.AddFlow(ticks(t++), ml_per_min(0.0f));
-  }
-
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(30.0f));
-
-  // reverse flow
-  flow = liters_per_sec(-1.0f);
-  // this does not increment t in order to allow oversampling (following test)
-  tidal_volume.AddFlow(ticks(t), flow);
-  // remove 1 l/s flow over 10 ms ==> 25 ml (rectangle rule)
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(25.0f));
-
-  // oversampling and expect volume to not change except on multiples of 5 ms
-  for (int i = 0; i < 50; i++) {
-    tidal_volume.AddFlow(ticks(t) + milliseconds(i), flow);
-
-    // remove 1l/s flow over 5 ms only when i is a multiple of 5
-    int j = i / 5 * 5;
-    EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(25.0f - static_cast<float>(j)));
-  }
-}
-
-// This test checks encapsulation of FlowIntegrator in getSensorsProto with
-// irregular sampling
-TEST(SensorTests, TidalVolume) {
-  // define pressure waveforms over which integration will take place
-  // This was chosen randomly
-  std::vector<Duration> sampling_time = {milliseconds(8), milliseconds(2),
-                                         milliseconds(5), milliseconds(4),
-                                         milliseconds(6), milliseconds(7)};
-  std::vector<Pressure> pressure_in = {kPa(0.0f), kPa(1.5f), kPa(0.0f),
-                                       kPa(1.0f), kPa(2.0f), kPa(3.0f)};
-  std::vector<Pressure> pressure_out = {kPa(1.0f), kPa(0.5f), kPa(2.0f),
-                                        kPa(0.0f), kPa(1.0f), kPa(2.0f)};
-
-  // Set the simulated analog signals to an ambient 0 kPa corresponding
-  // voltage during calibration
-  Voltage voltage_at_0kPa = MPXV5004_PressureToVoltage(kPa(0)); //[V]
-  Hal.test_setAnalogPin(AnalogPin::PATIENT_PRESSURE, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::INFLOW_PRESSURE_DIFF, voltage_at_0kPa);
-  Hal.test_setAnalogPin(AnalogPin::OUTFLOW_PRESSURE_DIFF, voltage_at_0kPa);
-
-  // Note: sensors' contructor calls Hal.delay, which means reference
-  // tidal_volume must be constructed before sensors in order to have the same
-  // initialization time.
-  // Note outside of tests: the sensors FlowIntegrator's TV has a constant bias:
-  // init value = time between sensors' init and first measure * first flow / 2
-  FlowIntegrator tidal_volume;
-  Sensors sensors;
-  sensors.Calibrate();
-
-  for (uint i = 0; i < sampling_time.size(); i++) {
-    Pressure p_in = pressure_in[i];
-    Pressure p_out = pressure_out[i];
-    Duration dt = sampling_time[i];
-    SensorReadings readings = update_readings(
-        dt, /*patient_pressure=*/kPa(0.0f), p_in, p_out, &sensors);
-
-    tidal_volume.AddFlow(Hal.now(), Sensors::PressureDeltaToFlow(p_in) -
-                                        Sensors::PressureDeltaToFlow(p_out));
-    EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), readings.volume);
-  }
-}
-
 TEST(SensorTests, Calibration) {
   // First set the simulated analog signals to randomly chosen signals
   // corresponding to pressure during calibration
@@ -285,60 +194,4 @@ TEST(SensorTests, Calibration) {
   EXPECT_PRESSURE_NEAR(readings.patient_pressure, kPa(-0.5f));
   EXPECT_FLOW_NEAR(readings.inflow, Sensors::PressureDeltaToFlow(kPa(1.1f)));
   EXPECT_FLOW_NEAR(readings.outflow, Sensors::PressureDeltaToFlow(kPa(0.01f)));
-}
-
-TEST(SensorTests, FlowDrift) {
-  // Set pressure sensors to 0kPa for calibration.
-  for (auto pin : {AnalogPin::PATIENT_PRESSURE, AnalogPin::INFLOW_PRESSURE_DIFF,
-                   AnalogPin::OUTFLOW_PRESSURE_DIFF}) {
-    Hal.test_setAnalogPin(pin, MPXV5004_PressureToVoltage(kPa(0)));
-  }
-
-  Sensors sensors;
-  sensors.Calibrate();
-
-  // Apply a constant pressure difference to the flow sensors over a few
-  // breaths.
-  std::vector<float> v1;
-  for (int i = 0; i < 10; i++) {
-    sensors.NoteNewBreath();
-    v1.push_back(update_readings(/*dt=*/seconds(6),
-                                 /*patient_pressure=*/cmH2O(0),
-                                 /*inflow_pressure=*/cmH2O(0.005f),
-                                 /*outflow_pressure=*/cmH2O(0), &sensors)
-                     .volume.ml());
-  }
-  // At first TV should increase, but eventually this should be detected as
-  // flow sensor drift, and the TV should level off and start decreasing.
-  // Check that the max isn't the first or last element.
-  EXPECT_GT(v1[0], 0.0f);
-  auto v1_max_idx =
-      std::distance(v1.begin(), std::max_element(v1.begin(), v1.end()));
-  EXPECT_GT(v1_max_idx, 0);
-  EXPECT_LT(v1_max_idx, static_cast<int>(v1.size()) - 1);
-
-  // Now remove the pressure difference.
-  //
-  // TODO: With the current flow-drift PID settings, the volume here doesn't
-  // converge to 0 as desired.
-  std::vector<float> v2;
-  for (size_t i = 0; i < 10; i++) {
-    sensors.NoteNewBreath();
-    v2.push_back(update_readings(/*dt=*/seconds(6),
-                                 /*patient_pressure=*/cmH2O(0),
-                                 /*inflow_pressure=*/cmH2O(0),
-                                 /*outflow_pressure=*/cmH2O(0), &sensors)
-                     .volume.ml());
-  }
-  // At first TV should decrease, but eventually it should level off.  Check
-  // that min derivative (i.e. the min flow) isn't the first element.
-  std::vector<float> f2;
-  for (size_t i = 1; i < v2.size(); i++) {
-    f2.push_back(v2[i] - v2[i - 1]);
-  }
-  EXPECT_LT(f2[0], 0.0f);
-  auto f2_min_idx =
-      std::distance(f2.begin(), std::min_element(f2.begin(), f2.end()));
-  EXPECT_GT(f2_min_idx, 0);
-  EXPECT_LT(f2_min_idx, f2.size() - 1);
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Move volume sensing into controller.
    
    At long last.
    
    This fixes a layering violation (sensors module shouldn't care about
    breaths), and opens the door to more sophisticated volume zeroing logic.
    It's also easier to test, because you don't have to compute voltages!
    
    I had to fix an edge case in blower_fsm; our breaths were one
    microsecond too long.  Not a big deal except in tests.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #505 Move volume sensing into controller. 👈 **YOU ARE HERE**
1. #506 Delete unused VentParams.rise_time_ms.
1. #507 Rename FlowIntegrator::GetTV -> GetVolume.
1. #508 Much better flow error correction.


</git-pr-chain>

















