### PR TITLE
[GUI] Silenced alarms widget

### DIFF
--- a/gui/app/app.pro
+++ b/gui/app/app.pro
@@ -19,7 +19,8 @@ LIBS += -L../src -leverything
 
 RESOURCES += qml.qrc images/ controls/ fonts/ modes/ sample-data/
 
-DISTFILES += images/Logo.png
+DISTFILES += images/Logo.png \
+    controls/AlarmButton.qml
 
 TRANSLATIONS += ProjectVentilatorGUI_es_GT.ts
 

--- a/gui/app/controls/AlarmButton.qml
+++ b/gui/app/controls/AlarmButton.qml
@@ -1,0 +1,111 @@
+import QtQuick 2.11
+import QtQuick.Layouts 1.3
+import QtQuick.Controls 2.4
+import QtGraphicalEffects 1.0
+import Respira 1.0
+import ".."
+
+HeaderButton {
+    id: root
+
+    property int numAlarms: 0
+    property int remainingSilenceMs: 0
+    property int priority: AlarmPriority.NONE
+
+    property color alarm_button_fg: "white"
+
+    width: remainingSilenceText.visible ? 168 : 104;
+    height: 40
+
+    state: switch(priority) {
+        case AlarmPriority.NONE: "";   break;
+        case AlarmPriority.LOW: "low"; break;
+        case AlarmPriority.MEDIUM: "medium"; break;
+        case AlarmPriority.HIGH: "high"; break;
+    }
+
+
+    states: [
+        State {
+            name: "high"
+            PropertyChanges {
+                target: root;
+                color: root.checked || root.down ? "black" : Style.theme.color.alarmHighBright
+                alarm_button_fg: "white"
+                restoreEntryValues: false
+            }
+        },
+        State {
+            name: "medium"
+            PropertyChanges {
+                target: root;
+                color: root.checked || root.down ? "white" : Style.theme.color.alarmMediumBright
+                alarm_button_fg: "black"
+                restoreEntryValues: false
+            }
+        },
+        State {
+            name: "low"
+            PropertyChanges {
+                target: root;
+                color: root.checked || root.down ? "black" : Style.theme.color.alarmLowBright
+                alarm_button_fg: "white"
+                restoreEntryValues: false
+            }
+        }
+    ]
+
+    contentItem: Item {
+
+        Row {
+            id: rect
+            anchors.centerIn: parent
+            spacing: 8
+            Text {
+                id: numSilencedAlarmsText
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.numAlarms.toString()
+                font: Style.theme.font.headerButton
+                color: alarm_button_fg
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+            }
+
+            Image {
+                id: icon
+                anchors.verticalCenter: parent.verticalCenter
+                width: 20; height: 20
+                sourceSize: Qt.size(width, height)
+                fillMode: Image.PreserveAspectFit
+                source: root.priority != AlarmPriority.NONE ?
+                            'qrc:/images/RW_alarm-off_24.svg' :
+                            'qrc:/images/RW_alarm_24.svg'
+                layer.enabled: true
+                layer.effect: ColorOverlay {
+                    anchors.fill: icon
+                    source: icon
+                    color: root.alarm_button_fg
+                }
+            }
+
+            Text {
+                id: remainingSilenceText
+                anchors.verticalCenter: parent.verticalCenter
+                text: {
+                    var totalSec = Math.floor(root.remainingSilenceMs / 1000)
+                    var minutes = Math.floor(totalSec / 60)
+                    var seconds = totalSec - 60 * minutes
+                    return (Number(minutes).toString() + ":" +
+                            (seconds < 10 ? "0" : "") + Number(seconds).toString())
+                }
+                width: visible ? implicitWidth : 0
+                visible: root.remainingSilenceMs > 0
+                font: Style.theme.font.headerButton
+                color: alarm_button_fg
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+    }
+}

--- a/gui/app/controls/AlarmNotificationBanner.qml
+++ b/gui/app/controls/AlarmNotificationBanner.qml
@@ -15,7 +15,7 @@ Item {
     width: parent.width; height: 72
 
     property alias title: titleText.text
-    property int alarmsCount: 0
+    property int numActiveAlarms: 0
     property int priority: AlarmPriority.NONE
 
     enabled: priority != AlarmPriority.NONE
@@ -125,7 +125,7 @@ Item {
             left: titleText.right; leftMargin: 8
             verticalCenter: parent.verticalCenter
         }
-        text: root.alarmsCount > 0 ? "+" + root.alarmsCount : ""
+        text: root.numActiveAlarms > 1 ? "+" + (root.numActiveAlarms - 1) : ""
         color: root.alarm_button_fg
         font: Style.theme.font.modalTitle
     }

--- a/gui/app/controls/HeaderButton.qml
+++ b/gui/app/controls/HeaderButton.qml
@@ -9,9 +9,11 @@ import ".."
 Button {
     id: control
 
-    implicitWidth:40; implicitHeight: 40
+    property alias color: bg.color
+    //implicitWidth:40; implicitHeight: 40
 
     background: Rectangle {
+        id: bg
         antialiasing: true
         color: control.down ? Style.theme.color.headerButtonHighlighted :
                               Style.theme.color.headerButton

--- a/gui/app/controls/MainHeader.qml
+++ b/gui/app/controls/MainHeader.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.11
 import QtQuick.Layouts 1.3
 import QtQuick.Controls 2.4
-
+import Respira 1.0
 import ".."
 
 /*!
@@ -72,45 +72,20 @@ Control {
         }
     }
 
-    HeaderButton {
-        id: alarmSettingsButton
-
-        width: 104; height: 40
-
+    AlarmButton {
         anchors {
             verticalCenter: parent.verticalCenter
             right: parent.right
         }
-        text: pageStack.currentMode.acronym
-
-        onClicked: alarmSettingsClicked()
-
-        contentItem: Item {
-            anchors.centerIn: parent
-
-            Row {
-                spacing: 10
-                anchors.centerIn: parent
-
-                Text {
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: 16; height: 27
-                    text: "0"
-                    font: Style.theme.font.headerButton
-                    color: Style.theme.color.textPrimary
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
-                }
-
-                Image {
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: 20; height: 20
-                    sourceSize: Qt.size(width, height)
-                    fillMode: Image.PreserveAspectFit
-                    source: 'qrc:/images/RW_alarm_24.svg'
-                }
-            }
+        priority: {
+          var alarm = GuiStateContainer.alarmManager.highestPrioritySilencedAlarm
+          return (alarm == null) ? AlarmPriority.NONE : alarm.nominalPriority
         }
+        numAlarms: GuiStateContainer.alarmManager.numSilencedAlarms
+        remainingSilenceMs: {
+          var alarm = GuiStateContainer.alarmManager.highestPrioritySilencedAlarm
+          return (alarm == null) ? 0 : alarm.remainingSilenceMs
+        }
+        onClicked: console.log("Alarm Button clicked")
     }
 }

--- a/gui/app/main.qml
+++ b/gui/app/main.qml
@@ -62,11 +62,11 @@ ApplicationWindow {
 
         AlarmNotificationBanner {
             id: alarmNotificationBanner
-            priority: GuiStateContainer.alarmManager.highestPriorityAlarm.effectiveAudioPriority
-            title: GuiStateContainer.alarmManager.highestPriorityAlarm.bannerText
-            alarmsCount: GuiStateContainer.alarmManager.numActiveAlarms
+            priority: GuiStateContainer.alarmManager.highestPriorityActiveAlarm.effectiveAudioPriority
+            title: GuiStateContainer.alarmManager.highestPriorityActiveAlarm.bannerText
+            numActiveAlarms: GuiStateContainer.alarmManager.numActiveAlarms
             onPauseAlarmClicked: {
-              GuiStateContainer.alarmManager.acknowledgeHighestPriorityAlarm()
+              GuiStateContainer.alarmManager.acknowledgeHighestPriorityActiveAlarm()
             }
             z: 999 // just to make sure its always on top
         }


### PR DESCRIPTION
This PR is Paulo's https://github.com/RespiraWorks/VentilatorSoftware/pull/560 but with some bugfixes.

Silenced alarms widget is now bound by color and the displayed remaining silence time to the _highest-priority silenced alarm_, unlike the alarm banner, which is bound to the _highest-priority active alarm_.

Clicking the widget still does nothing.