### PR TITLE
Refactor breath detection

### DIFF
--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -101,8 +101,7 @@ PressureAssistFsm::PressureAssistFsm(Time now, const VentParams &params)
       expire_pressure_(cmH2O(static_cast<float>(params.peep_cm_h2o))),
       setpoint_(expire_pressure_), start_time_(now),
       inspire_end_(start_time_ + InspireDuration(params)),
-      expire_deadline_(inspire_end_ + ExpireDuration(params)) {
-}
+      expire_deadline_(inspire_end_ + ExpireDuration(params)) {}
 
 void PressureAssistFsm::Update(Time now, const BreathDetectionInputs &inputs) {
   if (now >= inspire_end_) {

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -173,22 +173,7 @@ private:
 
   bool inspire_finished_ = false;
   bool finished_ = false;
-<<<<<<< HEAD
-
-  // During exhale we maintain two exponentially-weighted averages of flow, one
-  // which updates quickly (fast_flow_avg_), and one which updates slowly
-  // (slow_flow_avg_).
-  //
-  // When fast_flow_avg_ exceeds slow_flow_avg_ by a threshold, we trigger a
-  // breath.
-  //
-  // More discussion of this algorithm:
-  // https://respiraworks.slack.com/archives/C011CJQV4Q7/p1592417313120400
-  std::optional<VolumetricFlow> fast_flow_avg_;
-  std::optional<VolumetricFlow> slow_flow_avg_;
-=======
   BreathDetection inspire_detection_;
->>>>>>> Refactor pressure assist mode so breath detection can be used in other breath FSM in the future
 };
 
 class BlowerFsm {

--- a/controller/lib/core/breath_detection.cpp
+++ b/controller/lib/core/breath_detection.cpp
@@ -1,0 +1,78 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include "breath_detection.h"
+#include "controller.h"
+#include "vars.h"
+#include <algorithm>
+
+// dbg_bd_* are breath detector configuration vars.
+//
+// These are read but never modified here.
+
+// TODO: This should be configurable from the GUI.
+static DebugFloat dbg_bd_flow_trigger("pa_flow_trigger",
+                                      "pressure assist flow trigger (ml/s)",
+                                      200);
+
+// pa_fast_avg_alpha and pa_slow_avg_alpha were tuned for a control loop that
+// runs at a particular frequency.
+//
+// In theory if the control loop gets slower, the alpha terms should get
+// bigger, placing more weight on newer readings, and similarly if the control
+// loop gets faster, the alpha terms should get smaller.  We've tried to encode
+// this here, although it remains to be seen if it actually works.
+static DebugFloat dbg_bd_fast_avg_alpha(
+    "pa_fast_avg_alpha",
+    "alpha term in pressure assist mode's fast-updating "
+    "exponentially-weighted average of flow",
+    0.2f * (Controller::GetLoopPeriod() / milliseconds(10)));
+static DebugFloat dbg_bd_slow_avg_alpha(
+    "pa_slow_avg_alpha",
+    "alpha term in pressure assist mode's slow-updating "
+    "exponentially-weighted average of flow",
+    0.01f * (Controller::GetLoopPeriod() / milliseconds(10)));
+
+BreathDetection::BreathDetection() = default;
+
+bool BreathDetection::PatientInspiring(const BreathDetectionInputs &inputs,
+                                       bool at_dwell) {
+  if (inputs.net_flow < ml_per_sec(0)) {
+    return false;
+  }
+
+  // Once flow is non-negative, start calculating two
+  // exponentially-weighted averages of net flow: slow_avg_flow_ and
+  // fast_avg_flow_.
+  //
+  // The slow one has a smaller alpha term, so updates slower than the fast
+  // one.  You can think of the slow average as estimating "flow at dwell" and
+  // the fast average as estimating "current flow".
+  //
+  // If the fast average exceeds the slow average by a threshold, we trigger a
+  // breath.
+  float slow_alpha = dbg_bd_slow_avg_alpha.Get();
+  float fast_alpha = dbg_bd_fast_avg_alpha.Get();
+  // TODO: This could be encapsulated in an exponentially-weighted-average
+  // class.
+  slow_avg_flow_ = slow_alpha * inputs.net_flow +
+                   (1 - slow_alpha) * slow_avg_flow_.value_or(inputs.net_flow);
+  fast_avg_flow_ = fast_alpha * inputs.net_flow +
+                   (1 - fast_alpha) * fast_avg_flow_.value_or(inputs.net_flow);
+
+  return at_dwell &&
+         *fast_avg_flow_ >
+             *slow_avg_flow_ + ml_per_sec(dbg_bd_flow_trigger.Get());
+}

--- a/controller/lib/core/breath_detection.h
+++ b/controller/lib/core/breath_detection.h
@@ -1,0 +1,54 @@
+/* Copyright 2020, RespiraWorks
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#ifndef BREATH_DETECTION_H
+#define BREATH_DETECTION_H
+
+#include "units.h"
+#include <optional>
+
+// Sensor readings etc that are used by breath detection.
+struct BreathDetectionInputs {
+  // Current patient volume, corrected for sensor zero-point drift.
+  Volume patient_volume;
+  // inflow - outflow, corrected for sensor zero-point drift.
+  VolumetricFlow net_flow;
+};
+
+// Provides a class that is used to detecting inspiratory effort.
+class BreathDetection {
+public:
+  BreathDetection();
+  // This method tells the system if a patient is inspiring and must be called
+  // only during exhale phase. Parameters:
+  // - net_flow, to allow inspire detection
+  // - at_dwell, telling BreathDetection that the dwell plateau has been reached
+  // TODO: automatically detect dwell plateau from flow
+  bool PatientInspiring(const BreathDetectionInputs &inputs, bool at_dwell);
+
+private:
+  // During exhale we maintain two exponentially-weighted averages of flow, one
+  // which updates quickly (fast_avg_flow_), and one which updates slowly
+  // (slow_avg_flow_).
+  //
+  // When fast_avg_flow_ exceeds slow_avg_flow_ by a threshold, we trigger a
+  // breath.
+  //
+  // More discussion of this algorithm:
+  // https://respiraworks.slack.com/archives/C011CJQV4Q7/p1592417313120400
+  std::optional<VolumetricFlow> fast_avg_flow_;
+  std::optional<VolumetricFlow> slow_avg_flow_;
+};
+
+#endif // BREATH_DETECTION_H

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -25,7 +25,7 @@ limitations under the License.
 
 namespace {
 
-constexpr BlowerFsmInputs inputs_zero = {
+constexpr BreathDetectionInputs inputs_zero = {
     .patient_volume = ml(0),
     .net_flow = ml_per_sec(0),
 };
@@ -106,7 +106,7 @@ TEST(BlowerFsmTest, DesiredPipPeep) {
 void testSequence(
     const std::vector<
         std::tuple<VentParams,
-                   /*inputs*/ BlowerFsmInputs,
+                   /*inputs*/ BreathDetectionInputs,
                    /*time_millis*/ uint64_t,
                    /*expected_pressure_setpoint*/ std::optional<Pressure>,
                    /*expected_flow_direction*/ FlowDirection>> &seq) {
@@ -121,7 +121,7 @@ void testSequence(
   Hal.delay(milliseconds(std::get<uint64_t>(seq.front())));
 
   VentParams last_params;
-  BlowerFsmInputs last_inputs;
+  BreathDetectionInputs last_inputs;
   for (const auto &[params, inputs, time_millis, expected_pressure,
                     expected_flow_direction] : seq) {
     SCOPED_TRACE("time = " + std::to_string(time_millis));


### PR DESCRIPTION
So it can be used in the future in other modes (pressure support?) and unit tested separately from breath_fsm.

For now it offers no functional change to the controller, only make the code a little more modular.