### PR TITLE
Update gain scheduling only at breath boundaries.

### DIFF
--- a/controller/lib/core/blower_fsm.cpp
+++ b/controller/lib/core/blower_fsm.cpp
@@ -18,6 +18,10 @@ limitations under the License.
 #include "vars.h"
 #include <algorithm>
 
+// TODO(jlebar): Refactor this so that instead of is_new_breath, we have
+// is_end_of_breath.  Then we can merge Update and DesiredState(), getting rid
+// of a lot of mutable state in the FSMs.
+
 // dbg_pa_* are pressure assist configuration vars.
 //
 // These are read but never modified here.
@@ -104,9 +108,19 @@ void PressureControlFsm::Update(Time now, const BlowerFsmInputs &inputs) {
 
 BlowerSystemState PressureControlFsm::DesiredState() const {
   if (inspire_finished_) {
-    return {expire_pressure_, FlowDirection::EXPIRATORY};
+    return {
+        .pressure_setpoint = expire_pressure_,
+        .flow_direction = FlowDirection::EXPIRATORY,
+        .pip = inspire_pressure_,
+        .peep = expire_pressure_,
+    };
   }
-  return {setpoint_, FlowDirection::INSPIRATORY};
+  return {
+      .pressure_setpoint = setpoint_,
+      .flow_direction = FlowDirection::INSPIRATORY,
+      .pip = inspire_pressure_,
+      .peep = expire_pressure_,
+  };
 }
 
 PressureAssistFsm::PressureAssistFsm(Time now, const VentParams &params)
@@ -135,9 +149,19 @@ void PressureAssistFsm::Update(Time now, const BlowerFsmInputs &inputs) {
 
 BlowerSystemState PressureAssistFsm::DesiredState() const {
   if (inspire_finished_) {
-    return {expire_pressure_, FlowDirection::EXPIRATORY};
+    return {
+        .pressure_setpoint = expire_pressure_,
+        .flow_direction = FlowDirection::EXPIRATORY,
+        .pip = inspire_pressure_,
+        .peep = expire_pressure_,
+    };
   }
-  return {setpoint_, FlowDirection::INSPIRATORY};
+  return {
+      .pressure_setpoint = setpoint_,
+      .flow_direction = FlowDirection::INSPIRATORY,
+      .pip = inspire_pressure_,
+      .peep = expire_pressure_,
+  };
 }
 
 // TODO don't rely on fsm inner states to make this usable in any fsm

--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -77,6 +77,14 @@ struct BlowerSystemState {
   // Should air be primarily flowing into the patient, or out of the patient?
   FlowDirection flow_direction;
 
+  // Max/min pressure that the blower will try to achieve over this breath.
+  //
+  // These may not be equal to the VentParams.pip/peep that you pass in to
+  // BlowerFsm::DesiredState, because BlowerFsm's parameters change only at
+  // breath boundaries.
+  Pressure pip;
+  Pressure peep;
+
   // Is this the first BlowerSystemState returned for a brand-new breath cycle?
   //
   // This is defaulted to false here and is handled by BlowerFsm, rather than

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -119,13 +119,12 @@ Controller::Run(Time now, const VentParams &params,
   // Gain scheduling of blower Ki based on PIP and PEEP settings.  Artisanally
   // hand-tuned by Edwin.
   //
-  // TODO(jlebar): Using params.{pip,peep}_cm_h2o is not quite correct.  When
-  // the params change, Controller receives that change immediately, but
-  // BlowerFsm doesn't apply them until the next breath.  Add fields to
-  // BlowerSystemState for current pip/peep and use those instead.
+  // Note that we use desired_state.pip/peep and not params.pip/peep because
+  // desired_state updates at breath boundaries, whereas params updates
+  // whenever the user clicks the touchscreen.
   float blower_ki = std::clamp(
-      2.0f * static_cast<float>(params.pip_cm_h2o - params.peep_cm_h2o) - 10.0f,
-      10.0f, 20.0f);
+      2.0f * (desired_state.pip - desired_state.peep).cmH2O() - 10.0f, 10.0f,
+      20.0f);
   dbg_blower_valve_computed_ki.Set(blower_ki);
 
   blower_valve_pid_.SetKP(dbg_blower_valve_kp.Get());


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. Update gain scheduling only at breath boundaries.
    
    The previous Ki gain scheduling in Controller would update whenever the
    VentParams changed, but this is not quite right. In reality, we only
    want to update when the BlowerFsm updates, at breath boundaries.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #571 Update gain scheduling only at breath boundaries. 👈 **YOU ARE HERE**
1. #572 Keep fan blowing during covent tests.


</git-pr-chain>




