### PR TITLE
Disable boot wizard & enable serial port for data

### DIFF
--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -50,8 +50,11 @@
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/
+    
+  - name: Disable first-time boot setup wizard
+    shell: rm -f /etc/xdg/autostart/piwiz.desktop
 
   - name: Add script to spin up gui docker instance on boot
     lineinfile:
       dest: /home/pi/.config/openbox/autostart
-      line: 'docker run --name=gui --privileged -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui /gui/build/app/ProjectVentilatorGUI &'
+      line: 'docker run --name=gui --privileged -d --restart unless-stopped --volume="$HOME/.Xauthority:/root/.Xauthority:rw" --env="DISPLAY" --net=host -i -t respiraworks/gui /gui/build/app/ProjectVentilatorGUI --serial-port /dev/ttyS0 &'

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -50,7 +50,7 @@
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/
-    
+
   - name: Disable first-time boot setup wizard
     shell: rm -f /etc/xdg/autostart/piwiz.desktop
 


### PR DESCRIPTION
The piwiz.desktop file is responsible for the first-time boot setup wizard. Since we configure the pi with this script, it's not a very useful popup and gets in the way. If deleting the file is too extreme, I think we can just move it elsewhere like the Downloads folder. 

The --serial-port flag disables the fake data being fed to the GUI and instead connects it to the rPi's UART pins. Now, the GUI and controller actually can communicate.