### PR TITLE
Set gui_mode last when applying a preset.

### DIFF
--- a/utils/controller_debug.py
+++ b/utils/controller_debug.py
@@ -124,12 +124,15 @@ Intended TV: {intended_tv} ml
     sec_per_breath = 60 / rr
     ie_ratio = inspiratory_time / sec_per_breath
     vars = {
-        "gui_mode": VentMode_PRESSURE_CONTROL,
         "gui_bpm": rr,
         "gui_ie_ratio": round(ie_ratio, 2),
         "gui_pip": bap + delta_inspiratory_pressure,
         "gui_peep": bap,
         # TODO: FiO2 not currently supported.
+        # It's important to set gui_mode last.  Otherwise we'll start breathing
+        # immediately, with whatever the old parameters happen to be.  (Python3
+        # dicts have consistent ordering.)
+        "gui_mode": VentMode_PRESSURE_CONTROL,
     }
     return Preset(f"covent_pc_{test_num}", desc, vars)
 


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Set gui_mode last when applying a preset.
    
    Otherwise we will do a breath with the old configuration!

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #535 Set gui_mode last when applying a preset. 👈 **YOU ARE HERE**
1. #536 Add script to run all covent tests in a row.
1. #527 Open exhale pinch valve to 0.3 during PIP.
1. #528 Add fan pressure readings at various power levels.
1. #531 DRAFT - Use different fan speed depending on PIP.


</git-pr-chain>





