### PR TITLE
Subsamples graph data, further improving graph performance

### DIFF
--- a/gui/app/main.cpp
+++ b/gui/app/main.cpp
@@ -23,7 +23,9 @@
 
 QObject *gui_state_instance(QQmlEngine *engine, QJSEngine *scriptEngine) {
   static GuiStateContainer state_container(
-      /*history_window=*/DurationMs(30000));
+      /*history_window=*/DurationMs(30000),
+      // 100ms looks a little janky, 50ms is fine.
+      /*granularity=*/DurationMs(50));
   Q_UNUSED(engine);
   Q_UNUSED(scriptEngine);
   // Since we are returning just a pointer, QQmlEngine does not know the object

--- a/gui/app/main.qml
+++ b/gui/app/main.qml
@@ -37,17 +37,6 @@ ApplicationWindow {
         z: 10
     }
 
-    Timer
-    {
-        id: refreshTimer
-        interval: 1 / 60 * 1000 // 60 Hz
-        running: true
-        repeat: true
-        onTriggered: {
-            GuiStateContainer.update();
-        }
-    }
-
     header: ToolBar {
         contentHeight: 60
         background:  Item {  }

--- a/gui/src/gui_state_container.cpp
+++ b/gui/src/gui_state_container.cpp
@@ -1,6 +1,6 @@
 #include "gui_state_container.h"
 
-void GuiStateContainer::update() {
+void GuiStateContainer::UpdateGraphs() {
   auto now = SteadyClock::now();
   QVector<QPointF> pressure_points, flow_points, tv_points;
 


### PR DESCRIPTION
With this change, on my machine it only takes about 6% CPU.

* We don't need the timer in QML, we can update the graphs from the controller status update signal.
* We only include points that are more than 50ms apart.