### PR TITLE
Slankard/pulseaudio tweaks

### DIFF
--- a/gui/rpi-image/README.md
+++ b/gui/rpi-image/README.md
@@ -10,6 +10,8 @@ The terminal will ask for the SUDO password for Raspbian. By default, this is "r
 
 The `inventory` parameter specifies a file containing a list of hosts to provision. For the default `hosts` file, this will be a virtual machine. However, you can also use the `hosts.raspberrypi` file to deploy to a Raspberry Pi on your network (having the default hostname `raspberrypi.local`.) This will be useful for development testing.
 
+For more rapid testing of the configuration (without testing the GUI itself) you can add `--skip-tags docker` to the `ansible-playbook` arguments. This will skip installing Docker and pulling the GUI image.
+
 ### hosts
 This is Ansible's inventory file that keeps track of the targets of playbooks. Place this file at `/etc/ansible/` or replace the contents of the preexisting `hosts` file
 

--- a/gui/rpi-image/files/lightdm.conf
+++ b/gui/rpi-image/files/lightdm.conf
@@ -1,0 +1,170 @@
+#
+# General configuration
+#
+# start-default-seat = True to always start one seat if none are defined in the configuration
+# greeter-user = User to run greeter as
+# minimum-display-number = Minimum display number to use for X servers
+# minimum-vt = First VT to run displays on
+# lock-memory = True to prevent memory from being paged to disk
+# user-authority-in-system-dir = True if session authority should be in the system location
+# guest-account-script = Script to be run to setup guest account
+# logind-check-graphical = True to on start seats that are marked as graphical by logind
+# log-directory = Directory to log information to
+# run-directory = Directory to put running state in
+# cache-directory = Directory to cache to
+# sessions-directory = Directory to find sessions
+# remote-sessions-directory = Directory to find remote sessions
+# greeters-directory = Directory to find greeters
+# backup-logs = True to move add a .old suffix to old log files when opening new ones
+# dbus-service = True if LightDM provides a D-Bus service to control it
+#
+[LightDM]
+#start-default-seat=true
+#greeter-user=lightdm
+#minimum-display-number=0
+#minimum-vt=7
+#lock-memory=true
+#user-authority-in-system-dir=false
+#guest-account-script=guest-account
+#logind-check-graphical=false
+#log-directory=/var/log/lightdm
+#run-directory=/var/run/lightdm
+#cache-directory=/var/cache/lightdm
+#sessions-directory=/usr/share/lightdm/sessions:/usr/share/xsessions:/usr/share/wayland-sessions
+#remote-sessions-directory=/usr/share/lightdm/remote-sessions
+#greeters-directory=$XDG_DATA_DIRS/lightdm/greeters:$XDG_DATA_DIRS/xgreeters
+#backup-logs=true
+#dbus-service=true
+
+#
+# Seat configuration
+#
+# Seat configuration is matched against the seat name glob in the section, for example:
+# [Seat:*] matches all seats and is applied first.
+# [Seat:seat0] matches the seat named "seat0".
+# [Seat:seat-thin-client*] matches all seats that have names that start with "seat-thin-client".
+#
+# type = Seat type (local, xremote, unity)
+# pam-service = PAM service to use for login
+# pam-autologin-service = PAM service to use for autologin
+# pam-greeter-service = PAM service to use for greeters
+# xserver-backend = X backend to use (mir)
+# xserver-command = X server command to run (can also contain arguments e.g. X -special-option)
+# xmir-command = Xmir server command to run (can also contain arguments e.g. Xmir -special-option)
+# xserver-config = Config file to pass to X server
+# xserver-layout = Layout to pass to X server
+# xserver-allow-tcp = True if TCP/IP connections are allowed to this X server
+# xserver-share = True if the X server is shared for both greeter and session
+# xserver-hostname = Hostname of X server (only for type=xremote)
+# xserver-display-number = Display number of X server (only for type=xremote)
+# xdmcp-manager = XDMCP manager to connect to (implies xserver-allow-tcp=true)
+# xdmcp-port = XDMCP UDP/IP port to communicate on
+# xdmcp-key = Authentication key to use for XDM-AUTHENTICATION-1 (stored in keys.conf)
+# unity-compositor-command = Unity compositor command to run (can also contain arguments e.g. unity-system-compositor -special-option)
+# unity-compositor-timeout = Number of seconds to wait for compositor to start
+# greeter-session = Session to load for greeter
+# greeter-hide-users = True to hide the user list
+# greeter-allow-guest = True if the greeter should show a guest login option
+# greeter-show-manual-login = True if the greeter should offer a manual login option
+# greeter-show-remote-login = True if the greeter should offer a remote login option
+# user-session = Session to load for users
+# allow-user-switching = True if allowed to switch users
+# allow-guest = True if guest login is allowed
+# guest-session = Session to load for guests (overrides user-session)
+# session-wrapper = Wrapper script to run session with
+# greeter-wrapper = Wrapper script to run greeter with
+# guest-wrapper = Wrapper script to run guest sessions with
+# display-setup-script = Script to run when starting a greeter session (runs as root)
+# display-stopped-script = Script to run after stopping the display server (runs as root)
+# greeter-setup-script = Script to run when starting a greeter (runs as root)
+# session-setup-script = Script to run when starting a user session (runs as root)
+# session-cleanup-script = Script to run when quitting a user session (runs as root)
+# autologin-guest = True to log in as guest by default
+# autologin-user = User to log in with by default (overrides autologin-guest)
+# autologin-user-timeout = Number of seconds to wait before loading default user
+# autologin-session = Session to load for automatic login (overrides user-session)
+# autologin-in-background = True if autologin session should not be immediately activated
+# exit-on-failure = True if the daemon should exit if this seat fails
+#
+[Seat:*]
+#type=local
+#pam-service=lightdm
+#pam-autologin-service=lightdm-autologin
+#pam-greeter-service=lightdm-greeter
+#xserver-backend=
+#xserver-command=X
+#xmir-command=Xmir
+#xserver-config=
+#xserver-layout=
+#xserver-allow-tcp=false
+#xserver-share=true
+#xserver-hostname=
+#xserver-display-number=
+#xdmcp-manager=
+#xdmcp-port=177
+#xdmcp-key=
+#unity-compositor-command=unity-system-compositor
+#unity-compositor-timeout=60
+#greeter-session=example-gtk-gnome
+#greeter-hide-users=false
+#greeter-allow-guest=true
+#greeter-show-manual-login=false
+#greeter-show-remote-login=true
+#user-session=default
+#allow-user-switching=true
+#allow-guest=true
+#guest-session=
+#session-wrapper=lightdm-session
+#greeter-wrapper=
+#guest-wrapper=
+#display-setup-script=
+#display-stopped-script=
+#greeter-setup-script=
+#session-setup-script=
+#session-cleanup-script=
+#autologin-guest=false
+autologin-user=pi
+#autologin-user-timeout=0
+#autologin-in-background=false
+#autologin-session=
+#exit-on-failure=false
+
+#
+# XDMCP Server configuration
+#
+# enabled = True if XDMCP connections should be allowed
+# port = UDP/IP port to listen for connections on
+# listen-address = Host/address to listen for XDMCP connections (use all addresses if not present)
+# key = Authentication key to use for XDM-AUTHENTICATION-1 or blank to not use authentication (stored in keys.conf)
+# hostname = Hostname to report to XDMCP clients (defaults to system hostname if unset)
+#
+# The authentication key is a 56 bit DES key specified in hex as 0xnnnnnnnnnnnnnn.  Alternatively
+# it can be a word and the first 7 characters are used as the key.
+#
+[XDMCPServer]
+#enabled=false
+#port=177
+#listen-address=
+#key=
+#hostname=
+
+#
+# VNC Server configuration
+#
+# enabled = True if VNC connections should be allowed
+# command = Command to run Xvnc server with
+# port = TCP/IP port to listen for connections on
+# listen-address = Host/address to listen for VNC connections (use all addresses if not present)
+# width = Width of display to use
+# height = Height of display to use
+# depth = Color depth of display to use
+#
+[VNCServer]
+#enabled=false
+#command=Xvnc
+#port=5900
+#listen-address=
+#width=1024
+#height=768
+#depth=8
+#autologin-user=

--- a/gui/rpi-image/files/pulseaudio.service
+++ b/gui/rpi-image/files/pulseaudio.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Sound Service
+
+# We require pulseaudio.socket to be active before starting the daemon, because
+# while it is possible to use the service without the socket, it is not clear
+# why it would be desirable.
+#
+# A user installing pulseaudio and doing `systemctl --user start pulseaudio`
+# will not get the socket started, which might be confusing and problematic if
+# the server is to be restarted later on, as the client autospawn feature
+# might kick in. Also, a start of the socket unit will fail, adding to the
+# confusion.
+#
+# After=pulseaudio.socket is not needed, as it is already implicit in the
+# socket-service relationship, see systemd.socket(5).
+Requires=pulseaudio.socket
+ConditionUser=!root
+
+[Service]
+ExecStart=/usr/bin/pulseaudio --daemonize=no --log-target=journal
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+Restart=on-failure
+RestrictNamespaces=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+# Note that notify will only work if --daemonize=no
+Type=notify
+UMask=0077
+
+[Install]
+Also=pulseaudio.socket
+WantedBy=default.target

--- a/gui/rpi-image/files/pulseaudio.socket
+++ b/gui/rpi-image/files/pulseaudio.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=Sound System
+ConditionUser=!root
+
+[Socket]
+Priority=6
+Backlog=5
+ListenStream=%t/pulse/native
+
+[Install]
+WantedBy=sockets.target

--- a/gui/rpi-image/hosts
+++ b/gui/rpi-image/hosts
@@ -1,1 +1,1 @@
-pi@localhost ansible_connection=ssh ansible_ssh_pass=raspberry ansible_port=5022
+pi@localhost ansible_connection=ssh ansible_ssh_pass=respiraworks ansible_port=5022

--- a/gui/rpi-image/hosts.raspberrypi
+++ b/gui/rpi-image/hosts.raspberrypi
@@ -1,1 +1,1 @@
-pi@raspberrypi.local ansible_connection=ssh ansible_ssh_pass=raspberry ansible_port=22
+pi@raspberrypi.local ansible_connection=ssh ansible_ssh_pass=respiraworks ansible_port=22

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -14,6 +14,8 @@
     apt_key:
       url: https://download.docker.com/linux/raspbian/gpg
       state: present
+    tags:
+      - docker
 
   - name: Update apt packages
     apt:
@@ -28,12 +30,18 @@
 
   - name: Download Docker convenience script
     shell: curl -fsSL https://get.docker.com -o get-docker.sh
+    tags:
+      - docker
 
   - name: Run Docker convenience script
     shell: sh get-docker.sh
+    tags:
+      - docker
 
   - name: Adding user pi to docker group
     shell: usermod -aG docker pi
+    tags:
+      - docker
 
   - name: Install Debian menu for Openbox
     apt:
@@ -66,14 +74,21 @@
       line: 'exec openbox-session'
       create: yes
 
-  - name: Enable auto-login
-    lineinfile:
+  - name: Configure lightdm (enables auto-login)
+    file:
+      src: lightdm.conf
       dest: /etc/lightdm/lightdm.conf
-      line: 'autologin-user=pi'
-      create: no
+      mode: '0644'
 
   - name: Cache most recent gui docker image from dockerhub
     shell: docker pull respiraworks/gui
+    tags:
+      - docker
+
+  - name: Create config directory
+    file:
+      path: /home/pi/.config
+      state: directory
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -51,6 +51,43 @@
         - openbox
         - menu
 
+  - name: Create config directory
+    file:
+      path: /home/pi/.config
+      state: directory
+      owner: pi
+      group: pi
+
+  - name: Create user systemd default.target.wants directory
+    file:
+      path: /home/pi/.config/systemd/user/default.target.wants/
+      state: directory
+      owner: pi
+      group: pi
+
+  - name: Create user systemd socket.target.wants directory
+    file:
+      path: /home/pi/.config/systemd/user/socket.target.wants/
+      state: directory
+      owner: pi
+      group: pi
+
+  - name: Create user systemd default.target.wants directory
+    file:
+      src: /usr/lib/systemd/user/pulseaudio.service
+      dest: /home/pi/.config/systemd/user/default.target.wants/pulseaudio.service
+      state: link
+      owner: pi
+      group: pi
+
+  - name: Create user systemd socket.target.wants directory
+    file:
+      src: /usr/lib/systemd/user/pulseaudio.socket
+      dest: /home/pi/.config/systemd/user/sockets.target.wants/pulseaudio.socket
+      state: directory
+      owner: pi
+      group: pi
+
   - name: Creates /lib/systemd/user directory
     file:
       path: /lib/systemd/user
@@ -61,12 +98,16 @@
       src: pulseaudio.socket
       dest: /lib/systemd/user/pulseaudio.socket
       mode: '0644'
+      owner: pi
+      group: pi
 
   - name: Add pulseaudio service systemd config
     copy:
       src: pulseaudio.service
       dest: /lib/systemd/user/pulseaudio.service
       mode: '0644'
+      owner: pi
+      group: pi
 
   - name: Set pi user's .xsession
     lineinfile:
@@ -84,11 +125,6 @@
     shell: docker pull respiraworks/gui
     tags:
       - docker
-
-  - name: Create config directory
-    file:
-      path: /home/pi/.config
-      state: directory
 
   - name: Copy openbox autostart folder from root to pi
     shell: cp -r /etc/xdg/openbox /home/pi/.config/

--- a/gui/rpi-image/rpi-primer.yml
+++ b/gui/rpi-image/rpi-primer.yml
@@ -116,10 +116,11 @@
       create: yes
 
   - name: Configure lightdm (enables auto-login)
-    file:
+    copy:
       src: lightdm.conf
       dest: /etc/lightdm/lightdm.conf
       mode: '0644'
+      force: yes
 
   - name: Cache most recent gui docker image from dockerhub
     shell: docker pull respiraworks/gui


### PR DESCRIPTION

    Add pulseaudio service config files (oops, forgot them).
    Fix auto-login issue by providing our own lightdm.conf file with autologin-user=pi.
    Update password from raspberry to respiraworks.
    Add a tag in the ansible playbook to skip the very slow Docker steps.
