### PR TITLE
Delete unused VentParams.rise_time_ms.

### DIFF
--- a/common/generated_libs/network_protocol/network_protocol.pb.h
+++ b/common/generated_libs/network_protocol/network_protocol.pb.h
@@ -47,7 +47,6 @@ typedef struct _VentParams {
     uint32_t breaths_per_min;
     uint32_t pip_cm_h2o;
     float inspiratory_expiratory_ratio;
-    uint32_t rise_time_ms;
     uint32_t inspiratory_trigger_cm_h2o;
     uint32_t expiratory_trigger_ml_per_min;
     uint32_t alarm_lo_tidal_volume_ml;
@@ -87,12 +86,12 @@ typedef struct _GuiStatus {
 /* Initializer values for message structs */
 #define GuiStatus_init_default                   {0, VentParams_init_default, 0, {Alarm_init_default, Alarm_init_default, Alarm_init_default, Alarm_init_default}}
 #define ControllerStatus_init_default            {0, VentParams_init_default, SensorsProto_init_default, 0, {Alarm_init_default, Alarm_init_default, Alarm_init_default, Alarm_init_default}, 0, 0}
-#define VentParams_init_default                  {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define VentParams_init_default                  {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define SensorsProto_init_default                {0, 0, 0, 0, 0}
 #define Alarm_init_default                       {0, _AlarmKind_MIN}
 #define GuiStatus_init_zero                      {0, VentParams_init_zero, 0, {Alarm_init_zero, Alarm_init_zero, Alarm_init_zero, Alarm_init_zero}}
 #define ControllerStatus_init_zero               {0, VentParams_init_zero, SensorsProto_init_zero, 0, {Alarm_init_zero, Alarm_init_zero, Alarm_init_zero, Alarm_init_zero}, 0, 0}
-#define VentParams_init_zero                     {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define VentParams_init_zero                     {_VentMode_MIN, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define SensorsProto_init_zero                   {0, 0, 0, 0, 0}
 #define Alarm_init_zero                          {0, _AlarmKind_MIN}
 
@@ -109,7 +108,6 @@ typedef struct _GuiStatus {
 #define VentParams_breaths_per_min_tag           4
 #define VentParams_pip_cm_h2o_tag                5
 #define VentParams_inspiratory_expiratory_ratio_tag 6
-#define VentParams_rise_time_ms_tag              7
 #define VentParams_inspiratory_trigger_cm_h2o_tag 8
 #define VentParams_expiratory_trigger_ml_per_min_tag 9
 #define VentParams_alarm_lo_tidal_volume_ml_tag  10
@@ -155,7 +153,6 @@ X(a, STATIC,   REQUIRED, UINT32,   peep_cm_h2o,       3) \
 X(a, STATIC,   REQUIRED, UINT32,   breaths_per_min,   4) \
 X(a, STATIC,   REQUIRED, UINT32,   pip_cm_h2o,        5) \
 X(a, STATIC,   REQUIRED, FLOAT,    inspiratory_expiratory_ratio,   6) \
-X(a, STATIC,   REQUIRED, UINT32,   rise_time_ms,      7) \
 X(a, STATIC,   REQUIRED, UINT32,   inspiratory_trigger_cm_h2o,   8) \
 X(a, STATIC,   REQUIRED, UINT32,   expiratory_trigger_ml_per_min,   9) \
 X(a, STATIC,   REQUIRED, UINT32,   alarm_lo_tidal_volume_ml,  10) \
@@ -194,9 +191,9 @@ extern const pb_msgdesc_t Alarm_msg;
 #define Alarm_fields &Alarm_msg
 
 /* Maximum encoded size of messages (where known) */
-#define GuiStatus_size                           140
-#define ControllerStatus_size                    177
-#define VentParams_size                          67
+#define GuiStatus_size                           134
+#define ControllerStatus_size                    171
+#define VentParams_size                          61
 #define SensorsProto_size                        25
 #define Alarm_size                               13
 

--- a/common/generated_libs/network_protocol/network_protocol.proto
+++ b/common/generated_libs/network_protocol/network_protocol.proto
@@ -135,7 +135,6 @@ message VentParams {
   required uint32 breaths_per_min = 4; // RR - respiratory rate
   required uint32 pip_cm_h2o = 5;      // PIP - peak inspiratory pressure
   required float inspiratory_expiratory_ratio = 6; // I:E
-  required uint32 rise_time_ms = 7; // time to reach inspiratory press. plateau
 
   required uint32 inspiratory_trigger_cm_h2o = 8; // P-trigger
 

--- a/controller/test/comms/comms_test.cpp
+++ b/controller/test/comms/comms_test.cpp
@@ -17,7 +17,6 @@ TEST(CommTests, SendControllerStatus) {
   s.active_params.breaths_per_min = 15;
   s.active_params.pip_cm_h2o = 1;
   s.active_params.inspiratory_expiratory_ratio = 2;
-  s.active_params.rise_time_ms = 100;
   s.active_params.inspiratory_trigger_cm_h2o = 5;
   s.active_params.expiratory_trigger_ml_per_min = 9;
   // Set very large values here because they take up more space in the encoded
@@ -63,7 +62,6 @@ TEST(CommTests, CommandRx) {
   s.desired_params.breaths_per_min = 15;
   s.desired_params.pip_cm_h2o = 1;
   s.desired_params.inspiratory_expiratory_ratio = 2;
-  s.desired_params.rise_time_ms = 100;
   s.desired_params.inspiratory_trigger_cm_h2o = 5;
   s.desired_params.expiratory_trigger_ml_per_min = 9;
   // Set very large values here because they take up more space in the encoded

--- a/utils/network_protocol_pb2.py
+++ b/utils/network_protocol_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
     syntax="proto2",
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
-    serialized_pb=b'\n\x16network_protocol.proto\x1a\x0cnanopb.proto"h\n\tGuiStatus\x12\x11\n\tuptime_ms\x18\x01 \x02(\x04\x12#\n\x0e\x64\x65sired_params\x18\x02 \x02(\x0b\x32\x0b.VentParams\x12#\n\x0c\x61\x63ked_alarms\x18\x03 \x03(\x0b\x32\x06.AlarmB\x05\x92?\x02\x10\x04"\xd0\x01\n\x10\x43ontrollerStatus\x12\x11\n\tuptime_ms\x18\x01 \x02(\x04\x12"\n\ractive_params\x18\x02 \x02(\x0b\x32\x0b.VentParams\x12&\n\x0fsensor_readings\x18\x03 \x02(\x0b\x32\r.SensorsProto\x12(\n\x11\x63ontroller_alarms\x18\x04 \x03(\x0b\x32\x06.AlarmB\x05\x92?\x02\x10\x04\x12 \n\x18pressure_setpoint_cm_h2o\x18\x05 \x02(\x02\x12\x11\n\tfan_power\x18\x06 \x02(\x02"\xf6\x02\n\nVentParams\x12\x17\n\x04mode\x18\x01 \x02(\x0e\x32\t.VentMode\x12\x13\n\x0bpeep_cm_h2o\x18\x03 \x02(\r\x12\x17\n\x0f\x62reaths_per_min\x18\x04 \x02(\r\x12\x12\n\npip_cm_h2o\x18\x05 \x02(\r\x12$\n\x1cinspiratory_expiratory_ratio\x18\x06 \x02(\x02\x12\x14\n\x0crise_time_ms\x18\x07 \x02(\r\x12"\n\x1ainspiratory_trigger_cm_h2o\x18\x08 \x02(\r\x12%\n\x1d\x65xpiratory_trigger_ml_per_min\x18\t \x02(\r\x12 \n\x18\x61larm_lo_tidal_volume_ml\x18\n \x02(\r\x12 \n\x18\x61larm_hi_tidal_volume_ml\x18\x0b \x02(\r\x12 \n\x18\x61larm_lo_breaths_per_min\x18\x0c \x02(\r\x12 \n\x18\x61larm_hi_breaths_per_min\x18\r \x02(\r"\xa6\x01\n\x0cSensorsProto\x12\x1f\n\x17patient_pressure_cm_h2o\x18\x01 \x02(\x02\x12\x11\n\tvolume_ml\x18\x02 \x02(\x02\x12\x17\n\x0f\x66low_ml_per_min\x18\x03 \x02(\x02\x12#\n\x1binflow_pressure_diff_cm_h2o\x18\x04 \x02(\x02\x12$\n\x1coutflow_pressure_diff_cm_h2o\x18\x05 \x02(\x02"5\n\x05\x41larm\x12\x12\n\nstart_time\x18\x01 \x02(\x04\x12\x18\n\x04kind\x18\x02 \x02(\x0e\x32\n.AlarmKind*)\n\x08VentMode\x12\x07\n\x03OFF\x10\x00\x12\x14\n\x10PRESSURE_CONTROL\x10\x01*}\n\tAlarmKind\x12\x1c\n\x18RESPIRATORY_RATE_TOO_LOW\x10\x01\x12\x1d\n\x19RESPIRATORY_RATE_TOO_HIGH\x10\x02\x12\x18\n\x14TIDAL_VOLUME_TOO_LOW\x10\x03\x12\x19\n\x15TIDAL_VOLUME_TOO_HIGH\x10\x04',
+    serialized_pb=b'\n\x16network_protocol.proto\x1a\x0cnanopb.proto"h\n\tGuiStatus\x12\x11\n\tuptime_ms\x18\x01 \x02(\x04\x12#\n\x0e\x64\x65sired_params\x18\x02 \x02(\x0b\x32\x0b.VentParams\x12#\n\x0c\x61\x63ked_alarms\x18\x03 \x03(\x0b\x32\x06.AlarmB\x05\x92?\x02\x10\x04"\xd0\x01\n\x10\x43ontrollerStatus\x12\x11\n\tuptime_ms\x18\x01 \x02(\x04\x12"\n\ractive_params\x18\x02 \x02(\x0b\x32\x0b.VentParams\x12&\n\x0fsensor_readings\x18\x03 \x02(\x0b\x32\r.SensorsProto\x12(\n\x11\x63ontroller_alarms\x18\x04 \x03(\x0b\x32\x06.AlarmB\x05\x92?\x02\x10\x04\x12 \n\x18pressure_setpoint_cm_h2o\x18\x05 \x02(\x02\x12\x11\n\tfan_power\x18\x06 \x02(\x02"\xe0\x02\n\nVentParams\x12\x17\n\x04mode\x18\x01 \x02(\x0e\x32\t.VentMode\x12\x13\n\x0bpeep_cm_h2o\x18\x03 \x02(\r\x12\x17\n\x0f\x62reaths_per_min\x18\x04 \x02(\r\x12\x12\n\npip_cm_h2o\x18\x05 \x02(\r\x12$\n\x1cinspiratory_expiratory_ratio\x18\x06 \x02(\x02\x12"\n\x1ainspiratory_trigger_cm_h2o\x18\x08 \x02(\r\x12%\n\x1d\x65xpiratory_trigger_ml_per_min\x18\t \x02(\r\x12 \n\x18\x61larm_lo_tidal_volume_ml\x18\n \x02(\r\x12 \n\x18\x61larm_hi_tidal_volume_ml\x18\x0b \x02(\r\x12 \n\x18\x61larm_lo_breaths_per_min\x18\x0c \x02(\r\x12 \n\x18\x61larm_hi_breaths_per_min\x18\r \x02(\r"\xa6\x01\n\x0cSensorsProto\x12\x1f\n\x17patient_pressure_cm_h2o\x18\x01 \x02(\x02\x12\x11\n\tvolume_ml\x18\x02 \x02(\x02\x12\x17\n\x0f\x66low_ml_per_min\x18\x03 \x02(\x02\x12#\n\x1binflow_pressure_diff_cm_h2o\x18\x04 \x02(\x02\x12$\n\x1coutflow_pressure_diff_cm_h2o\x18\x05 \x02(\x02"5\n\x05\x41larm\x12\x12\n\nstart_time\x18\x01 \x02(\x04\x12\x18\n\x04kind\x18\x02 \x02(\x0e\x32\n.AlarmKind*)\n\x08VentMode\x12\x07\n\x03OFF\x10\x00\x12\x14\n\x10PRESSURE_CONTROL\x10\x01*}\n\tAlarmKind\x12\x1c\n\x18RESPIRATORY_RATE_TOO_LOW\x10\x01\x12\x1d\n\x19RESPIRATORY_RATE_TOO_HIGH\x10\x02\x12\x18\n\x14TIDAL_VOLUME_TOO_LOW\x10\x03\x12\x19\n\x15TIDAL_VOLUME_TOO_HIGH\x10\x04',
     dependencies=[nanopb__pb2.DESCRIPTOR,],
 )
 
@@ -52,8 +52,8 @@ _VENTMODE = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=958,
-    serialized_end=999,
+    serialized_start=936,
+    serialized_end=977,
 )
 _sym_db.RegisterEnumDescriptor(_VENTMODE)
 
@@ -100,8 +100,8 @@ _ALARMKIND = _descriptor.EnumDescriptor(
     ],
     containing_type=None,
     serialized_options=None,
-    serialized_start=1001,
-    serialized_end=1126,
+    serialized_start=979,
+    serialized_end=1104,
 )
 _sym_db.RegisterEnumDescriptor(_ALARMKIND)
 
@@ -433,28 +433,9 @@ _VENTPARAMS = _descriptor.Descriptor(
             create_key=_descriptor._internal_create_key,
         ),
         _descriptor.FieldDescriptor(
-            name="rise_time_ms",
-            full_name="VentParams.rise_time_ms",
-            index=5,
-            number=7,
-            type=13,
-            cpp_type=3,
-            label=2,
-            has_default_value=False,
-            default_value=0,
-            message_type=None,
-            enum_type=None,
-            containing_type=None,
-            is_extension=False,
-            extension_scope=None,
-            serialized_options=None,
-            file=DESCRIPTOR,
-            create_key=_descriptor._internal_create_key,
-        ),
-        _descriptor.FieldDescriptor(
             name="inspiratory_trigger_cm_h2o",
             full_name="VentParams.inspiratory_trigger_cm_h2o",
-            index=6,
+            index=5,
             number=8,
             type=13,
             cpp_type=3,
@@ -473,7 +454,7 @@ _VENTPARAMS = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="expiratory_trigger_ml_per_min",
             full_name="VentParams.expiratory_trigger_ml_per_min",
-            index=7,
+            index=6,
             number=9,
             type=13,
             cpp_type=3,
@@ -492,7 +473,7 @@ _VENTPARAMS = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="alarm_lo_tidal_volume_ml",
             full_name="VentParams.alarm_lo_tidal_volume_ml",
-            index=8,
+            index=7,
             number=10,
             type=13,
             cpp_type=3,
@@ -511,7 +492,7 @@ _VENTPARAMS = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="alarm_hi_tidal_volume_ml",
             full_name="VentParams.alarm_hi_tidal_volume_ml",
-            index=9,
+            index=8,
             number=11,
             type=13,
             cpp_type=3,
@@ -530,7 +511,7 @@ _VENTPARAMS = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="alarm_lo_breaths_per_min",
             full_name="VentParams.alarm_lo_breaths_per_min",
-            index=10,
+            index=9,
             number=12,
             type=13,
             cpp_type=3,
@@ -549,7 +530,7 @@ _VENTPARAMS = _descriptor.Descriptor(
         _descriptor.FieldDescriptor(
             name="alarm_hi_breaths_per_min",
             full_name="VentParams.alarm_hi_breaths_per_min",
-            index=11,
+            index=10,
             number=13,
             type=13,
             cpp_type=3,
@@ -575,7 +556,7 @@ _VENTPARAMS = _descriptor.Descriptor(
     extension_ranges=[],
     oneofs=[],
     serialized_start=358,
-    serialized_end=732,
+    serialized_end=710,
 )
 
 
@@ -691,8 +672,8 @@ _SENSORSPROTO = _descriptor.Descriptor(
     syntax="proto2",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=735,
-    serialized_end=901,
+    serialized_start=713,
+    serialized_end=879,
 )
 
 
@@ -751,8 +732,8 @@ _ALARM = _descriptor.Descriptor(
     syntax="proto2",
     extension_ranges=[],
     oneofs=[],
-    serialized_start=903,
-    serialized_end=956,
+    serialized_start=881,
+    serialized_end=934,
 )
 
 _GUISTATUS.fields_by_name["desired_params"].message_type = _VENTPARAMS


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Delete unused VentParams.rise_time_ms.
    
    I didn't realize that we had this param and, in an earlier change,
    hardcoded it to 100.  I guess that's...fine?  We don't expect to change
    it from the GUI.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #506 Delete unused VentParams.rise_time_ms. 👈 **YOU ARE HERE**
1. #507 Rename FlowIntegrator::GetTV -> GetVolume.
1. #508 Much better flow error correction.


</git-pr-chain>

















