### PR TITLE
Install pulseaudio, lightdm, openbox, enable auto-login

### DIFF
--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -37,13 +37,40 @@
 
   - name: Install Debian menu for Openbox
     apt:
-      name: menu
+      pkg:
+        - pulseaudio
+        - lightdm
+        - openbox
+        - menu
+
+  - name: Creates /lib/systemd/user directory
+    file:
+      path: /lib/systemd/user
+      state: directory
+
+  - name: Add pulseaudio socket systemd config
+    copy:
+      src: pulseaudio.socket
+      dest: /lib/systemd/user/pulseaudio.socket
+      mode: '0644'
+
+  - name: Add pulseaudio service systemd config
+    copy:
+      src: pulseaudio.service
+      dest: /lib/systemd/user/pulseaudio.service
+      mode: '0644'
 
   - name: Set pi user's .xsession
     lineinfile:
       dest: /home/pi/.xsession
       line: 'exec openbox-session'
       create: yes
+
+  - name: Enable auto-login
+    lineinfile:
+      dest: /etc/lightdm/lightdm.conf
+      line: 'autologin-user=pi'
+      create: no
 
   - name: Cache most recent gui docker image from dockerhub
     shell: docker pull respiraworks/gui


### PR DESCRIPTION
This change adds some packages and configuration required to provision an RPi image from a basic Raspbian Buster image (instead of a desktop one.)

It also adds pulseaudio support for the login user. I haven't tested alarms yet so I'm not certain this is the correct approach here. However, this is what Ubuntu does for user audio support so I'm guessing it'll work here too.