### PR TITLE
Controller fsm refactor

### DIFF
--- a/controller/lib/core/blower_fsm.h
+++ b/controller/lib/core/blower_fsm.h
@@ -86,9 +86,6 @@ struct BlowerSystemState {
   Pressure peep;
 
   // Is this the last BlowerSystemState returned at the end of the breath cycle?
-  //
-  // Individual FSM classes are responsible for setting this to true if
-  // end-of-cycle condition is encountered while computing the desired state.
   bool is_end_of_breath = false;
 };
 
@@ -104,9 +101,6 @@ inline constexpr Duration RISE_TIME = milliseconds(100);
 //    Constructs a new FSM for a single breath starting at the given time and
 //    with the given params.  Those params don't change during the life of the
 //    FSM.
-//
-//  - void Update(Time now, const BlowerFsmInputs& inputs):
-//    Updates the state of the fsm based on time and values in inputs.
 //
 //  - BlowerSystemState DesiredState(): Gets the solenoid open/closed
 //    state and the pressure that the fan should be trying to hit for the
@@ -128,6 +122,8 @@ public:
         // Same applies to the is_end_of_breath flag: it doesn't really pertain
         // to the off state but hardcode it to false by convention.
         .flow_direction = FlowDirection::EXPIRATORY,
+        .pip = cmH2O(0.0f),
+        .peep = cmH2O(0.0f),
         .is_end_of_breath = false,
     };
   }

--- a/controller/lib/core/controller.cpp
+++ b/controller/lib/core/controller.cpp
@@ -114,7 +114,7 @@ Controller::Run(Time now, const VentParams &params,
   BlowerSystemState desired_state = fsm_.DesiredState(
       now, params, {.patient_volume = patient_volume, .net_flow = net_flow});
 
-  if (desired_state.is_new_breath) {
+  if (desired_state.is_end_of_breath) {
     // The "correct" volume at the breath boundary is 0.
     flow_integrator_->NoteExpectedVolume(ml(0));
     breath_id_ = now.microsSinceStartup();

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -93,11 +93,19 @@ TEST(BlowerFsmTest, DesiredPipPeep) {
     EXPECT_EQ(s.pip.cmH2O(), 20.f);
     EXPECT_EQ(s.peep.cmH2O(), 10.f);
 
-    // Now the pip/peep values update.
+    // We are at the breath boundary; the FSM will return the last desired state
+    // for the just-completed breath; is_end_of_breath flag should be true
     Hal.delay(seconds(2));
+    s = fsm.DesiredState(Hal.now(), p, inputs_zero);
+    EXPECT_EQ(s.pip.cmH2O(), 20.f);
+    EXPECT_EQ(s.peep.cmH2O(), 10.f);
+    EXPECT_EQ(s.is_end_of_breath, true);
+
+    // the next desired state should contain updated values
     s = fsm.DesiredState(Hal.now(), p, inputs_zero);
     EXPECT_EQ(s.pip.cmH2O(), 25.f);
     EXPECT_EQ(s.peep.cmH2O(), 15.f);
+    EXPECT_EQ(s.is_end_of_breath, false);
   }
 }
 
@@ -237,7 +245,7 @@ RunFlowTrace(const VolumetricFlow *trace, size_t n, const VentParams &params,
       ++check_it;
     }
 
-    if (fsm.Finished()) {
+    if (desired_state.is_end_of_breath) {
       results.finish_time = Hal.now() - start;
       break;
     }

--- a/controller/test/blower_fsm/blower_fsm_test.cpp
+++ b/controller/test/blower_fsm/blower_fsm_test.cpp
@@ -212,8 +212,9 @@ RunFlowTrace(const VolumetricFlow *trace, size_t n, const VentParams &params,
     VolumetricFlow f = trace[i];
 
     // Our traces don't contain volume measurements, but this is OK for now.
-    fsm.Update(Hal.now(), {.patient_volume = ml(0), .net_flow = f});
-    FlowDirection dir = fsm.DesiredState().flow_direction;
+    BlowerSystemState desired_state =
+        fsm.DesiredState(Hal.now(), {.patient_volume = ml(0), .net_flow = f});
+    FlowDirection dir = desired_state.flow_direction;
     if (dir == FlowDirection::EXPIRATORY && !results.expire_start_time) {
       results.expire_start_time = Hal.now() - start;
     }
@@ -227,7 +228,7 @@ RunFlowTrace(const VolumetricFlow *trace, size_t n, const VentParams &params,
     if (check_it != setpoint_checks.end()) {
       const auto &[check_ms, check_cmh2o] = *check_it;
       if (check_ms == ms) {
-        auto sp = fsm.DesiredState().pressure_setpoint;
+        auto sp = desired_state.pressure_setpoint;
         EXPECT_TRUE(sp.has_value());
         if (sp.has_value()) {
           EXPECT_EQ(sp->cmH2O(), check_cmh2o);


### PR DESCRIPTION
This addresses @jlebar's TODO regarding renaming is_new_breath and merging FSM methods.

This change simplifies the logic for obtaining the currently desired FSM state. This allows us to get rid of intermediate state stored in the classes. Note that this slightly changes the behavior of the FSM at the breath boundary: the state returned is always the last computed state (unless we were in the OFF state).

Previous behavior was desired state from the current (possibly freshly created) instance of the FSM. Note that transitioning from off to on state is a special case: here, we will compute and return the correct "on mode" state.
