### PR TITLE
[Draft] Wires the max pressure alarm to the color of the pressure graph

### DIFF
--- a/gui/app/Style.qml
+++ b/gui/app/Style.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 import QtQuick 2.11
+import Respira 1.0
 
 /*!
     \qmltype Style
@@ -42,6 +43,15 @@ QtObject {
 
             property color textPrimary: "white"
             property color textAlternative:"#AFAFAF"
+
+            property var timeSeries: QtObject {
+              property var lineByPriority: function(p) {
+                return (p == AlarmPriority.HIGH) ? "#C6393F" : "white";
+              }
+              property var areaByPriority: function(p) {
+                return (p == AlarmPriority.HIGH) ? "#521F28" : "#202A32";
+              }
+            }
         }
 
         property QtObject font: QtObject {

--- a/gui/app/controls/ScopeView.qml
+++ b/gui/app/controls/ScopeView.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import Respira 1.0
-
 import ".."
 
 Item {
@@ -12,13 +11,14 @@ Item {
     property double yMin: -1.5
     property double yMax: 1.5
     property double rangeInSeconds: 30
+    property int alarmPriority: AlarmPriority.NONE
 
     property alias name: nameLabel.text
     property alias unit: unitLabel.text
 
     property alias showBottomLine: bottomLine.visible
     property alias dataset: timeSeriesGraph.dataset
-    property alias color: timeSeriesGraph.color
+
 
     Text {
         id: yMaxLabel
@@ -70,7 +70,8 @@ Item {
 
     TimeSeriesGraph {
         id: timeSeriesGraph
-        color: "white"
+        lineColor: Style.theme.color.timeSeries.lineByPriority(alarmPriority)
+        areaColor: Style.theme.color.timeSeries.areaByPriority(alarmPriority)
         anchors {
             top: parent.top; topMargin: 12
             left: parent.left; leftMargin: 48

--- a/gui/app/main.cpp
+++ b/gui/app/main.cpp
@@ -1,3 +1,4 @@
+#include "alarm.h"
 #include "chrono.h"
 #include "connected_device.h"
 #include "controller_history.h"
@@ -155,6 +156,8 @@ int main(int argc, char *argv[]) {
   communicate.Start();
 
   qmlRegisterType<TimeSeriesGraph>("Respira", 1, 0, "TimeSeriesGraph");
+  qmlRegisterUncreatableType<AlarmPriority>("Respira", 1, 0, "AlarmPriority",
+                                            "is an enum");
   qmlRegisterSingletonType<GuiStateContainer>(
       "Respira", 1, 0, "GuiStateContainer", &gui_state_instance);
 

--- a/gui/app/modes/CommandPressureMode.qml
+++ b/gui/app/modes/CommandPressureMode.qml
@@ -59,7 +59,10 @@ Mode {
             anchors.fill: parent
             spacing: 0
 
-            PressureGraph { Layout.fillHeight: true; Layout.fillWidth: true }
+            PressureGraph {
+              Layout.fillHeight: true; Layout.fillWidth: true
+              alarmPriority: GuiStateContainer.maxPressureAlarm.isVisualActive ? AlarmPriority.HIGH : AlarmPriority.NONE
+            }
             FlowGraph { Layout.fillHeight: true; Layout.fillWidth: true }
             TvGraph { Layout.fillHeight: true; Layout.fillWidth: true }
         }

--- a/gui/src/alarm.h
+++ b/gui/src/alarm.h
@@ -1,0 +1,20 @@
+#ifndef ALARM_H_
+#define ALARM_H_
+
+#include <QObject>
+
+class AlarmPriority {
+  Q_GADGET
+
+public:
+  enum class Enum {
+    NONE,
+    LOW,
+    MEDIUM,
+    HIGH,
+  };
+
+  Q_ENUM(Enum)
+};
+
+#endif // ALARM_H_

--- a/gui/src/src.pro
+++ b/gui/src/src.pro
@@ -1,5 +1,4 @@
-# TODO see if I can minimize this
-QT += core quick serialport
+QT += core quick charts serialport qml
 
 include( ../defaults.pri )
 ! include( ../common.pri ) {
@@ -15,7 +14,8 @@ TARGET = everything
 TEMPLATE = lib
 CONFIG += staticlib
 
-HEADERS += chrono.h \
+HEADERS += alarm.h \
+  chrono.h \
   connected_device.h \
   controller_history.h \
   gui_state_container.h \

--- a/gui/src/time_series_graph.h
+++ b/gui/src/time_series_graph.h
@@ -23,7 +23,10 @@ class TimeSeriesGraph : public QNanoQuickItem {
       float maxValue READ GetMaxValue WRITE SetMaxValue NOTIFY MaxValueChanged)
   Q_PROPERTY(float rangeInSeconds READ GetRangeInSeconds WRITE SetRangeInSeconds
                  NOTIFY RangeInSecondsChanged)
-  Q_PROPERTY(QColor color READ GetColor WRITE SetColor NOTIFY ColorChanged)
+  Q_PROPERTY(QColor lineColor READ GetLineColor WRITE SetLineColor NOTIFY
+                 LineColorChanged)
+  Q_PROPERTY(QColor areaColor READ GetAreaColor WRITE SetAreaColor NOTIFY
+                 AreaColorChanged)
   Q_PROPERTY(bool showBaseline READ GetShowBaseline WRITE SetShowBaseline NOTIFY
                  ShowBaselineChanged)
   Q_PROPERTY(float baselineValue READ GetBaselineValue WRITE SetBaselineValue
@@ -40,7 +43,9 @@ public:
 
   float GetRangeInSeconds() const { return range_in_secs_; };
 
-  QColor GetColor() const { return color_; };
+  QColor GetLineColor() const { return line_color_; };
+
+  QColor GetAreaColor() const { return area_color_; };
 
   bool GetShowBaseline() const { return show_baseline_; }
 
@@ -68,10 +73,17 @@ public slots:
     }
   }
 
-  void SetColor(QColor color) {
-    if (color_ != color) {
-      color_ = color;
-      emit ColorChanged();
+  void SetLineColor(QColor color) {
+    if (line_color_ != color) {
+      line_color_ = color;
+      emit LineColorChanged();
+    }
+  }
+
+  void SetAreaColor(QColor color) {
+    if (area_color_ != color) {
+      area_color_ = color;
+      emit AreaColorChanged();
     }
   }
 
@@ -103,7 +115,8 @@ signals:
   void DatasetChanged();
   void MinValueChanged();
   void MaxValueChanged();
-  void ColorChanged();
+  void LineColorChanged();
+  void AreaColorChanged();
   void RangeInSecondsChanged();
   void ShowBaselineChanged();
   void BaselineValueChanged();
@@ -111,7 +124,8 @@ signals:
 private:
   QVector<QPointF> dataset_;
 
-  QColor color_ = QColor(255, 255, 255, 255);
+  QColor line_color_ = QColor(255, 255, 255, 255);
+  QColor area_color_ = QColor(255, 255, 255, 255);
   float max_value_ = 0;
   float min_value_ = 0;
   float range_in_secs_ = 30.0;

--- a/gui/src/time_series_graph_painter.cpp
+++ b/gui/src/time_series_graph_painter.cpp
@@ -68,10 +68,10 @@ void TimeSeriesGraphPainter::synchronize(QNanoQuickItem *item) {
   min_value_ = realItem->GetMinValue();
   max_value_ = realItem->GetMaxValue();
   range_in_sec = realItem->GetRangeInSeconds();
-  color_line_ =
-      QNanoColor(realItem->GetColor().red(), realItem->GetColor().green(),
-                 realItem->GetColor().blue(), realItem->GetColor().alpha());
-
-  color_fill_ = QNanoColor(color_line_);
-  color_fill_.setAlpha(0x1A);
+  color_line_ = QNanoColor(
+      realItem->GetLineColor().red(), realItem->GetLineColor().green(),
+      realItem->GetLineColor().blue(), realItem->GetLineColor().alpha());
+  color_fill_ = QNanoColor(
+      realItem->GetAreaColor().red(), realItem->GetAreaColor().green(),
+      realItem->GetAreaColor().blue(), realItem->GetAreaColor().alpha());
 }

--- a/gui/tests/max_pressure_alarm_test.h
+++ b/gui/tests/max_pressure_alarm_test.h
@@ -29,7 +29,7 @@ private slots:
 
     auto now = t(0);
     QVERIFY(!alarm.IsAudioActive(now));
-    QVERIFY(!alarm.IsVisualActive(now));
+    QVERIFY(!alarm.IsVisualActive());
     QVERIFY(!alarm.CanAcknowledge());
     QVERIFY(!alarm.CanReset());
 
@@ -37,7 +37,7 @@ private slots:
     // Go above pressure threshold.
     alarm.Update(now, pressure(100));
     QVERIFY(alarm.IsAudioActive(now));
-    QVERIFY(alarm.IsVisualActive(now));
+    QVERIFY(alarm.IsVisualActive());
     // Allowed to acknowledge - audio is active.
     QVERIFY(alarm.CanAcknowledge());
     // Not allowed to reset because condition is currently met.
@@ -48,7 +48,7 @@ private slots:
     // active.
     alarm.Update(now, pressure(30));
     QVERIFY(alarm.IsAudioActive(now));
-    QVERIFY(alarm.IsVisualActive(now));
+    QVERIFY(alarm.IsVisualActive());
     QVERIFY(alarm.CanAcknowledge());
     // Allowed to reset now, as the condition is not currently met.
     QVERIFY(alarm.CanReset());
@@ -81,7 +81,7 @@ private slots:
     QVERIFY(alarm.CanReset());
     alarm.Reset(now);
     QVERIFY(!alarm.IsAudioActive(now));
-    QVERIFY(!alarm.IsVisualActive(now));
+    QVERIFY(!alarm.IsVisualActive());
 
     // Activate again.
     now = t(126);
@@ -89,7 +89,7 @@ private slots:
     now = t(127);
     alarm.Update(now, pressure(50));
     QVERIFY(alarm.IsAudioActive(now));
-    QVERIFY(alarm.IsVisualActive(now));
+    QVERIFY(alarm.IsVisualActive());
     QVERIFY(alarm.CanAcknowledge());
     QVERIFY(alarm.CanReset());
   }


### PR DESCRIPTION
This is further progress towards #366 .

The goal of this PR is to lay the groundwork for wiring alarms to GUI.

Marked "draft" because there's a bunch more stuff to be done UX-wise before this can be merged - @paulovap let's discuss the sequencing during our chat tomorrow.

Basically the PR does the following:
* Makes GuiStateContainer a regular QObject obeying QT threading logic instead of using its own mutex. I did this because:
  * Both comms thread (gui/controller status exchange) and GUI thread need to talk to the alarm state
  * I want MaxPressureAlarm to be a property of GuiStateContainer, because alarm state is GUI state
  * Using a mutex in GuiStateContainer meant that GuiStateContainer manages thread safety, but it cannot manage thread safety transitively through MaxPressureAlarm, and I don't want to add mutexes to the alarm.
  * So it's much easier to use regular QObject's and handle interaction with the comms thread via Qt queued signal connections (when invoked from a thread other than the object's thread, signals by default get queued for later delivery).
* Introduces style elements for graph area/line color based on priority of the alarm associated with this graph. This is based on @ThomasSonsalla's idea that, since we have a pressure-based alarm but don't have a pressure readout, maybe we should color the graph itself.
* Wires the state of the MaxPressureAlarm to a property of the pressure graph in QML.