### PR TITLE
Separates commanded and measured parameter properties in GuiStateContainer

### DIFF
--- a/gui/app/controls/parameters/ITimeParameter.qml
+++ b/gui/app/controls/parameters/ITimeParameter.qml
@@ -6,10 +6,12 @@ import ".."
 ParameterButton {
     parameterName: qsTr("I-time")
     parameterUnit: "sec"
-    parameterValue: Number(GuiStateContainer.ier).toFixed(1)
-    parameterMaxValue: 1
-    parameterMinValue: 0
-    parameterStepSize: 0.05
+    parameterValue: GuiStateContainer.commanded_i_time
+    onValueConfirmed: GuiStateContainer.commanded_i_time = value
+    // Per https://respiraworks.slack.com/archives/C015FL7TSG2/p1592266276036600?thread_ts=1592264406.025800&cid=C015FL7TSG2
+    parameterMinValue: 0.4
+    parameterMaxValue: 3.3
+    parameterStepSize: 0.1
     parameterDisplayFormatter: function (value) {
         return Number(value).toFixed(1)
     }

--- a/gui/app/controls/parameters/PeepParameter.qml
+++ b/gui/app/controls/parameters/PeepParameter.qml
@@ -9,6 +9,6 @@ ParameterButton {
     parameterMaxValue: 20
     parameterMinValue: 0
     parameterStepSize: 2
-    parameterValue: GuiStateContainer.peep
-    onValueConfirmed: GuiStateContainer.peep = value
+    parameterValue: GuiStateContainer.commanded_peep
+    onValueConfirmed: GuiStateContainer.commanded_peep = value
 }

--- a/gui/app/controls/parameters/PipParameter.qml
+++ b/gui/app/controls/parameters/PipParameter.qml
@@ -6,6 +6,6 @@ import ".."
 ParameterButton {
     parameterName: qsTr("PIP")
     parameterUnit: qsTr("cmH<sub>2</sub>0")
-    parameterValue: GuiStateContainer.pip
-    onValueConfirmed: GuiStateContainer.pip = value
+    parameterValue: GuiStateContainer.commanded_pip
+    onValueConfirmed: GuiStateContainer.commanded_pip = value
 }

--- a/gui/app/controls/parameters/RrParameter.qml
+++ b/gui/app/controls/parameters/RrParameter.qml
@@ -9,6 +9,6 @@ ParameterButton {
     parameterMaxValue: 30
     parameterMinValue: 10
     parameterStepSize: 1
-    parameterValue: GuiStateContainer.rr
-    onValueConfirmed: GuiStateContainer.rr = value
+    parameterValue: GuiStateContainer.commanded_rr
+    onValueConfirmed: GuiStateContainer.commanded_rr = value
 }

--- a/gui/app/controls/readings/FlowDisplay.qml
+++ b/gui/app/controls/readings/FlowDisplay.qml
@@ -6,5 +6,5 @@ import ".."
 ParameterDisplay {
     parameterName: qsTr("Flow")
     parameterUnit: qsTr("L/min")
-    parameterValue: GuiStateContainer.flowReadout.toFixed(0)
+    parameterValue: GuiStateContainer.measured_flow.toFixed(0)
 }

--- a/gui/app/controls/readings/IerDisplay.qml
+++ b/gui/app/controls/readings/IerDisplay.qml
@@ -6,5 +6,5 @@ import ".."
 ParameterDisplay {
     parameterName: qsTr("I:E")
     parameterUnit: qsTr("ratio")
-    parameterValue: GuiStateContainer.ier.toFixed(1).toString()
+    parameterValue: GuiStateContainer.measured_ier.toFixed(2).toString()
 }

--- a/gui/app/controls/readings/PeepDisplay.qml
+++ b/gui/app/controls/readings/PeepDisplay.qml
@@ -6,5 +6,5 @@ import ".."
 ParameterDisplay {
     parameterName: qsTr("PEEP")
     parameterUnit: qsTr("cmH<sub>2</sub>O")
-    parameterValue: GuiStateContainer.peep.toString()
+    parameterValue: GuiStateContainer.measured_peep.toString()
 }

--- a/gui/app/controls/readings/PipDisplay.qml
+++ b/gui/app/controls/readings/PipDisplay.qml
@@ -6,5 +6,5 @@ import ".."
 ParameterDisplay {
     parameterName: qsTr("PIP")
     parameterUnit: qsTr("cmH<sub>2</sub>O")
-    parameterValue: GuiStateContainer.pip.toString()
+    parameterValue: GuiStateContainer.measured_pip.toString()
 }

--- a/gui/app/controls/readings/RrDisplay.qml
+++ b/gui/app/controls/readings/RrDisplay.qml
@@ -6,5 +6,5 @@ import ".."
 ParameterDisplay {
     parameterName: qsTr("RR")
     parameterUnit: qsTr("b/min")
-    parameterValue: GuiStateContainer.rr.toString()
+    parameterValue: GuiStateContainer.measured_rr.toString()
 }

--- a/gui/app/controls/readings/TvDisplay.qml
+++ b/gui/app/controls/readings/TvDisplay.qml
@@ -10,5 +10,5 @@ ParameterDisplay {
     // show *max* volume averaged over the past few breaths?  This
     // is what "TV" actually means, and I suspect it's much more
     // meaningful than showing the last-measured patient volume.
-    parameterValue: GuiStateContainer.tvReadout.toFixed(0);
+    parameterValue: GuiStateContainer.measured_tv.toFixed(0);
 }

--- a/gui/app/main.cpp
+++ b/gui/app/main.cpp
@@ -133,11 +133,10 @@ int main(int argc, char *argv[]) {
   // Run comm thread at the same time interval as Cycle Controller.
   std::mutex gui_status_mutex;
   GuiStatus gui_status = state_container->GetGuiStatus();
-  QObject::connect(state_container, &GuiStateContainer::params_changed,
-                   [&](const GuiStatus &status) {
-                     std::unique_lock<std::mutex> l(gui_status_mutex);
-                     gui_status = status;
-                   });
+  QObject::connect(state_container, &GuiStateContainer::params_changed, [&]() {
+    std::unique_lock<std::mutex> l(gui_status_mutex);
+    gui_status = state_container->GetGuiStatus();
+  });
   PeriodicClosure communicate(DurationMs(30), [&] {
     auto now = SteadyClock::now();
     ControllerStatus controller_status;


### PR DESCRIPTION
We don't yet measure anything based on recent breaths but after this PR there'll be a place to plug that logic.

This PR also fixes a bug that we were using IER as I-Time. Now they are kept in sync: you command I-Time and we compute and display the "measured" (actually forced IER) based on that and on RR.