### PR TITLE
Only rezero volume when vent transitions from Off to On

### DIFF
--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -140,24 +140,19 @@ BlowerSystemState BlowerFsm::DesiredState(Time now, const VentParams &params,
   // Immediately turn off the ventilator if params.mode == OFF; otherwise,
   // wait until the end of a cycle before implementing the mode change.
   bool is_new_breath = false;
-  bool start_ventilation = false;
 
   std::visit([&](auto &fsm) { return fsm.Update(now, inputs); }, fsm_);
 
   if (params.mode == VentMode_OFF ||
       std::visit([&](auto &fsm) { return fsm.Finished(); }, fsm_)) {
-    // Set is_new_breath to true even when the ventilator transitions from on
-    // to off, but not when ventilator stays off.
-    // It's a little arbitrary, but for the most part, is_new_breath is used to
-    // mark breath boundaries rather than simply signal the beginning of a
-    // breath, and it would be weird if the last breath before turning off the
-    // ventilator appeared to continue indefinitely.
+    // Set is_new_breath to true only when entering a new cycle, not if this
+    // is the continuation of the Off Fsm.
+    // This means setting it to true on the transition from On to Off, which
+    // allows the controller to keep track of volume once the ventilator is
+    // turned Off, assuming the user will stop the ventilator when volume
+    // is close to 0.
     if (!std::holds_alternative<OffFsm>(fsm_)) {
       is_new_breath = true;
-    }
-    // Set start_ventilation to true when we leave Off State
-    if (std::holds_alternative<OffFsm>(fsm_) && params.mode != VentMode_OFF) {
-      start_ventilation = true;
     }
 
     switch (params.mode) {
@@ -176,6 +171,5 @@ BlowerSystemState BlowerFsm::DesiredState(Time now, const VentParams &params,
   BlowerSystemState s =
       std::visit([&](auto &fsm) { return fsm.DesiredState(); }, fsm_);
   s.is_new_breath = is_new_breath;
-  s.start_ventilation = start_ventilation;
   return s;
 }

--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -145,15 +145,9 @@ BlowerSystemState BlowerFsm::DesiredState(Time now, const VentParams &params,
 
   if (params.mode == VentMode_OFF ||
       std::visit([&](auto &fsm) { return fsm.Finished(); }, fsm_)) {
-    // Set is_new_breath to true only when entering a new cycle, not if this
-    // is the continuation of the Off Fsm.
-    // This means setting it to true on the transition from On to Off, which
-    // allows the controller to keep track of volume once the ventilator is
-    // turned Off, assuming the user will stop the ventilator when volume
-    // is close to 0.
-    if (!std::holds_alternative<OffFsm>(fsm_)) {
-      is_new_breath = true;
-    }
+    // For the purpose of is_new_breath, treat multiple occurrences of OffFsm
+    // as a "single breath".
+    is_new_breath = !std::holds_alternative<OffFsm>(fsm_);
 
     switch (params.mode) {
     case VentMode_OFF:

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -82,11 +82,6 @@ struct BlowerSystemState {
   // This is defaulted to false here and is handled by BlowerFsm, rather than
   // the individual FSM classes (OffFsm, PressureControlFsm, etc).
   bool is_new_breath = false;
-
-  // Is this the first BlowerSystemState for a state different from Off state?
-  // Used to reset some variables (volume integrators) to 0 when we start the
-  // ventilator (transition from Off mode to any other mode).
-  bool start_ventilation = false;
 };
 
 // Transition from PEEP to PIP pressure over this length of time.  Citation:

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -82,6 +82,11 @@ struct BlowerSystemState {
   // This is defaulted to false here and is handled by BlowerFsm, rather than
   // the individual FSM classes (OffFsm, PressureControlFsm, etc).
   bool is_new_breath = false;
+
+  // Is this the first BlowerSystemState for a state different from Off state?
+  // Used to reset some variables (volume integrators) to 0 when we start the
+  // ventilator (transition from Off mode to any other mode).
+  bool start_ventilation = false;
 };
 
 // Transition from PEEP to PIP pressure over this length of time.  Citation:

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -90,13 +90,13 @@ Controller::Run(Time now, const VentParams &params,
     // them to the desired positions.
     blower_valve_pid_.Reset();
 
-    // Reset the two flow integrators, forcing volume to 0.
+    // Reset the flow integrators, forcing volume to 0 when vent transitions
+    // from Off state to any other state.
     //
-    // TODO: This isn't ideal; if the blower is off, we should still be able to
-    // report volume.
-    flow_integrator_.emplace();
-    uncorrected_flow_integrator_.emplace();
-
+    if (desired_state.start_ventilation) {
+      flow_integrator_.emplace();
+      uncorrected_flow_integrator_.emplace();
+    }
     actuators_state = {
         .fio2_valve = 0,
         .blower_power = 0,

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -96,9 +96,9 @@ Controller::Run(Time now, const VentParams &params,
         .blower_valve = 0,
         .exhale_valve = 1,
     };
-    ventilator_was_off_ = true;
+    ventilator_was_on_ = false;
   } else {
-    if (ventilator_was_off_) {
+    if (!ventilator_was_on_) {
       // reset volume integrators
       flow_integrator_.emplace();
       uncorrected_flow_integrator_.emplace();
@@ -115,7 +115,7 @@ Controller::Run(Time now, const VentParams &params,
         .exhale_valve =
             desired_state.flow_direction == FlowDirection::EXPIRATORY ? 1 : 0,
     };
-    ventilator_was_off_ = false;
+    ventilator_was_on_ = true;
   }
 
   ControllerState controller_state = {

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -90,20 +90,19 @@ Controller::Run(Time now, const VentParams &params,
     // them to the desired positions.
     blower_valve_pid_.Reset();
 
-    // Reset the flow integrators, forcing volume to 0 when vent transitions
-    // from Off state to any other state.
-    //
-    if (desired_state.start_ventilation) {
-      flow_integrator_.emplace();
-      uncorrected_flow_integrator_.emplace();
-    }
     actuators_state = {
         .fio2_valve = 0,
         .blower_power = 0,
         .blower_valve = 0,
         .exhale_valve = 1,
     };
+    ventilator_was_off_ = true;
   } else {
+    if (ventilator_was_off_) {
+      // reset volume integrators
+      flow_integrator_.emplace();
+      uncorrected_flow_integrator_.emplace();
+    }
     // Start controlling pressure.
     actuators_state = {
         .fio2_valve = 0, // not used yet
@@ -116,6 +115,7 @@ Controller::Run(Time now, const VentParams &params,
         .exhale_valve =
             desired_state.flow_direction == FlowDirection::EXPIRATORY ? 1 : 0,
     };
+    ventilator_was_off_ = false;
   }
 
   ControllerState controller_state = {

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -52,6 +52,10 @@ private:
   // objects.
   std::optional<FlowIntegrator> flow_integrator_ = FlowIntegrator();
   std::optional<FlowIntegrator> uncorrected_flow_integrator_ = FlowIntegrator();
+
+  // This state allows resetting integrators when transitioning from Off state
+  // to On state.
+  bool ventilator_was_off_ = true;
 };
 
 #endif // CONTROLLER_H_

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -53,9 +53,10 @@ private:
   std::optional<FlowIntegrator> flow_integrator_ = FlowIntegrator();
   std::optional<FlowIntegrator> uncorrected_flow_integrator_ = FlowIntegrator();
 
-  // This state allows resetting integrators when transitioning from Off state
-  // to On state.
-  bool ventilator_was_off_ = true;
+  // This state tells the controller whether the vent was already On when Run()
+  // was last called, and allows resetting integrators when transitioning from
+  // Off state to On state.
+  bool ventilator_was_on_ = false;
 };
 
 #endif // CONTROLLER_H_


### PR DESCRIPTION
Instead of constantly when vent is Off. This should allow us to report volume when the vent is off, provided each venturi still see the flow in the correct direction when vent is off (thanks to check valves, which are lacking in our pizza builds), and provided we can take care of the drift when flow is close to zero (incoming PR with my drift correction algorithm).