### PR TITLE
DRAFT - Use different fan speed depending on PIP.

### DIFF
--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -104,9 +104,9 @@ void PressureControlFsm::Update(Time now, const BlowerFsmInputs &inputs) {
 
 BlowerSystemState PressureControlFsm::DesiredState() const {
   if (inspire_finished_) {
-    return {expire_pressure_, FlowDirection::EXPIRATORY};
+    return {expire_pressure_, inspire_pressure_, FlowDirection::EXPIRATORY};
   }
-  return {setpoint_, FlowDirection::INSPIRATORY};
+  return {setpoint_, inspire_pressure_, FlowDirection::INSPIRATORY};
 }
 
 PressureAssistFsm::PressureAssistFsm(Time now, const VentParams &params)
@@ -135,9 +135,9 @@ void PressureAssistFsm::Update(Time now, const BlowerFsmInputs &inputs) {
 
 BlowerSystemState PressureAssistFsm::DesiredState() const {
   if (inspire_finished_) {
-    return {expire_pressure_, FlowDirection::EXPIRATORY};
+    return {expire_pressure_, inspire_pressure_, FlowDirection::EXPIRATORY};
   }
-  return {setpoint_, FlowDirection::INSPIRATORY};
+  return {setpoint_, inspire_pressure_, FlowDirection::INSPIRATORY};
 }
 
 // TODO don't rely on fsm inner states to make this usable in any fsm

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -74,6 +74,10 @@ struct BlowerSystemState {
   // to achieve 0 pressure by e.g. closing valves.
   std::optional<Pressure> pressure_setpoint;
 
+  // Maximum pressure we'll want to achieve during this breath, i.e. PIP.
+  // TODO: Test me!
+  Pressure max_pressure;
+
   // Should air be primarily flowing into the patient, or out of the patient?
   FlowDirection flow_direction;
 
@@ -116,6 +120,7 @@ public:
   BlowerSystemState DesiredState() {
     return {
         .pressure_setpoint = std::nullopt,
+        .max_pressure = kPa(0),
         // TODO: It doesn't make much sense to specify a flow direction when the
         // device is off and therefore there's no flow!  It might be better to
         // have a different BlowerSystemState struct for different categories of

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "controller.h"
 
+#include "fan_pressures.h"
 #include "pid.h"
 #include "vars.h"
 #include <math.h>
@@ -128,9 +129,9 @@ Controller::Run(Time now, const VentParams &params,
     // Start controlling pressure.
     actuators_state = {
         .fio2_valve = 0, // not used yet
-        // In normal mode, blower is always full power; pid controls pressure by
-        // actuating the blower pinch valve.
-        .blower_power = 1,
+        // TODO: Add a comment.
+        // TODO: Make 10 cmH2O a DebugVar.
+        .blower_power = FanPowerFor(desired_state.max_pressure + cmH2O(10)),
         .blower_valve = blower_valve_pid_.Compute(
             now, sensor_readings.patient_pressure.kPa(),
             desired_state.pressure_setpoint->kPa()),

--- a/controller/lib/core/fan_pressures.h
+++ b/controller/lib/core/fan_pressures.h
@@ -1,0 +1,83 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef FAN_PRESSURES_H
+#define FAN_PRESSURES_H
+
+#include "units.h"
+#include <algorithm>
+#include <array>
+#include <utility>
+
+// Steady-state fan pressure recorded at various fan power levels.
+//
+// This data comes from sample-data/2020-06-15-fan-pressure/make_cpp_table.py,
+// but with some cleanups.
+//
+//  - Power levels below 35% are removed.  The fan is barely spinning at those
+//    power levels; it doesn't generate a meaningful amount of pressure.
+//
+//  - Power levels in range [86%, 100%) are removed.
+//
+//    Above 85% our measured pressure stops increasing, because we max out our
+//    pressure sensor.  So if you want more pressure than you can get at 85%,
+//    this table directs you to use 100% power.  (In theory we could try
+//    interpolating or something, but it's not clear that's worthwhile.)
+//
+inline constexpr std::array<std::pair<float, Pressure>, 40> FAN_PRESSURES{{
+    {0.35f, cmH2O(1.92f)},  {0.40f, cmH2O(3.89f)},  {0.45f, cmH2O(6.13f)},
+    {0.50f, cmH2O(8.68f)},  {0.51f, cmH2O(9.19f)},  {0.52f, cmH2O(9.72f)},
+    {0.53f, cmH2O(10.46f)}, {0.54f, cmH2O(11.03f)}, {0.55f, cmH2O(11.57f)},
+    {0.56f, cmH2O(12.07f)}, {0.57f, cmH2O(12.77f)}, {0.58f, cmH2O(13.54f)},
+    {0.59f, cmH2O(14.05f)}, {0.60f, cmH2O(14.62f)}, {0.61f, cmH2O(15.16f)},
+    {0.62f, cmH2O(15.88f)}, {0.63f, cmH2O(16.53f)}, {0.64f, cmH2O(17.07f)},
+    {0.65f, cmH2O(17.76f)}, {0.66f, cmH2O(18.43f)}, {0.67f, cmH2O(18.88f)},
+    {0.68f, cmH2O(19.56f)}, {0.69f, cmH2O(20.38f)}, {0.70f, cmH2O(21.03f)},
+    {0.71f, cmH2O(21.69f)}, {0.72f, cmH2O(22.43f)}, {0.73f, cmH2O(23.24f)},
+    {0.74f, cmH2O(24.05f)}, {0.75f, cmH2O(24.96f)}, {0.76f, cmH2O(26.05f)},
+    {0.77f, cmH2O(26.96f)}, {0.78f, cmH2O(27.84f)}, {0.79f, cmH2O(29.15f)},
+    {0.80f, cmH2O(30.37f)}, {0.81f, cmH2O(32.05f)}, {0.82f, cmH2O(33.33f)},
+    {0.83f, cmH2O(35.22f)}, {0.84f, cmH2O(36.71f)}, {0.85f, cmH2O(38.42f)},
+    {1.00f, cmH2O(38.75f)},
+}};
+
+// Check at compile time that the FAN_PRESSURES array is monotonic in both the
+// fan speed (first element of the pair) and fan pressure (second element).
+//
+// This lets us binary search with confidence!
+static_assert([] {
+  for (int i = 1; i < FAN_PRESSURES.size(); i++) {
+    auto p0 = FAN_PRESSURES[i - 1];
+    auto p1 = FAN_PRESSURES[i];
+    if (p0.first > p1.first || p0.second > p1.second) {
+      return false;
+    }
+  }
+  return true;
+}());
+
+// Finds the lowest fan power which achieves at least this pressure.
+inline float FanPowerFor(Pressure p) {
+  auto it = std::lower_bound(
+      FAN_PRESSURES.begin(), FAN_PRESSURES.end(), p,
+      [&](const auto &elem, const Pressure &p) { return elem.second < p; });
+
+  if (it == FAN_PRESSURES.end()) {
+    it = FAN_PRESSURES.end() - 1;
+  }
+  return it->first;
+}
+
+#endif // FAN_PRESSURES_H


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. DRAFT - Use different fan speed depending on PIP.
    
    Instead of always running the blower at full speed, choose a fan speed
    that's sufficient to achieve PIP + 10 cmH2O.
    
    TODO: This seems to reduce overshoot and undershoot, but a more
    comprehensive test of all the covent testcases is needed.
    
    TODO: Unit tests.
    
    TODO: Resolve TODOs in code :)

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #548 Update breath detection algorithm.
1. #527 Open exhale pinch valve to 0.3 during PIP.
1. #528 Add fan pressure readings at various power levels.
1. 👉 #531 DRAFT - Use different fan speed depending on PIP. 👈 **YOU ARE HERE**

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>






























