### PR TITLE
[GUI] Fix small glitch on Alarm Banner.

### DIFF
--- a/gui/src/latching_alarm.h
+++ b/gui/src/latching_alarm.h
@@ -120,7 +120,7 @@ public:
   // Whether the visual signal should currently be active.
   bool IsVisualActive() const { return is_condition_active_; }
 
-  QString GetBannerText() const { return banner_text_.value_or("(inactive)"); }
+  QString GetBannerText() const { return banner_text_.value_or(""); }
 
   // ACKNOWLEDGEs the alarm, suppressing audio for 2 minutes.
   void Acknowledge(SteadyInstant now) {

--- a/gui/tests/latching_alarm_test.h
+++ b/gui/tests/latching_alarm_test.h
@@ -133,7 +133,7 @@ private slots:
     alarm.Update(t(i++), pressure(25.0), bs);
     QVERIFY(!alarm.IsVisualActive());
     QVERIFY(!alarm.IsAudioActive());
-    QCOMPARE("(inactive)", alarm.GetBannerText());
+    QCOMPARE("", alarm.GetBannerText());
 
     // Condition goes back up: visual goes back up, audio beeps again because
     // it is no longer silenced.


### PR DESCRIPTION
Once the alarm is dismissed and the animation for dismissal starts,
the banner shows the text "(inactive)" which is unecessary.