### PR TITLE
Adds a "PIP not reached" alarm + some logic to combine it with "PIP exceeded"

### DIFF
--- a/gui/app/controls/graphs/PressureGraph.qml
+++ b/gui/app/controls/graphs/PressureGraph.qml
@@ -14,4 +14,8 @@ ScopeView {
     dataset: GuiStateContainer.pressureSeries
     yMin: -3
     yMax: 30
+
+    alarmPriority: Math.max(
+      GuiStateContainer.alarmManager.pipExceededAlarm.effectiveVisualPriority,
+      GuiStateContainer.alarmManager.pipNotReachedAlarm.effectiveVisualPriority)
 }

--- a/gui/app/controls/readings/PipDisplay.qml
+++ b/gui/app/controls/readings/PipDisplay.qml
@@ -7,5 +7,7 @@ ParameterDisplay {
     parameterName: qsTr("PIP")
     parameterUnit: qsTr("cmH<sub>2</sub>O")
     parameterValue: GuiStateContainer.measured_pip.toString()
-    alarmPriority: GuiStateContainer.alarmManager.pipExceededAlarm.effectiveVisualPriority
+    alarmPriority: Math.max(
+      GuiStateContainer.alarmManager.pipExceededAlarm.effectiveVisualPriority,
+      GuiStateContainer.alarmManager.pipNotReachedAlarm.effectiveVisualPriority)
 }

--- a/gui/app/modes/CommandPressureMode.qml
+++ b/gui/app/modes/CommandPressureMode.qml
@@ -58,11 +58,7 @@ Mode {
             id: scopeGridLayout
             anchors.fill: parent
             spacing: 0
-
-            PressureGraph {
-              Layout.fillHeight: true; Layout.fillWidth: true
-              alarmPriority: GuiStateContainer.alarmManager.pipExceededAlarm.effectiveVisualPriority
-            }
+            PressureGraph { Layout.fillHeight: true; Layout.fillWidth: true }
             FlowGraph { Layout.fillHeight: true; Layout.fillWidth: true }
             TvGraph { Layout.fillHeight: true; Layout.fillWidth: true }
         }

--- a/gui/src/gui_state_container.h
+++ b/gui/src/gui_state_container.h
@@ -50,6 +50,8 @@ public:
       // TODO: This should come from GUI alarm settings instead.
       alarm_manager_.get_pip_exceeded_alarm()->SetThresholdCmH2O(
           commanded_pip_ + 2);
+      alarm_manager_.get_pip_not_reached_alarm()->SetThresholdCmH2O(
+          commanded_pip_ - 2);
     });
   }
 

--- a/gui/src/pip_not_reached_alarm.h
+++ b/gui/src/pip_not_reached_alarm.h
@@ -1,0 +1,45 @@
+#ifndef PIP_NOT_REACHED_ALARM_H_
+#define PIP_NOT_REACHED_ALARM_H_
+
+#include "breath_signals.h"
+#include "chrono.h"
+#include "latching_alarm.h"
+#include "network_protocol.pb.h"
+
+#include <QObject>
+#include <QString>
+
+// An alarm for the condition "PIP < threshold".
+class PipNotReachedAlarm : public LatchingAlarm {
+  Q_OBJECT
+
+public:
+  PipNotReachedAlarm() : LatchingAlarm(AlarmPriority::MEDIUM) {}
+
+private:
+  std::optional<QString>
+  IsActive(SteadyInstant now, const ControllerStatus &status,
+           const BreathSignals &breath_signals) override {
+    (void)now;
+    (void)status;
+    auto pip = breath_signals.pip();
+    if (pip.has_value() && *pip < threshold_cmh2o_) {
+      return {QString("PIP not reached: measured %1, threshold %2")
+                  .arg(QString::number(*pip, 'f', 1),
+                       QString::number(threshold_cmh2o_, 'f', 1))};
+    }
+    return std::nullopt;
+  }
+
+public:
+  float GetThresholdCmH2O() const { return threshold_cmh2o_; }
+  void SetThresholdCmH2O(float threshold_cmh2o) {
+    threshold_cmh2o_ = threshold_cmh2o;
+    updated();
+  }
+
+private:
+  float threshold_cmh2o_ = 10;
+};
+
+#endif // PIP_NOT_REACHED_ALARM_H_

--- a/gui/src/src.pro
+++ b/gui/src/src.pro
@@ -24,6 +24,7 @@ HEADERS += \
   latching_alarm.h \
   periodic_closure.h \
   pip_exceeded_alarm.h \
+  pip_not_reached_alarm.h \
   respira_connected_device.h \
   simple_clock.h \
   time_series_graph.h \


### PR DESCRIPTION
Fixes #368 . 

Also fixes a bug that the Pressure Assist graph wasn't using the alarm.

Verified e.g. that if I tweak the commanded PIP here and there so that both alarms are active, then the alarm banner displays in red, and if I dismiss it then it's in yellow, if I dismiss that too then it disappears.