### PR TITLE
Initial psol control.

### DIFF
--- a/controller/lib/core/actuators.cpp
+++ b/controller/lib/core/actuators.cpp
@@ -24,7 +24,6 @@ static PinchValve exhale_pinch(1);
 // actuators that need it
 
 void actuators_execute(const ActuatorsState &desired_state) {
-
   // set blower PWM
   Hal.analogWrite(PwmPin::BLOWER, desired_state.blower_power);
 
@@ -39,6 +38,8 @@ void actuators_execute(const ActuatorsState &desired_state) {
     exhale_pinch.SetOutput(*desired_state.exhale_valve);
   else
     exhale_pinch.Disable();
+
+  Hal.PSOL_Value(desired_state.fio2_valve);
 }
 
 // Return true if all actuators are enabled and ready for action

--- a/controller/lib/core/controller.h
+++ b/controller/lib/core/controller.h
@@ -47,6 +47,7 @@ private:
   uint64_t breath_id_ = 0;
   BlowerFsm fsm_;
   PID blower_valve_pid_;
+  PID psol_pid_;
 
   // These objects accumulate flow to calculate volume.
   //

--- a/controller/src/main.cpp
+++ b/controller/src/main.cpp
@@ -81,6 +81,9 @@ static DebugUInt32 gui_peep("gui_peep", "PEEP (cm/h2O) for GUI free testing",
 static DebugUInt32 gui_pip("gui_pip", "PIP (cm/h2O) for GUI free testing", 15);
 static DebugFloat gui_ie_ratio("gui_ie_ratio", "I/E ratio for GUI free testing",
                                0.66f);
+static DebugFloat
+    gui_fio2("gui_fio2", "Percent oxygen (range [21,100]) for GUI-free testing",
+             21);
 static void DEV_MODE_comms_handler(const ControllerStatus &controller_status,
                                    GuiStatus *gui_status) {
   gui_status->desired_params.mode = static_cast<VentMode>(gui_mode.Get());
@@ -88,6 +91,7 @@ static void DEV_MODE_comms_handler(const ControllerStatus &controller_status,
   gui_status->desired_params.peep_cm_h2o = gui_peep.Get();
   gui_status->desired_params.pip_cm_h2o = gui_pip.Get();
   gui_status->desired_params.inspiratory_expiratory_ratio = gui_ie_ratio.Get();
+  gui_status->desired_params.fio2 = gui_fio2.Get() / 100.f;
 
   static std::optional<Time> last_sent;
   Time now = Hal.now();


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Initial psol control.
    
    Not hooked up to closed-loop control yet.  What's done here is:
    
     - We found the "active range" of the psol and encoded that.  (Below
       about 80% power, the psol is fully closed, and above about 90% power,
       it's completely open.)
     - Added a DebugVar to control "gui_fio2"
     - Added a PID controller for the psol (but not using it yet).
     - Added DebugVars to force the actuators into specific positions.
       Super useful for e.g. figuring out the active range of the psol.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #558 Initial psol control. 👈 **YOU ARE HERE**


</git-pr-chain>

