### PR TITLE
Fix calculation of IE ratio for covent tests.

### DIFF
--- a/utils/controller_debug.py
+++ b/utils/controller_debug.py
@@ -122,7 +122,7 @@ Intended TV: {intended_tv} ml
 """
 
     sec_per_breath = 60 / rr
-    ie_ratio = inspiratory_time / sec_per_breath
+    ie_ratio = inspiratory_time / (sec_per_breath - inspiratory_time)
     vars = {
         "gui_bpm": rr,
         "gui_ie_ratio": round(ie_ratio, 2),


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Fix calculation of IE ratio for covent tests.
    
    Oops.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #544 Fix calculation of IE ratio for covent tests. 👈 **YOU ARE HERE**
1. #548 Update breath detection algorithm.
1. #527 Open exhale pinch valve to 0.3 during PIP.
1. #528 Add fan pressure readings at various power levels.
1. #531 DRAFT - Use different fan speed depending on PIP.


</git-pr-chain>








