### PR TITLE
Rename FlowIntegrator::GetTV -> GetVolume.

### DIFF
--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -65,7 +65,7 @@ Controller::Run(Time now, const VentParams &params,
   flow_integrator_->AddFlow(now, uncorrected_net_flow);
   uncorrected_flow_integrator_->AddFlow(now, uncorrected_net_flow);
 
-  Volume patient_volume = flow_integrator_->GetTV();
+  Volume patient_volume = flow_integrator_->GetVolume();
   VolumetricFlow net_flow =
       uncorrected_net_flow + flow_integrator_->FlowCorrection();
 
@@ -127,7 +127,7 @@ Controller::Run(Time now, const VentParams &params,
   dbg_net_flow_uncorrected.Set(
       (sensor_readings.inflow - sensor_readings.outflow).ml_per_sec());
   dbg_volume.Set(controller_state.patient_volume.ml());
-  dbg_volume_uncorrected.Set(uncorrected_flow_integrator_->GetTV().ml());
+  dbg_volume_uncorrected.Set(uncorrected_flow_integrator_->GetVolume().ml());
 
   return {actuators_state, controller_state};
 }

--- a/controller/lib/core/flow_integrator.h
+++ b/controller/lib/core/flow_integrator.h
@@ -32,7 +32,7 @@ public:
   // don't pre-correct it yourself!
   void AddFlow(Time now, VolumetricFlow uncorrected_flow);
 
-  Volume GetTV() const { return volume_; }
+  Volume GetVolume() const { return volume_; }
 
   // FlowIntegrator adds this value to measured flow when computing volume, in
   // an attempt to drive flow to the "correct" volume (as given by

--- a/controller/test/controller/controller_test.cpp
+++ b/controller/test/controller/controller_test.cpp
@@ -65,7 +65,8 @@ TEST(ControllerTest, ControllerVolumeMatchesFlowIntegrator) {
     EXPECT_FLOAT_EQ(
         status.net_flow.ml_per_sec(),
         (uncorrected_flow + flow_integrator.FlowCorrection()).ml_per_sec());
-    EXPECT_FLOAT_EQ(status.patient_volume.ml(), flow_integrator.GetTV().ml());
+    EXPECT_FLOAT_EQ(status.patient_volume.ml(),
+                    flow_integrator.GetVolume().ml());
 
     if (breath_pos == 0) {
       flow_integrator.NoteExpectedVolume(ml(0));

--- a/controller/test/flow_integrator/flow_integrator_test.cpp
+++ b/controller/test/flow_integrator/flow_integrator_test.cpp
@@ -38,33 +38,33 @@ TEST(FlowIntegrator, FlowIntegrator) {
   int t = 0;
   tidal_volume.AddFlow(ticks(t++), flow);
   // first call to AddFlow ==> initialization and TV is 0, even if flow is not
-  EXPECT_EQ(tidal_volume.GetTV().ml(), 0.0f);
+  EXPECT_EQ(tidal_volume.GetVolume().ml(), 0.0f);
   tidal_volume.AddFlow(ticks(t++), flow);
   // integrate 1 l/s flow over 10 ms ==> 5 ml (rectangle rule with initial flow
   // set to 0)
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(5));
+  EXPECT_VOLUME_NEAR(tidal_volume.GetVolume(), ml(5));
 
   tidal_volume.AddFlow(ticks(t++), cubic_m_per_sec(2e-3f));
   // add 2 l/s flow over 10 ms ==> 20 ml ()
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(20));
+  EXPECT_VOLUME_NEAR(tidal_volume.GetVolume(), ml(20));
 
   tidal_volume.AddFlow(ticks(t++), ml_per_min(0.0f));
   // add 0 l/s flow over 10 ms ==> 30 ml (rectangle rule)
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(30.0f));
+  EXPECT_VOLUME_NEAR(tidal_volume.GetVolume(), ml(30.0f));
 
   // integrate 0 for some time ==> still 30 ms
   while (t < 100) {
     tidal_volume.AddFlow(ticks(t++), ml_per_min(0.0f));
   }
 
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(30.0f));
+  EXPECT_VOLUME_NEAR(tidal_volume.GetVolume(), ml(30.0f));
 
   // reverse flow
   flow = liters_per_sec(-1.0f);
   // this does not increment t in order to allow oversampling (following test)
   tidal_volume.AddFlow(ticks(t), flow);
   // remove 1 l/s flow over 10 ms ==> 25 ml (rectangle rule)
-  EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(25.0f));
+  EXPECT_VOLUME_NEAR(tidal_volume.GetVolume(), ml(25.0f));
 
   // oversampling and expect volume to not change except on multiples of 5 ms
   for (int i = 0; i < 50; i++) {
@@ -72,6 +72,7 @@ TEST(FlowIntegrator, FlowIntegrator) {
 
     // remove 1l/s flow over 5 ms only when i is a multiple of 5
     int j = i / 5 * 5;
-    EXPECT_VOLUME_NEAR(tidal_volume.GetTV(), ml(25.0f - static_cast<float>(j)));
+    EXPECT_VOLUME_NEAR(tidal_volume.GetVolume(),
+                       ml(25.0f - static_cast<float>(j)));
   }
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Rename FlowIntegrator::GetTV -> GetVolume.
    
    Tidal volume is the max patient volume over a breath.  Therefore
    FlowIntegrator::GetTV, which gets the *current* volume, should be called
    GetVolume.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #507 Rename FlowIntegrator::GetTV -> GetVolume. 👈 **YOU ARE HERE**
1. #508 Much better flow error correction.


</git-pr-chain>

















