### PR TITLE
Adjusted the buzzer duty cycle to increase volume

### DIFF
--- a/controller/lib/hal/buzzer.cpp
+++ b/controller/lib/hal/buzzer.cpp
@@ -81,8 +81,8 @@ void HalApi::BuzzerOn(float volume) {
 
   volume = std::clamp(volume, 0.0f, 1.0f);
 
-  // We get maximum volume at about 50% duty cycle
-  float duty = volume * 0.5f * static_cast<float>(tmr->reload);
+  // We get maximum volume at about 80% duty cycle
+  float duty = volume * 0.8f * static_cast<float>(tmr->reload);
   tmr->compare[0] = static_cast<int>(duty);
 }
 


### PR DESCRIPTION
I was doing some tests with a dB meter on my phone and found that I could get more volume from the buzzer on the controller by slightly increasing the duty cycle.  