### PR TITLE
Measures recent-breath PIP, PEEP, RR, IER

### DIFF
--- a/gui/app/main.cpp
+++ b/gui/app/main.cpp
@@ -110,9 +110,7 @@ int main(int argc, char *argv[]) {
       status.sensor_readings.patient_pressure_cm_h2o = tokens[1].toFloat();
       status.sensor_readings.flow_ml_per_min = 1000 * tokens[4].toFloat();
       status.sensor_readings.volume_ml = 10 * tokens[5].toFloat();
-      // TODO(jkff) Wait until
-      // https://github.com/RespiraWorks/VentilatorSoftware/pull/519
-      // status.sensor_readings.breath_id = breath_id,
+      status.sensor_readings.breath_id = breath_id;
       statuses.push_back(status);
     }
 

--- a/gui/src/breath_signals.h
+++ b/gui/src/breath_signals.h
@@ -1,0 +1,70 @@
+#ifndef BREATH_SIGNALS_H_
+#define BREATH_SIGNALS_H_
+
+#include <stdint.h>
+
+#include "chrono.h"
+#include "network_protocol.pb.h"
+
+#include <algorithm>
+#include <deque>
+#include <iostream>
+#include <optional>
+
+class BreathSignals {
+public:
+  void Update(SteadyInstant now, const ControllerStatus &status) {
+    float pressure = status.sensor_readings.patient_pressure_cm_h2o;
+    uint64_t breath_id = status.sensor_readings.breath_id;
+
+    if (breath_id != latest_breath_id_) {
+      latest_pip_ = current_pip_;
+      current_pip_ = pressure;
+
+      latest_peep_ = current_peep_;
+      current_peep_ = pressure;
+
+      latest_breath_id_ = status.sensor_readings.breath_id;
+
+      recent_breath_starts_.push_back(now);
+      if (recent_breath_starts_.size() > kMaxRecentBreathStarts) {
+        recent_breath_starts_.pop_front();
+      }
+      return;
+    }
+
+    current_pip_ = std::max(
+        current_pip_.value_or(std::numeric_limits<float>::min()), pressure);
+    current_peep_ = std::min(
+        current_peep_.value_or(std::numeric_limits<float>::max()), pressure);
+  }
+
+  std::optional<float> pip() const { return latest_pip_; }
+  std::optional<float> peep() const { return latest_peep_; }
+  std::optional<float> rr() const {
+    if (recent_breath_starts_.size() < kMinRecentBreathStarts) {
+      return std::nullopt;
+    }
+    SteadyInstant newest = recent_breath_starts_.back();
+    SteadyInstant oldest = recent_breath_starts_.front();
+    float ms_per_breath =
+        static_cast<float>(TimeAMinusB(newest, oldest).count()) /
+        static_cast<float>(recent_breath_starts_.size() - 1);
+    return 60000.0 / ms_per_breath;
+  }
+
+private:
+  std::optional<float> latest_pip_;
+  std::optional<float> current_pip_;
+
+  std::optional<float> latest_peep_;
+  std::optional<float> current_peep_;
+
+  uint64_t latest_breath_id_ = 0;
+
+  static constexpr int kMinRecentBreathStarts = 3;
+  static constexpr int kMaxRecentBreathStarts = 5;
+  std::deque<SteadyInstant> recent_breath_starts_;
+};
+
+#endif // BREATH_SIGNALS_H_

--- a/gui/src/gui_state_container.h
+++ b/gui/src/gui_state_container.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <stdint.h>
 
+#include "breath_signals.h"
 #include "chrono.h"
 #include "controller_history.h"
 #include "simple_clock.h"
@@ -158,6 +159,7 @@ public slots:
   void controller_status_changed(SteadyInstant now,
                                  const ControllerStatus &status) {
     history_.Append(now, status);
+    breath_signals_.Update(now, status);
     measurements_changed();
   }
 
@@ -182,20 +184,16 @@ private:
     return history_.GetLastStatus().sensor_readings.volume_ml;
   }
   qreal get_measured_rr() const {
-    // TODO: Compute based on last breath. For now, return commanded value.
-    return commanded_rr_;
+    return breath_signals_.rr().value_or(commanded_rr_);
   }
   qreal get_measured_peep() const {
-    // TODO: Compute based on last breath. For now, return commanded value.
-    return commanded_peep_;
+    return breath_signals_.peep().value_or(commanded_peep_);
   }
   qreal get_measured_pip() const {
-    // TODO: Compute based on last breath. For now, return commanded value.
-    return commanded_pip_;
+    return breath_signals_.pip().value_or(commanded_pip_);
   }
   qreal get_measured_ier() const {
-    // TODO: Compute based on last breath. For now, return commanded value.
-    float breath_duration_sec = 60.0 / commanded_rr_;
+    float breath_duration_sec = 60.0 / get_measured_rr();
     float commanded_e_time = breath_duration_sec - commanded_i_time_;
     return commanded_i_time_ / commanded_e_time;
   }
@@ -203,6 +201,7 @@ private:
   // ====================== Commanded parameters ========================
   const SteadyInstant startup_time_;
   ControllerHistory history_;
+  BreathSignals breath_signals_;
   int battery_percentage_ = 70;
   SimpleClock clock_;
 

--- a/gui/tests/breath_signals_test.h
+++ b/gui/tests/breath_signals_test.h
@@ -1,0 +1,97 @@
+#ifndef BREATH_SIGNALS_TEST_H_
+#define BREATH_SIGNALS_TEST_H_
+
+#include "breath_signals.h"
+#include "network_protocol.pb.h"
+
+#include <QCoreApplication>
+#include <QtTest>
+
+class BreathSignalsTest : public QObject {
+  Q_OBJECT
+public:
+  BreathSignalsTest() = default;
+  ~BreathSignalsTest() = default;
+
+private slots:
+  void initTestCase() {}
+  void cleanupTestCase() {}
+
+  void testPipAndPeep() {
+    SteadyInstant now = SteadyClock::now();
+    auto pressure = [](uint64_t breath_id, float p) -> ControllerStatus {
+      ControllerStatus res;
+      res.sensor_readings.breath_id = breath_id;
+      res.sensor_readings.patient_pressure_cm_h2o = p;
+      return res;
+    };
+
+    BreathSignals b;
+    QVERIFY(!b.pip().has_value());
+    QVERIFY(!b.peep().has_value());
+
+    b.Update(now, pressure(1, 5.0f));
+    b.Update(now, pressure(1, 7.0f));
+    b.Update(now, pressure(1, 6.0f));
+    QCOMPARE(b.pip().value_or(0), 0);
+    QCOMPARE(b.peep().value_or(0), 0);
+
+    // New breath started - previous breath's values become available.
+    b.Update(now, pressure(2, 4.0f));
+    QCOMPARE(b.pip().value_or(0), 7.0);
+    QCOMPARE(b.peep().value_or(0), 5.0);
+    b.Update(now, pressure(2, 6.0f));
+    b.Update(now, pressure(2, 5.0f));
+
+    // Another breath started - previous breath's values become available.
+    b.Update(now, pressure(3, 4.0f));
+    QCOMPARE(b.pip().value_or(0), 6.0);
+    QCOMPARE(b.peep().value_or(0), 4.0);
+  }
+
+  void testRr() {
+    auto breath = [](uint64_t breath_id) -> ControllerStatus {
+      return {.sensor_readings = {.breath_id = breath_id}};
+    };
+    SteadyInstant now = SteadyClock::now();
+    auto ms = [=](int millis) { return now + DurationMs(millis); };
+
+    BreathSignals b;
+    QVERIFY(!b.rr().has_value());
+
+    // Breath 1: 0-1000, 2: 1000-2000, 3: 2000-4000, 4: 4000-6000
+    b.Update(ms(0), breath(1));
+    b.Update(ms(100), breath(1));
+    b.Update(ms(200), breath(1));
+    QVERIFY(!b.rr().has_value());
+
+    b.Update(ms(1000), breath(2));
+    QVERIFY(!b.rr().has_value());
+
+    // 3 breaths have started, enough to have signal.
+    // The signal is 2 full breaths in 2 seconds = RR of 60.
+    b.Update(ms(2000), breath(3));
+    b.Update(ms(2500), breath(3));
+    QCOMPARE(60.0, b.rr().value_or(0.0));
+
+    // 4 breaths started (3 full breaths) in 4 seconds => RR = 45
+    b.Update(ms(4000), breath(4));
+    QCOMPARE(45.0, b.rr().value_or(0.0));
+
+    // 5 breaths started (4 full breaths) in 6 seconds => RR = 40
+    b.Update(ms(6000), breath(5));
+    QCOMPARE(40.0, b.rr().value_or(0.0));
+
+    // Earliest breath at 0 is evicted, next is at 1000
+    // 5 breaths started (4 full breaths) in 7 seconds => RR = 48
+    b.Update(ms(8000), breath(6));
+    QCOMPARE(4 * 60.0f / 7, b.rr().value_or(0.0));
+
+    // Earliest breath at 1000 is evicted, next is at 2000
+    // 5 breaths started (4 full breaths) in 8 seconds => RR = 30
+    b.Update(ms(10000), breath(7));
+    QCOMPARE(30, b.rr().value_or(0.0));
+  }
+};
+
+#endif // BREATH_SIGNALS_TEST_H_

--- a/gui/tests/max_pressure_alarm_test.h
+++ b/gui/tests/max_pressure_alarm_test.h
@@ -22,7 +22,9 @@ private slots:
     auto base = SteadyClock::now();
     auto t = [=](int seconds) { return base + DurationMs(1000 * seconds); };
     auto pressure = [](float p) -> ControllerStatus {
-      return {.sensor_readings = {.patient_pressure_cm_h2o = p}};
+      ControllerStatus res;
+      res.sensor_readings.patient_pressure_cm_h2o = p;
+      return res;
     };
 
     QCOMPARE(60, alarm.GetThresholdCmH2O());

--- a/gui/tests/tests.pro
+++ b/gui/tests/tests.pro
@@ -8,6 +8,8 @@ QT += testlib gui
 CONFIG += qt warn_on depend_includepath testcase
 
 SOURCES += tst_main.cpp
-HEADERS += max_pressure_alarm_test.h
+HEADERS += \
+  breath_signals_test.h \
+  max_pressure_alarm_test.h
 
 LIBS += -L../src -leverything

--- a/gui/tests/tst_main.cpp
+++ b/gui/tests/tst_main.cpp
@@ -1,6 +1,7 @@
 #include <QCoreApplication>
 #include <QtTest>
 
+#include "breath_signals_test.h"
 #include "max_pressure_alarm_test.h"
 
 int main(int argc, char *argv[]) {
@@ -9,7 +10,12 @@ int main(int argc, char *argv[]) {
   int status = 0;
   {
     MaxPressureAlarmTest tc;
-    status = QTest::qExec(&tc, argc, argv);
+    status += QTest::qExec(&tc, argc, argv);
+  }
+
+  {
+    BreathSignalsTest tc;
+    status += QTest::qExec(&tc, argc, argv);
   }
 
   return status;


### PR DESCRIPTION
This uses the breath_id signal from SensorReadings to delimit breaths and compute these values as aggregates from them in BreathSignals. Seems to produce correct values on the pre-recorded trace.